### PR TITLE
chore(eslint): sweep 2 — warnings no triviales

### DIFF
--- a/src/app/checkout/pago/page.tsx
+++ b/src/app/checkout/pago/page.tsx
@@ -86,9 +86,12 @@ export default function PagoPage() {
 
       clearCheckout();
       router.replace(`/checkout/gracias?orden=${result.orderId}`);
-    } catch (e: any) {
-      console.error(e);
-      setError(e.message || "No se pudo procesar el pago. Intenta de nuevo.");
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      console.error(error);
+      setError(
+        error.message || "No se pudo procesar el pago. Intenta de nuevo.",
+      );
     } finally {
       setSending(false);
       sendingRef.current = false;
@@ -163,6 +166,7 @@ export default function PagoPage() {
             {...register("email", {
               required: "El email es requerido",
               pattern: {
+                // eslint-disable-next-line sonarjs/slow-regex -- regex simple validación email; validado en backend
                 value: /^\S+@\S+$/i,
                 message: "Email inválido",
               },

--- a/src/app/cuenta/direcciones/page.tsx
+++ b/src/app/cuenta/direcciones/page.tsx
@@ -5,8 +5,22 @@ import { AuthGuard } from "@/components/auth/AuthGuard";
 import { supabase } from "@/lib/supabase/client";
 import { Plus, Edit, Trash2 } from "lucide-react";
 
+type Address = {
+  id: string;
+  user_id: string;
+  label: string;
+  street: string;
+  ext_no: string;
+  int_no?: string | null;
+  neighborhood: string;
+  city: string;
+  state: string;
+  zip: string;
+  is_default: boolean;
+};
+
 export default function DireccionesPage() {
-  const [addresses, setAddresses] = useState<any[]>([]);
+  const [addresses, setAddresses] = useState<Address[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -41,16 +55,21 @@ export default function DireccionesPage() {
 
     if (!user) return;
 
-    const addressData: any = {
+    const getString = (key: string): string => {
+      const value = formData.get(key);
+      return value instanceof File ? "" : (value?.toString() ?? "");
+    };
+
+    const addressData: Omit<Address, "id"> = {
       user_id: user.id,
-      label: formData.get("label"),
-      street: formData.get("street"),
-      ext_no: formData.get("ext_no"),
-      int_no: formData.get("int_no"),
-      neighborhood: formData.get("neighborhood"),
-      city: formData.get("city"),
-      state: formData.get("state"),
-      zip: formData.get("zip"),
+      label: getString("label"),
+      street: getString("street"),
+      ext_no: getString("ext_no"),
+      int_no: formData.get("int_no")?.toString() ?? null,
+      neighborhood: getString("neighborhood"),
+      city: getString("city"),
+      state: getString("state"),
+      zip: getString("zip"),
       is_default: formData.get("is_default") === "on",
     };
 

--- a/src/app/cuenta/page.tsx
+++ b/src/app/cuenta/page.tsx
@@ -44,9 +44,17 @@ export default function CuentaPage() {
           setSuccess(result.message);
         }
       }
-    } catch (err: any) {
-      if (err.errors) {
-        setError(err.errors[0].message);
+    } catch (err) {
+      if (
+        err &&
+        typeof err === "object" &&
+        "errors" in err &&
+        Array.isArray((err as { errors: Array<{ message?: string }> }).errors)
+      ) {
+        const zodErr = err as { errors: Array<{ message?: string }> };
+        setError(
+          zodErr.errors[0]?.message || "Ocurrió un error. Inténtalo de nuevo.",
+        );
       } else {
         setError("Ocurrió un error. Inténtalo de nuevo.");
       }

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -23,8 +23,23 @@ const statusColors: Record<string, string> = {
   cancelled: "bg-red-100 text-red-800",
 };
 
+type OrderItem = {
+  id: string;
+  quantity: number;
+  product_name: string;
+  price: number;
+};
+
+type Order = {
+  id: string;
+  status: string;
+  created_at: string;
+  total_amount: number;
+  order_items?: OrderItem[];
+};
+
 export default function PedidosPage() {
-  const [orders, setOrders] = useState<any[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -106,7 +121,7 @@ export default function PedidosPage() {
                       Productos ({order.order_items?.length || 0})
                     </h4>
                     <div className="space-y-2">
-                      {order.order_items?.map((item: any) => (
+                      {order.order_items?.map((item: OrderItem) => (
                         <div
                           key={item.id}
                           className="flex justify-between text-sm"

--- a/src/app/cuenta/puntos/page.tsx
+++ b/src/app/cuenta/puntos/page.tsx
@@ -36,9 +36,22 @@ const typeIcons: Record<string, IconType> = {
   adjust: Award,
 };
 
+type UserProfile = {
+  points_balance: number;
+};
+
+type LedgerItem = {
+  id: string;
+  type: string;
+  points: number;
+  created_at: string;
+  description?: string | null;
+  order_id?: string | null;
+};
+
 export default function PuntosPage() {
-  const [profile, setProfile] = useState<any>(null);
-  const [ledger, setLedger] = useState<any[]>([]);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [ledger, setLedger] = useState<LedgerItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/src/lib/utils/catalog.ts
+++ b/src/lib/utils/catalog.ts
@@ -85,6 +85,7 @@ export function normalizeRow(
     description,
     image,
     slug: slugify(
+      // eslint-disable-next-line sonarjs/pseudo-random -- fallback slug único cuando falta título; no crítico
       title || `${fallbackSection}-${Math.random().toString(36).slice(2, 8)}`,
     ),
   };

--- a/src/lib/utils/csv.ts
+++ b/src/lib/utils/csv.ts
@@ -23,6 +23,7 @@ function parseCSV(text: string) {
       if (ch === '"') {
         if (inQ && line[i + 1] === '"') {
           cur += '"';
+          // eslint-disable-next-line sonarjs/updated-loop-counter -- intencional: saltar siguiente carácter en comillas escapadas
           i++;
         } else {
           inQ = !inQ;

--- a/src/types/csv-parse-sync.d.ts
+++ b/src/types/csv-parse-sync.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- tipos de terceros csv-parse/sync */
 declare module "csv-parse/sync" {
   export interface Options {
     columns?: boolean | string[];
@@ -6,3 +7,4 @@ declare module "csv-parse/sync" {
   }
   export function parse(input: string | Buffer, options?: Options): any[];
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
Refactor puntual para tipar any y documentar regex/PRNG/loops (sin tocar APIs ni UI).

- Tipados: Address, Order, OrderItem, UserProfile, LedgerItem
- Catch handlers: Error tipado en lugar de any
- FormData: helper getString() para tipado seguro
- Regex/documentación: eslint-disable con justificación
- PRNG: Math.random() documentado como intencional
- Loop counter: i++ intencional en CSV parser documentado