### PR TITLE
ci(audit): probe remote URL, fallback to local :3002; relax navigation for Axe

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 30
     env:
       CI: true
-      AUDIT_URL: ${{ inputs.preview_url }}
 
     steps:
       - name: Checkout
@@ -57,6 +56,42 @@ jobs:
           ls -la
           ls -la scripts || true
           ls -la scripts/audit || true
+
+      - name: Resolve target URL or fallback
+        shell: bash
+        run: |
+          set -e
+          INPUT_URL="${{ inputs.preview_url }}"
+          echo "AUDIT_URL_INPUT=${INPUT_URL}" >> "$GITHUB_ENV"
+
+          echo "Probing ${INPUT_URL} ..."
+          if curl -sSfL --max-time 8 "${INPUT_URL}" >/dev/null; then
+            echo "Remote is reachable."
+            echo "AUDIT_URL=${INPUT_URL}" >> "$GITHUB_ENV"
+            echo "USING_REMOTE=1" >> "$GITHUB_ENV"
+          else
+            echo "Remote NOT reachable from runner. Will use local server."
+            echo "USING_REMOTE=0" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build app (fallback local)
+        if: env.USING_REMOTE != '1'
+        run: pnpm build
+
+      - name: Start local server :3002
+        if: env.USING_REMOTE != '1'
+        run: |
+          pnpm exec next start -p 3002 &>/tmp/next.log &
+          echo "Started next on :3002"
+
+      - name: Wait for local server
+        if: env.USING_REMOTE != '1'
+        run: npx --yes wait-on --timeout 300000 http://127.0.0.1:3002
+
+      - name: Set AUDIT_URL to local
+        if: env.USING_REMOTE != '1'
+        run: |
+          echo "AUDIT_URL=http://127.0.0.1:3002" >> "$GITHUB_ENV"
 
       - name: Lighthouse
         run: pnpm audit:lh

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [["line"], ["html", { outputFolder: "playwright-report" }]],
   use: {
-    baseURL: AUDIT_URL || "http://localhost:3000",
     headless: true,
+    baseURL: AUDIT_URL || "http://127.0.0.1:3002",
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
@@ -29,9 +29,9 @@ export default defineConfig({
   webServer: AUDIT_URL
     ? undefined
     : {
-        command: "pnpm dev --port 3000",
-        url: "http://localhost:3000",
-        reuseExistingServer: true,
+        command: "pnpm exec next start -p 3002",
+        url: "http://127.0.0.1:3002",
         timeout: 120000,
+        reuseExistingServer: false,
       },
 });

--- a/scripts/audit/axe.spec.ts
+++ b/scripts/audit/axe.spec.ts
@@ -1,29 +1,37 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
-const ROUTES = [
-  "/",
-  "/destacados",
-  "/tienda",
-  "/buscar?q=arco",
-  "/checkout/datos",
-];
-const MAX_VIOLATIONS = 10;
-
 test.describe("A11y (Axe)", () => {
-  for (const route of ROUTES) {
+  const routes = [
+    "/",
+    "/destacados",
+    "/tienda",
+    "/buscar?q=arco",
+    "/checkout/datos",
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    page.setDefaultNavigationTimeout(20000);
+  });
+
+  for (const route of routes) {
     test(`a11y ${route}`, async ({ page, baseURL }) => {
       const url = new URL(route, baseURL).toString();
-      await page.goto(url, { waitUntil: "networkidle" });
+
+      try {
+        await page.goto(url, { waitUntil: "domcontentloaded" });
+      } catch {
+        // un intento más si el runner está tonto
+        await page.goto(url);
+      }
 
       const results = await new AxeBuilder({ page })
         .withTags(["wcag2a", "wcag2aa"])
         .analyze();
 
-      console.log(
-        `[axe] route=${route} violations=${results.violations.length}`,
-      );
-      expect(results.violations.length).toBeLessThanOrEqual(MAX_VIOLATIONS);
+      const violations = results.violations?.length ?? 0;
+      console.log(`[axe] route=${route} violations=${violations}`);
+      expect(violations).toBeLessThanOrEqual(10);
     });
   }
 });


### PR DESCRIPTION
Hace el workflow más robusto: prueba la URL pública y, si no es accesible, usa servidor local en puerto 3002. Ajusta navegación de Axe para menos flakiness (domcontentloaded + reintentos).