### PR TITLE
chore(test): jsdom + setup + mocks for Next

### DIFF
--- a/src/test/components/ProductImage.test.tsx
+++ b/src/test/components/ProductImage.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import ProductImage from '../../components/ProductImage';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import ProductImage from "@/components/ProductImage";
 
 describe('ProductImage', () => {
   it('renders with alt text', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,9 @@ export default defineConfig({
   test: {
     include: ["src/test/**/*.test.ts", "src/test/**/*.test.tsx"],
     exclude: ["tests/**", "e2e/**", "node_modules/**", "dist/**"],
-    environment: "node",
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    globals: true,
   },
   resolve: { preserveSymlinks: true },
 });
-

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,27 @@
+import "@testing-library/jest-dom/vitest";
+import * as React from "react";
+import { vi } from "vitest";
+
+// Mock de next/image para evitar SSR behavior y loaders
+vi.mock("next/image", () => ({
+  default: (props: any) => {
+    const { src, alt, ...rest } = props ?? {};
+    const resolved =
+      typeof src === "string" ? src : (src?.src ?? "");
+    return React.createElement("img", { src: resolved, alt, ...rest });
+  },
+}));
+
+// Mocks defensivos de next/navigation si algún test lo toca
+vi.mock("next/navigation", () => {
+  return {
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+    }),
+    useSearchParams: () => new URLSearchParams(),
+  };
+});
+


### PR DESCRIPTION
## JSdom environment + setup + mocks for Next.js

### Cambios realizados:
- ✅ Switch Vitest environment to jsdom
- ✅ Add vitest.setup.ts with jest-dom and mocks for next/image & next/navigation
- ✅ Keep Playwright specs excluded from Vitest
- ✅ All unit tests in src/test now pass locally (no "document is not defined")

### Validaciones:
- ✅ `pnpm test`: Sin fallas por "document is not defined"
- ✅ `pnpm build`: OK
- ✅ Nada de Playwright corriendo bajo Vitest
- ✅ Sin cambios de API ni de rutas

**Cambio mínimo y seguro.** 🚀

