### PR TITLE
chore(test): vitest config + alias + exclude playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5",
     "typescript-eslint": "^8.46.1",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4",
     "zod": "^3.23.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       typescript-eslint:
         specifier: ^8.46.1
         version: 8.46.1(eslint@8.57.1)(typescript@5.9.3)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.3)(vite@7.1.10(@types/node@22.18.10)(jiti@1.21.7)(terser@5.44.0)(yaml@2.8.1))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.18.10)(jiti@1.21.7)(jsdom@27.0.1(postcss@8.5.6))(terser@5.44.0)(yaml@2.8.1)
@@ -3039,6 +3042,9 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4660,6 +4666,16 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4754,6 +4770,14 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@7.1.10:
     resolution: {integrity: sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==}
@@ -8435,6 +8459,8 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -10119,6 +10145,10 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -10264,6 +10294,17 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.1.10(@types/node@22.18.10)(jiti@1.21.7)(terser@5.44.0)(yaml@2.8.1)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
+    optionalDependencies:
+      vite: 7.1.10(@types/node@22.18.10)(jiti@1.21.7)(terser@5.44.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@7.1.10(@types/node@22.18.10)(jiti@1.21.7)(terser@5.44.0)(yaml@2.8.1):
     dependencies:

--- a/src/test/lib/routes.test.ts
+++ b/src/test/lib/routes.test.ts
@@ -6,7 +6,7 @@ describe('ROUTES', () => {
     expect(ROUTES.home()).toBe('/');
     expect(ROUTES.catalogIndex()).toBe('/catalogo');
     expect(ROUTES.carrito()).toBe('/carrito');
-    expect(ROUTES.cuenta()).toBe('/cuenta');
+    expect(ROUTES.cuenta()).toBe('/account');
     expect(ROUTES.destacados()).toBe('/destacados');
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    include: ["src/test/**/*.test.ts", "src/test/**/*.test.tsx"],
+    exclude: ["tests/**", "e2e/**", "node_modules/**", "dist/**"],
+    environment: "node",
+  },
+  resolve: { preserveSymlinks: true },
+});
+


### PR DESCRIPTION
## Vitest config and alias resolution

### Cambios realizados:
- ✅ Add itest.config.ts with tsconfig paths plugin
- ✅ Exclude Playwright specs from Vitest (	ests/**, 2e/**)
- ✅ Fix routes test expectation (/account instead of /cuenta)
- ✅ Create minimal stubs only if files are missing (normalizeImageUrl, sections) - ya existían
- ✅ Install ite-tsconfig-paths dev dependency

### Validaciones:
- ✅ pnpm test: Solo ejecuta tests de Vitest, excluye Playwright
- ✅ pnpm build: OK
- ✅ Resolución de alias @/ funciona correctamente

**Cambio mínimo y seguro.** 🚀