### PR TITLE
feat(perf): fuentes con next/font + preconnect/preload y headers de caché para assets

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,37 @@ const nextConfig = {
     ],
     unoptimized: true,
   },
+  async headers() {
+    return [
+      {
+        source: "/og/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/fonts/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+    ];
+  },
   webpack: (config, { isServer }) => {
     // Hacer resend opcional: no fallar si no está instalado
     if (isServer) {


### PR DESCRIPTION
Mejoras de rendimiento:

- **next/font**: Ya configurado con Inter y display: 'swap' (sin bloqueo de render)
- **preconnect**: Ya configurado para lh3.googleusercontent.com
- **Headers de caché**: Agregados para /og/*, /_next/static/* y /fonts/* con max-age=31536000 (1 año)

Esto mejora el tiempo de carga de assets estáticos y reduce requests repetidos.