### PR TITLE
chore: enable Dependabot for npm and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+﻿version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: { interval: "weekly" }


### PR DESCRIPTION
Habilita Dependabot para mantener actualizadas las dependencias automÃ¡ticamente.

**ConfiguraciÃ³n:**
- **npm**: RevisiÃ³n semanal de dependencias de package.json
  - LÃ­mite: 5 PRs abiertos simultÃ¡neamente
- **GitHub Actions**: RevisiÃ³n semanal de versiones de actions

**Beneficios:**
- Actualizaciones automÃ¡ticas de seguridad
- Mantenimiento proactivo de dependencias
- PRs automÃ¡ticos con changelogs
- Reduce deuda tÃ©cnica