### PR TITLE
ci: stabilize SBOM and relax pr-size thresholds

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,72 @@
+name: PR Size Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate PR size
+        id: size
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          
+          # Excluir lockfiles y archivos grandes sin sentido
+          excluded="pnpm-lock.yaml|package-lock.json|yarn.lock|.next|node_modules|dist|build"
+          
+          changed_files=$(git diff --name-only --diff-filter=d "$base".."$head" | grep -vE "$excluded" || true)
+          
+          if [ -z "$changed_files" ]; then
+            echo "size=xs" >> $GITHUB_OUTPUT
+            echo "No relevant files changed"
+            exit 0
+          fi
+          
+          additions=$(git diff --numstat "$base".."$head" | grep -vE "$excluded" | awk '{sum+=$1} END {print sum+0}')
+          
+          if [ -z "$additions" ] || [ "$additions" -eq 0 ]; then
+            echo "size=xs" >> $GITHUB_OUTPUT
+          elif [ "$additions" -lt 10 ]; then
+            echo "size=xs" >> $GITHUB_OUTPUT
+          elif [ "$additions" -lt 200 ]; then
+            echo "size=s" >> $GITHUB_OUTPUT
+          elif [ "$additions" -lt 600 ]; then
+            echo "size=m" >> $GITHUB_OUTPUT
+          elif [ "$additions" -lt 1200 ]; then
+            echo "size=l" >> $GITHUB_OUTPUT
+          else
+            echo "size=xl" >> $GITHUB_OUTPUT
+          fi
+          
+          echo "Additions: $additions"
+
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const size = '${{ steps.size.outputs.size }}';
+            const emoji = {
+              xs: '🟢',
+              s: '🟡',
+              m: '🟠',
+              l: '🔴',
+              xl: '🚨'
+            };
+            const comment = ## PR Size: ${emoji[size]} ${size.toUpperCase()}\n\nThis PR has been classified as **${size.toUpperCase()}** size.;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -22,7 +22,7 @@ jobs:
 
       # No hace falta instalar pnpm ni deps para generar SBOM con Anchore
       - name: Generate SBOM (CycloneDX JSON)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.15.0
         with:
           path: .
           format: cyclonedx-json
@@ -42,6 +42,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/dependency-graph/sbom \
             -f sbom=@sbom.cdx.json
-
-
-


### PR DESCRIPTION
## CI Grooming

### Cambios
- ✅ SBOM: Fijar versión de \nchore/sbom-action@v0.15.0\ para estabilidad
- ✅ pr-size: Subir umbrales razonables (xs<10, s<200, m<600, l<1200, xl>=1200)
- ✅ pr-size: Excluir lockfiles y archivos grandes sin sentido
- ✅ Timeouts: 10 min para SBOM, 5 min para pr-size

### Validaciones
- ✅ \pnpm lint\: OK (solo warning previo en vitest.setup.ts)
- ✅ \pnpm build\: OK

### Nota
- Estos workflows pueden fallar ocasionalmente pero no bloquean merge (no-blocking)
- Los umbrales de pr-size son más realistas para proyectos medianos

**No functional changes.** 🚀