### PR TITLE
chore: cleanup post-merge hardening

### DIFF
--- a/src/app/api/debug/domains/route.ts
+++ b/src/app/api/debug/domains/route.ts
@@ -13,7 +13,9 @@ export async function GET() {
     if (p.image_url) {
       try {
         set.add(new URL(p.image_url).hostname);
-      } catch {}
+      } catch {
+        // Ignorar URLs inválidas
+      }
     }
   }
   return NextResponse.json({

--- a/src/app/api/debug/img-check/route.ts
+++ b/src/app/api/debug/img-check/route.ts
@@ -13,7 +13,9 @@ async function checkOnce(url: string) {
   try {
     const h = await fetch(url, { method: "HEAD" });
     if (h.ok) return { ok: true, status: h.status } as const;
-  } catch {}
+  } catch {
+    // Ignorar errores de HEAD, intentar GET
+  }
   try {
     const g = await fetch(url, { method: "GET" });
     return { ok: g.ok, status: g.status } as const;

--- a/src/app/api/healthz/route.ts
+++ b/src/app/api/healthz/route.ts
@@ -1,39 +1,9 @@
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  try {
-    // Verificar que las variables de entorno estén configuradas
-    const requiredEnvVars = [
-      "NEXT_PUBLIC_SUPABASE_URL",
-      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-    ];
-
-    const missingVars = requiredEnvVars.filter(
-      (varName) => !process.env[varName],
-    );
-
-    if (missingVars.length > 0) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: `Missing environment variables: ${missingVars.join(", ")}`,
-        },
-        { status: 500 },
-      );
-    }
-
-    return NextResponse.json({
-      ok: true,
-      timestamp: new Date().toISOString(),
-      environment: process.env.NODE_ENV || "development",
-    });
-  } catch (error) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json({
+    ok: true,
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV || "development",
+  });
 }

--- a/src/test/lib/catalog.test.ts
+++ b/src/test/lib/catalog.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isDebugEnabled } from "../../lib/utils/debug";
+import {
+  getFeaturedProducts,
+  listBySection,
+  getBySectionSlug,
+} from "../../lib/supabase/catalog";
+
+describe("isDebugEnabled", () => {
+  const originalEnv = process.env.ALLOW_DEBUG_ROUTES;
+
+  beforeEach(() => {
+    delete process.env.ALLOW_DEBUG_ROUTES;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ALLOW_DEBUG_ROUTES = originalEnv;
+    } else {
+      delete process.env.ALLOW_DEBUG_ROUTES;
+    }
+  });
+
+  it("should return false when ALLOW_DEBUG_ROUTES is not set", () => {
+    expect(isDebugEnabled()).toBe(false);
+  });
+
+  it("should return false when ALLOW_DEBUG_ROUTES is empty", () => {
+    process.env.ALLOW_DEBUG_ROUTES = "";
+    expect(isDebugEnabled()).toBe(false);
+  });
+
+  it("should return true when ALLOW_DEBUG_ROUTES is '1'", () => {
+    process.env.ALLOW_DEBUG_ROUTES = "1";
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  it("should return true when ALLOW_DEBUG_ROUTES is 'true'", () => {
+    process.env.ALLOW_DEBUG_ROUTES = "true";
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  it("should return true when ALLOW_DEBUG_ROUTES is 'TRUE'", () => {
+    process.env.ALLOW_DEBUG_ROUTES = "TRUE";
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  it("should return false when ALLOW_DEBUG_ROUTES is '0'", () => {
+    process.env.ALLOW_DEBUG_ROUTES = "0";
+    expect(isDebugEnabled()).toBe(false);
+  });
+});
+
+describe("catalog functions with null envs", () => {
+  const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  });
+
+  afterEach(() => {
+    if (originalUrl !== undefined) {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl;
+    } else {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    }
+    if (originalKey !== undefined) {
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalKey;
+    } else {
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    }
+  });
+
+  it("getFeaturedProducts should return empty array without throwing", async () => {
+    const result = await getFeaturedProducts();
+    expect(result).toEqual([]);
+  });
+
+  it("listBySection should return empty array without throwing", async () => {
+    const result = await listBySection("equipos");
+    expect(result).toEqual([]);
+  });
+
+  it("getBySectionSlug should return null without throwing", async () => {
+    const result = await getBySectionSlug("equipos", "test-slug");
+    expect(result).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Post-merge hardening

### Cambios realizados:
- ✅ **ESLint warnings corregidos**: empty blocks en `img-check` y `domains` ahora tienen comentarios
- ✅ **/healthz simplificado**: ya no requiere Supabase envs, responde 200 sin dependencias
- ✅ **Tests unitarios agregados**:
  - `isDebugEnabled()`: valida todos los casos de `ALLOW_DEBUG_ROUTES`
  - `catalog.ts`: valida que funciones retornan vacío/null sin throw cuando faltan envs

### Validaciones en main:
- ✅ `next.config.mjs`: sin `output:'export'`
- ✅ `package.json`: sin `"next export"` ni `"postbuild"`
- ✅ Sin marcadores de conflicto en `src/`
- ✅ Sin instanciaciones de Supabase en módulo (solo dentro de funciones)
- ✅ `tsc/lint/build` OK

### Pendiente verificar en Vercel:
- `NEXT_PUBLIC_SUPABASE_URL` y `NEXT_PUBLIC_SUPABASE_ANON_KEY` en Preview y Production
- `ALLOW_DEBUG_ROUTES` vacío en Production, `true` en Preview
- Smoke test: `/`, `/destacados`, `/catalogo`, `/catalogo/equipos` → 200
- `/api/debug/*` → 404 en Production

