### PR TITLE
ci: auto-merge por etiqueta 'automerge' (requiere checks)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,16 @@
+﻿name: Auto Merge (label-based)
+on:
+  pull_request_target:
+    types: [labeled, opened, reopened, synchronize]
+jobs:
+  automerge:
+    if: contains(join(fromJson(toJson(github.event.pull_request.labels)).*.name, ' '), 'automerge')
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --auto


### PR DESCRIPTION
AÃ±ade workflow para habilitar auto-merge automÃ¡tico en PRs con la etiqueta 'automerge'.

**Funcionamiento:**
- Se activa cuando un PR recibe la etiqueta 'automerge'
- Habilita auto-merge con squash
- El PR se fusionarÃ¡ automÃ¡ticamente cuando:
  - Pasen todos los checks requeridos (CI, CodeQL)
  - Se obtengan las aprobaciones necesarias
  - Se resuelvan todas las conversaciones

**Seguridad:**
- Usa pull_request_target para seguridad
- Respeta todas las protecciones de rama
- Solo habilita auto-merge, no bypasea checks

**Uso:**
1. AÃ±adir label 'automerge' a un PR
2. El workflow habilitarÃ¡ auto-merge
3. El PR se mergearÃ¡ cuando cumpla requisitos