### PR TITLE
feat(seo): JSON-LD Product en PDP + meta descriptions específicas

### DIFF
--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -102,9 +102,41 @@ export default async function ProductDetailPage({ params }: Props) {
 
     const image_url = product.image_url;
     const price = formatMXNFromCents(product.price_cents);
+    const base =
+      process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app";
+    const canonicalUrl = `${base}/catalogo/${product.section}/${product.slug}`;
+
+    // JSON-LD Product schema
+    const jsonLd = {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      name: product.title,
+      description:
+        product.description ?? `${product.title} en Depósito Dental Noriega`,
+      image: image_url ? [image_url] : [],
+      url: canonicalUrl,
+      offers: {
+        "@type": "Offer",
+        price: product.price_cents
+          ? (product.price_cents / 100).toFixed(2)
+          : "0",
+        priceCurrency: "MXN",
+        availability:
+          product.in_stock && product.price_cents && product.price_cents > 0
+            ? "https://schema.org/InStock"
+            : "https://schema.org/OutOfStock",
+        url: canonicalUrl,
+      },
+    };
 
     return (
       <div className="min-h-screen bg-gray-50">
+        {/* JSON-LD Product schema */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+
         {/* Analítica: view_item */}
         <ProductViewTracker
           productId={product.id}


### PR DESCRIPTION
Mejoras de SEO:

- **JSON-LD Product**: Schema estructurado con name, description, image, offers (price, currency, availability)
- **Meta descriptions**: Ya implementadas en generateMetadata con descripciones específicas por producto
- **Canonical URL**: Ya configurado en alternates

Esto mejora el SEO para búsquedas de productos y permite rich snippets en Google.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds JSON-LD Product schema to the PDP using a computed canonical URL and offer data for richer SEO.
> 
> - **SEO**:
>   - Add JSON-LD `Product` schema in `src/app/catalogo/[section]/[slug]/page.tsx` with `name`, `description`, `image`, `url`, and `offers` (`price`, `priceCurrency`, `availability`).
>   - Compute `canonicalUrl` from `NEXT_PUBLIC_SITE_URL` (with fallback) and use it in the JSON-LD.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1c3fa8125482a0fcbe7d3ca4ea8f71751e207c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->