### PR TITLE
fix(perf-78): cache + ultra lazy controls

### DIFF
--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -1,17 +1,25 @@
 // src/components/FeaturedCard.tsx
 "use client";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import ImageWithFallback from "@/components/ui/ImageWithFallback";
-import FeaturedCardControls from "@/components/FeaturedCardControls";
 import { mxnFromCents, formatMXN } from "@/lib/utils/currency";
 import { hasPurchasablePrice } from "@/lib/catalog/model";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
 
 type Props = {
   item: FeaturedItem;
+  priority?: boolean;
+  sizes?: string;
+  controls?: ReactNode;
 };
 
-export default function FeaturedCard({ item }: Props) {
+export default function FeaturedCard({
+  item,
+  priority = false,
+  sizes,
+  controls,
+}: Props) {
   const href =
     item.section && item.product_slug
       ? `/catalogo/${item.section}/${item.product_slug}`
@@ -29,6 +37,8 @@ export default function FeaturedCard({ item }: Props) {
             alt={item.title}
             width={512}
             height={512}
+            priority={priority}
+            sizes={sizes ?? "(min-width: 1024px) 33vw, 100vw"}
             className="w-full h-full object-contain"
           />
         </div>
@@ -44,15 +54,14 @@ export default function FeaturedCard({ item }: Props) {
             {item.title}
           </Link>
         </h3>
-        <div className="mt-2">
+        <div className="mt-2 space-y-2">
           <div className="text-lg font-semibold">
             {price !== null ? formatMXN(price) : "—"}
           </div>
-          {canPurchase ? (
-            <FeaturedCardControls item={item} compact />
-          ) : (
-            <p className="text-sm text-muted-foreground mt-2">Agotado</p>
-          )}
+          {controls}
+          {!controls && !canPurchase ? (
+            <p className="text-sm text-muted-foreground">Agotado</p>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/FeaturedCardControls.lazy.client.tsx
+++ b/src/components/FeaturedCardControls.lazy.client.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ComponentType } from "react";
+import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
+
+const skeletonButtonClass =
+  "inline-flex items-center gap-2 rounded-xl bg-black/40 px-4 py-2 text-white opacity-60 h-9";
+
+function scheduleIdle(cb: () => void) {
+  if (typeof window === "undefined") return undefined;
+  const win = window as typeof window & {
+    requestIdleCallback?: (
+      cb: IdleRequestCallback,
+      opts?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (win.requestIdleCallback) {
+    const handle = win.requestIdleCallback(cb, { timeout: 500 });
+    return () => win.cancelIdleCallback?.(handle);
+  }
+
+  const timeout = window.setTimeout(cb, 120);
+  return () => window.clearTimeout(timeout);
+}
+
+async function loadControls() {
+  const mod = await import("./FeaturedCardControls");
+  return mod.default as ComponentType<{
+    item: FeaturedItem;
+    compact?: boolean;
+  }>;
+}
+
+type LazyProps = {
+  item: FeaturedItem;
+  compact?: boolean;
+};
+
+export default function FeaturedCardControlsLazy({
+  item,
+  compact = false,
+}: LazyProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [Controls, setControls] = useState<ComponentType<{
+    item: FeaturedItem;
+    compact?: boolean;
+  }> | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+    let cleanupIdle: (() => void) | undefined;
+    let observer: IntersectionObserver | undefined;
+
+    const run = () => {
+      if (!cancelled) {
+        cleanupIdle?.();
+        setReady(true);
+      }
+    };
+
+    const node = containerRef.current;
+    if (node && "IntersectionObserver" in window) {
+      observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) {
+            cleanupIdle = scheduleIdle(run);
+            observer?.disconnect();
+          }
+        },
+        { rootMargin: "200px" },
+      );
+      observer.observe(node);
+    } else {
+      cleanupIdle = scheduleIdle(run);
+    }
+
+    return () => {
+      cancelled = true;
+      cleanupIdle?.();
+      observer?.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!ready || Controls) return;
+    let mounted = true;
+    loadControls().then((component) => {
+      if (mounted) setControls(() => component);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [ready, Controls]);
+
+  const skeletonQty = (
+    <div className="flex items-center rounded-lg border h-9 px-3 opacity-70">
+      <span className="h-9 w-6 text-base font-medium flex items-center justify-center">
+        –
+      </span>
+      <span className="w-10 text-center text-base">1</span>
+      <span className="h-9 w-6 text-base font-medium flex items-center justify-center">
+        +
+      </span>
+    </div>
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className={compact ? "mt-2 space-y-2" : "mt-auto pt-3 space-y-2"}
+    >
+      {Controls ? (
+        <Controls item={item} compact={compact} />
+      ) : (
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            {skeletonQty}
+            <button type="button" className={skeletonButtonClass} disabled>
+              Agregar
+            </button>
+          </div>
+          <span className="text-sm underline text-muted-foreground block opacity-60">
+            Consultar por WhatsApp
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/FeaturedCardControls.tsx
+++ b/src/components/FeaturedCardControls.tsx
@@ -1,22 +1,46 @@
 // src/components/FeaturedCardControls.tsx
 "use client";
 import { useState } from "react";
-import { ShoppingCart } from "lucide-react";
-import { useCartStore } from "@/lib/store/cartStore";
+import type { SVGProps } from "react";
 import { mxnFromCents } from "@/lib/utils/currency";
 import { normalizePrice, hasPurchasablePrice } from "@/lib/catalog/model";
 import { getWhatsAppHref } from "@/lib/whatsapp";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
+import { useCartStore } from "@/lib/store/cartStore";
 
 type Props = {
   item: FeaturedItem;
   compact?: boolean;
 };
 
+type AddToCartFn = ReturnType<typeof useCartStore.getState>["addToCart"];
+
+const ShoppingCartIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <circle cx={9} cy={21} r={1} />
+    <circle cx={20} cy={21} r={1} />
+    <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+  </svg>
+);
+
+function useAddToCart(): AddToCartFn {
+  return useCartStore((state) => state.addToCart);
+}
+
 export default function FeaturedCardControls({ item, compact = false }: Props) {
-  const addToCart = useCartStore((s) => s.addToCart);
+  const addToCart = useAddToCart();
   const [qty, setQty] = useState(1);
   const [isAdding, setIsAdding] = useState(false);
+
   const priceCents = normalizePrice(item.price_cents);
   const stockQty = normalizePrice(item.stock_qty);
   const canPurchase = hasPurchasablePrice(item);
@@ -51,6 +75,10 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
     );
   }
 
+  const handleQtyChange = (next: number) => {
+    setQty(Math.min(maxQty, Math.max(1, next)));
+  };
+
   const onAdd = async () => {
     if (isAdding) return;
     try {
@@ -64,9 +92,7 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
         image_url: item.image_url ?? undefined,
         selected: true,
       });
-      console.info("✅ Agregado al carrito:", item.title, "x", qty);
 
-      // Analítica: add_to_cart
       if (typeof window !== "undefined" && window.dataLayer) {
         window.dataLayer.push({
           event: "add_to_cart",
@@ -89,8 +115,25 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
     }
   };
 
+  const qtyInput = (
+    <input
+      aria-label="Cantidad"
+      className={
+        compact
+          ? "w-10 text-center outline-none text-base"
+          : "w-10 text-center outline-none"
+      }
+      inputMode="numeric"
+      value={qty}
+      onChange={(e) => {
+        const v = parseInt(e.target.value.replace(/[^\d]/g, "") || "1", 10);
+        handleQtyChange(v);
+      }}
+      disabled={isAdding}
+    />
+  );
+
   if (!compact) {
-    // Versión existente (no compacta)
     return (
       <div className="mt-auto pt-3 space-y-2">
         <div className="flex items-center gap-3">
@@ -99,31 +142,18 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
               type="button"
               className="h-8 w-6 text-xl"
               aria-label="Disminuir cantidad"
-              onClick={() => setQty((q) => Math.max(1, q - 1))}
-              disabled={isAdding}
+              onClick={() => handleQtyChange(qty - 1)}
+              disabled={isAdding || qty <= 1}
             >
               –
             </button>
-            <input
-              aria-label="Cantidad"
-              className="w-10 text-center outline-none"
-              inputMode="numeric"
-              value={qty}
-              onChange={(e) => {
-                const v = parseInt(
-                  e.target.value.replace(/[^\d]/g, "") || "1",
-                  10,
-                );
-                setQty(Math.min(maxQty, Math.max(1, v)));
-              }}
-              disabled={isAdding}
-            />
+            {qtyInput}
             <button
               type="button"
               className="h-8 w-6 text-xl"
               aria-label="Aumentar cantidad"
-              onClick={() => setQty((q) => Math.min(maxQty, q + 1))}
-              disabled={isAdding}
+              onClick={() => handleQtyChange(qty + 1)}
+              disabled={isAdding || qty >= maxQty}
             >
               +
             </button>
@@ -135,7 +165,7 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
             className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-white hover:bg-black/90 disabled:opacity-60"
             disabled={isAdding}
           >
-            <ShoppingCart className="h-4 w-4" />
+            <ShoppingCartIcon className="h-4 w-4" />
             Agregar
           </button>
         </div>
@@ -155,47 +185,31 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
     );
   }
 
-  // Versión compacta v2
   return (
     <div className="mt-2 space-y-2">
       <div className="flex items-center gap-3">
-        {/* QtyStepper compacto */}
         <div className="flex items-center rounded-lg border h-9 px-3">
           <button
             type="button"
             className="h-9 w-6 text-base font-medium"
             aria-label="Disminuir cantidad"
-            onClick={() => setQty((q) => Math.max(1, q - 1))}
+            onClick={() => handleQtyChange(qty - 1)}
             disabled={isAdding || qty <= 1}
           >
             –
           </button>
-          <input
-            aria-label="Cantidad"
-            className="w-10 text-center outline-none text-base"
-            inputMode="numeric"
-            value={qty}
-            onChange={(e) => {
-              const v = parseInt(
-                e.target.value.replace(/[^\d]/g, "") || "1",
-                10,
-              );
-              setQty(Math.min(maxQty, Math.max(1, v)));
-            }}
-            disabled={isAdding}
-          />
+          {qtyInput}
           <button
             type="button"
             className="h-9 w-6 text-base font-medium"
             aria-label="Aumentar cantidad"
-            onClick={() => setQty((q) => Math.min(maxQty, q + 1))}
+            onClick={() => handleQtyChange(qty + 1)}
             disabled={isAdding || qty >= maxQty}
           >
             +
           </button>
         </div>
 
-        {/* Botón Agregar con ícono */}
         <button
           type="button"
           onClick={onAdd}
@@ -203,12 +217,11 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
           className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-white hover:bg-black/90 disabled:opacity-60 h-9"
           disabled={isAdding}
         >
-          <ShoppingCart className="h-4 w-4" />
+          <ShoppingCartIcon className="h-4 w-4" />
           <span>Agregar</span>
         </button>
       </div>
 
-      {/* WhatsApp link en una sola línea */}
       {waHref && (
         <a
           href={waHref}

--- a/src/components/FeaturedCarousel.tsx
+++ b/src/components/FeaturedCarousel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import FeaturedCard from "@/components/FeaturedCard";
+import FeaturedCardControlsLazy from "@/components/FeaturedCardControls.lazy.client";
+import { hasPurchasablePrice } from "@/lib/catalog/model";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
 
 export default function FeaturedCarousel({ items }: { items: FeaturedItem[] }) {
@@ -9,9 +11,20 @@ export default function FeaturedCarousel({ items }: { items: FeaturedItem[] }) {
   return (
     <div className="w-full overflow-x-auto no-scrollbar py-3">
       <div className="flex gap-4 min-w-max">
-        {items.map((item) => (
+        {items.map((item, index) => (
           <div key={item.product_id} className="flex-shrink-0 w-64">
-            <FeaturedCard item={item} />
+            <FeaturedCard
+              item={item}
+              priority={index === 0}
+              sizes="(max-width: 768px) 90vw, 50vw"
+              controls={
+                hasPurchasablePrice(item) ? (
+                  <FeaturedCardControlsLazy item={item} compact />
+                ) : (
+                  <p className="text-sm text-muted-foreground">Agotado</p>
+                )
+              }
+            />
           </div>
         ))}
       </div>

--- a/src/components/FeaturedGrid.tsx
+++ b/src/components/FeaturedGrid.tsx
@@ -1,4 +1,6 @@
 import FeaturedCard from "@/components/FeaturedCard";
+import FeaturedCardControlsLazy from "@/components/FeaturedCardControls.lazy.client";
+import { hasPurchasablePrice } from "@/lib/catalog/model";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
 
 export default function FeaturedGrid({ items }: { items: FeaturedItem[] }) {
@@ -6,8 +8,20 @@ export default function FeaturedGrid({ items }: { items: FeaturedItem[] }) {
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      {items.map((item) => (
-        <FeaturedCard key={item.product_id} item={item} />
+      {items.map((item, index) => (
+        <FeaturedCard
+          key={item.product_id}
+          item={item}
+          priority={index < 4}
+          sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+          controls={
+            hasPurchasablePrice(item) ? (
+              <FeaturedCardControlsLazy item={item} compact />
+            ) : (
+              <p className="text-sm text-muted-foreground">Agotado</p>
+            )
+          }
+        />
       ))}
     </div>
   );

--- a/src/lib/catalog/cache.ts
+++ b/src/lib/catalog/cache.ts
@@ -1,0 +1,12 @@
+import { revalidateTag } from "next/cache";
+
+export const FEATURED_TAG = "featured";
+export const CATALOG_TAG = "catalog";
+
+export function revalidateFeatured() {
+  revalidateTag(FEATURED_TAG);
+}
+
+export function revalidateCatalog() {
+  revalidateTag(CATALOG_TAG);
+}


### PR DESCRIPTION
## Cambios
- FeaturedCard renderiza markup estático y recibe `controls` inyectados.
- Nuevo `FeaturedCardControls.lazy.client.tsx` monta Qty/Agregar al estar en viewport (IntersectionObserver + requestIdleCallback).
- `FeaturedCardControls` sin `lucide-react`; SVG inline y skeleton accesible.
- `FeaturedGrid`/`FeaturedCarousel` usan controles perezosos.
- Cache centralizada (`cache.ts`) y `unstable_cache` en featured/sections/catalog (revalidate 120s, tags consistentes).

## Objetivo
Elevar Perf ≥ 0.80 en #78 reduciendo CSS/JS bloqueante y TTFB en portada/tienda.
