### PR TITLE
docs(security): SECURITY.md y plantilla de reporte

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.yaml
+++ b/.github/ISSUE_TEMPLATE/security.yaml
@@ -1,0 +1,18 @@
+﻿name: Reporte de seguridad (privado)
+description: No publiques PII ni secretos.
+title: "[SEC] "
+labels: ["security"]
+assignees: ["hekouo"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **No pegues secretos aquÃ­.**
+  - type: textarea
+    id: desc
+    attributes:
+      label: DescripciÃ³n
+      description: Â¿QuÃ© viste? Â¿CÃ³mo se reproduce?
+      placeholder: Pasos, URLs, stacktrace.
+    validations:
+      required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+﻿# Security Policy
+
+## Reportar vulnerabilidades
+
+Por favor no abras un issue pÃºblico. EnvÃ­a un correo a **seguridad@ejemplo.invalid** con detalles y pasos de reproducciÃ³n.
+Responderemos en 72h. Si es crÃ­tico, indicaremos mitigaciÃ³n y fecha de parche.


### PR DESCRIPTION
AÃ±ade polÃ­tica de seguridad y plantilla para reportes de vulnerabilidades.

**Archivos aÃ±adidos:**
- SECURITY.md - PolÃ­tica de divulgaciÃ³n responsable
- .github/ISSUE_TEMPLATE/security.yaml - Plantilla para reportes de seguridad

**CaracterÃ­sticas:**
- Instrucciones para reportar vulnerabilidades de forma privada
- Plantilla estructurada con campos obligatorios
- AsignaciÃ³n automÃ¡tica a @hekouo
- Label 'security' automÃ¡tico