### PR TITLE
test: unskip ProductImage and stabilize next/image mock

### DIFF
--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import Image from "next/image";
 import { normalizeImageUrl } from "@/lib/img/normalizeImageUrl";
 
@@ -9,6 +10,7 @@ type Props = {
   height?: number;
   priority?: boolean;
   sizes?: string;
+  "data-testid"?: string;
 };
 
 export default function ProductImage({
@@ -18,6 +20,7 @@ export default function ProductImage({
   height = 512,
   priority = false,
   sizes = "(max-width: 768px) 100vw, 33vw",
+  "data-testid": dataTestId,
 }: Props) {
   const url = normalizeImageUrl(src, Math.max(width, height));
   return (
@@ -28,6 +31,7 @@ export default function ProductImage({
       height={height}
       sizes={sizes}
       priority={priority}
+      data-testid={dataTestId || "product-image"}
       onError={(e) => {
         const img = e.currentTarget as HTMLImageElement;
         if (!img.src.endsWith("/images/fallback-product.png")) {

--- a/src/test/components/ProductImage.test.tsx
+++ b/src/test/components/ProductImage.test.tsx
@@ -11,9 +11,7 @@ vi.mock("@/lib/img/normalizeImageUrl", () => ({
 }));
 
 describe("ProductImage", () => {
-  // TODO: unskip cuando se estabilice el mock de next/image
-  // Issue sugerido: "stabilize(ProductImage): unskip tests y revisar props/mock de next/image"
-  it.skip("renders with alt text", () => {
+  it("renders with alt text", () => {
     render(
       <ProductImage
         src="/test.jpg"
@@ -23,17 +21,20 @@ describe("ProductImage", () => {
       />,
     );
 
-    const img = screen.getByRole("img", { name: /guantes nitrilo azul/i });
+    const img = screen.getByTestId("product-image");
     expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("alt", "Guantes nitrilo azul");
     expect(img).toHaveAttribute("src");
     const srcAttr = img.getAttribute("src");
     expect(srcAttr).toBeTruthy();
+    expect(srcAttr).toContain("/test.jpg");
   });
 
-  it.skip("renders placeholder when no src", () => {
+  it("renders placeholder when no src", () => {
     render(<ProductImage src="" alt="Sin imagen" width={120} height={120} />);
 
-    const img = screen.getByRole("img", { name: /sin imagen/i });
+    const img = screen.getByTestId("product-image");
     expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("alt", "Sin imagen");
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,12 +2,23 @@ import "@testing-library/jest-dom/vitest";
 import * as React from "react";
 import { vi } from "vitest";
 
-// Mock de next/image para evitar SSR behavior y loaders
+// Mock unificado de next/image para evitar SSR behavior y loaders
+// Usa React.createElement para evitar problemas con JSX en entorno de test
 vi.mock("next/image", () => ({
+  __esModule: true,
   default: (props: any) => {
-    const { src, alt, ...rest } = props ?? {};
-    const resolved = typeof src === "string" ? src : (src?.src ?? "");
-    return React.createElement("img", { src: resolved, alt, ...rest });
+    const { src, alt, width, height, ...rest } = props ?? {};
+    const resolvedSrc = typeof src === "string" ? src : (src?.src ?? "");
+    return React.createElement("img", {
+      src: resolvedSrc || "/placeholder.png",
+      alt: alt || "",
+      width: width,
+      height: height,
+      loading: "lazy",
+      decoding: "async",
+      "data-testid": rest["data-testid"],
+      ...rest,
+    });
   },
 }));
 


### PR DESCRIPTION
## Stabilize ProductImage tests

### Cambios
- ✅ Mock unificado de \
ext/image\ en \itest.setup.ts\ usando \React.createElement\
- ✅ Soporte para \data-testid\ en \ProductImage.tsx\
- ✅ Import explícito de React en \ProductImage.tsx\ para entorno de test
- ✅ Tests usando \getByTestId\ para queries más robustas
- ✅ Quitar \it.skip\ y dejar tests pasando

### Validaciones
- ✅ \pnpm test\: Todos los tests pasando (21/21, sin skips)
- ✅ \pnpm tsc --noEmit\: Sin errores
- ✅ \pnpm build\: OK

### Checklist
- [x] Mock estabilizado sin JSX
- [x] data-testid añadido y usado
- [x] Import React explícito para tests
- [x] Tests pasando sin skips
- [x] Build sin errores

Refs #29