### PR TITLE
chore(a11y): labels accesibles, enlaces descriptivos y contraste AA

### DIFF
--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -39,7 +39,7 @@ export default function FeaturedCard({ item }: Props) {
           <Link
             href={href}
             prefetch={false}
-            className="text-sm font-medium hover:text-primary-600"
+            className="text-sm font-medium text-gray-900 hover:text-primary-600"
           >
             {item.title}
           </Link>
@@ -51,7 +51,7 @@ export default function FeaturedCard({ item }: Props) {
           {canPurchase ? (
             <FeaturedCardControls item={item} compact />
           ) : (
-            <p className="text-sm text-muted-foreground mt-2">Agotado</p>
+            <p className="text-sm text-gray-700 mt-2">Agotado</p>
           )}
         </div>
       </div>

--- a/src/components/FeaturedCardControls.tsx
+++ b/src/components/FeaturedCardControls.tsx
@@ -34,14 +34,15 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
   ) {
     return (
       <div className="mt-2">
-        <p className="text-sm text-muted-foreground">Agotado</p>
+        <p className="text-sm text-gray-700">Agotado</p>
         {waHref && (
           <div className="mt-1">
             <a
               href={waHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm underline text-muted-foreground"
+              aria-label={`Consultar por WhatsApp: ${item.title}`}
+              className="text-sm underline text-gray-700 hover:text-gray-900"
             >
               Consultar por WhatsApp
             </a>
@@ -145,7 +146,8 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
               href={waHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm underline text-muted-foreground"
+              aria-label={`Consultar por WhatsApp: ${item.title}`}
+              className="text-sm underline text-gray-700 hover:text-gray-900"
             >
               Consultar por WhatsApp
             </a>
@@ -214,7 +216,8 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
           href={waHref}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sm underline text-muted-foreground block"
+          aria-label={`Consultar por WhatsApp: ${item.title}`}
+          className="text-sm underline text-gray-700 hover:text-gray-900 block"
         >
           Consultar por WhatsApp
         </a>


### PR DESCRIPTION
Mejoras de accesibilidad:

- **Enlaces descriptivos**: WhatsApp links incluyen nombre del producto en aria-label
- **Contraste AA**: Cambiado text-muted-foreground a text-gray-700 para mejor contraste (≥4.5:1)
- **Labels**: Todos los inputs ya tienen labels visibles o aria-label
- **QtyStepper**: Ya tiene aria-label en input y botones

Esto mejora la accesibilidad para lectores de pantalla y usuarios con baja visión.