### PR TITLE
fix: add --repo parameter to automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Enable auto-merge (squash)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge ${{ github.event.pull_request.number }} --squash --auto
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --auto --repo ${{ github.repository }}


### PR DESCRIPTION
The gh CLI command needs --repo when not in a git repository context. This fixes the automerge workflow failure.