### PR TITLE
chore(ci): ensure AUDIT_URL disables Playwright webServer + job-level env

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 30
     env:
       CI: true
+      AUDIT_URL: ${{ inputs.preview_url }}
 
     steps:
       - name: Checkout
@@ -51,16 +52,12 @@ jobs:
         uses: browser-actions/setup-chrome@v1
 
       - name: Install Playwright browsers (for Axe)
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
       - name: Lighthouse
-        env:
-          AUDIT_URL: ${{ inputs.preview_url }}
         run: pnpm audit:lh
 
       - name: Axe (accessibility)
-        env:
-          AUDIT_URL: ${{ inputs.preview_url }}
         run: pnpm audit:axe
 
       - name: Upload reports

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,30 +1,36 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
+
+const AUDIT_URL = process.env.AUDIT_URL?.trim();
 
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
+  timeout: 30000,
+  expect: { timeout: 10000 },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 2,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [
-    ['line'],
-    ['html', { outputFolder: 'playwright-report' }]
-  ],
+  reporter: [["line"], ["html", { outputFolder: "playwright-report" }]],
   use: {
-    baseURL: 'http://localhost:3000',
-    trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure'
+    baseURL: AUDIT_URL || "http://localhost:3000",
+    headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-  },
+  // Deshabilitar webServer si AUDIT_URL está definido (auditorías externas)
+  webServer: AUDIT_URL
+    ? undefined
+    : {
+        command: "pnpm dev --port 3000",
+        url: "http://localhost:3000",
+        reuseExistingServer: true,
+        timeout: 120000,
+      },
 });

--- a/scripts/audit/axe.spec.ts
+++ b/scripts/audit/axe.spec.ts
@@ -16,11 +16,8 @@ const PAGES = [
 test.describe("A11y (axe) smoke", () => {
   for (const route of PAGES) {
     test(`axe: ${route}`, async ({ page }) => {
-      const base =
-        process.env.AUDIT_URL ||
-        process.env.NEXT_PUBLIC_SITE_URL ||
-        "http://localhost:3000";
-      await page.goto(`${base}${route}`, { waitUntil: "domcontentloaded" });
+      // Usar rutas relativas - baseURL ya está configurado en playwright.config.ts
+      await page.goto(route, { waitUntil: "domcontentloaded" });
 
       const results = await new AxeBuilder({ page })
         .disableRules(["color-contrast"]) // opcional si hay falsos positivos iniciales


### PR DESCRIPTION
Fix timeout de Playwright: AUDIT_URL a nivel de job, webServer deshabilitado cuando AUDIT_URL existe, timeouts aumentados, solo Chromium instalado, rutas relativas en axe.spec.ts.