### PR TITLE
ci: use packageManager + Corepack as single pnpm source; drop action version

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,7 +28,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Importante: no fijar 'version' aquí para no chocar con packageManager del package.json
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Prepare pnpm from packageManager
+        run: corepack prepare pnpm@$(jq -r '.packageManager' package.json | cut -d'@' -f2 | cut -d'+' -f1) --activate
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [chore/wip-pre-restart]
+    branches: [main]
   pull_request:
-    branches: [chore/wip-pre-restart]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -24,22 +24,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Setup corepack para habilitar pnpm
-      - name: Setup Corepack
+      - name: Enable Corepack
         run: corepack enable
 
-      # Setup pnpm con versión específica
+      - name: Prepare pnpm from packageManager
+        run: corepack prepare pnpm@$(jq -r '.packageManager' package.json | cut -d'@' -f2 | cut -d'+' -f1) --activate
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.2
           run_install: false
 
-      # Setup Node con cache de pnpm
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.0'
+          node-version: '20'
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,4 +80,3 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 - Sizes correctos para responsive images
 - Defer de componentes adicionales
 - Final tuning de imágenes optimizadas
-

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Catálogo completo con carrito "light" y consultas por WhatsApp. **Sin login ni 
 ### Debug del checkout
 
 Activar con `NEXT_PUBLIC_CHECKOUT_DEBUG=1` (no usar en producción):
+
 - Muestra estado del formulario en tiempo real
 - Indica por qué el botón está deshabilitado
 - Útil para debugging en desarrollo/preview

--- a/docs/QA_SEO.md
+++ b/docs/QA_SEO.md
@@ -50,7 +50,7 @@ AUDIT_URL="https://<tu-deploy>.vercel.app" pnpm audit:axe
 
 - **Fecha:** 2025-11-10 00:54 UTC
 - **URL:** https://dental-noriega.vercel.app
-- **Artifacts:** 
+- **Artifacts:**
   - `docs/audits/2025-11-10/lighthouse.json`
   - `docs/audits/2025-11-10/lighthouse.html`
 - **Release:** [v1.0.0](https://github.com/hekouo/dental-noriega/releases/tag/v1.0.0)

--- a/docs/audits/2025-11-10/lighthouse.json
+++ b/docs/audits/2025-11-10/lighthouse.json
@@ -584,9 +584,7 @@
             "duration": 33.288000000000004
           }
         ],
-        "sortedBy": [
-          "duration"
-        ]
+        "sortedBy": ["duration"]
       },
       "guidanceLevel": 1
     },
@@ -658,9 +656,7 @@
         "summary": {
           "wastedMs": 1447.4159999999938
         },
-        "sortedBy": [
-          "total"
-        ]
+        "sortedBy": ["total"]
       },
       "guidanceLevel": 1
     },
@@ -1162,9 +1158,7 @@
             "rtt": 12.024000000000001
           }
         ],
-        "sortedBy": [
-          "rtt"
-        ]
+        "sortedBy": ["rtt"]
       }
     },
     "network-server-latency": {
@@ -1197,9 +1191,7 @@
             "serverResponseTime": 109.36500000000001
           }
         ],
-        "sortedBy": [
-          "serverResponseTime"
-        ]
+        "sortedBy": ["serverResponseTime"]
       }
     },
     "main-thread-tasks": {
@@ -1794,12 +1786,8 @@
             "startTime": 1176.365
           }
         ],
-        "sortedBy": [
-          "duration"
-        ],
-        "skipSumming": [
-          "startTime"
-        ],
+        "sortedBy": ["duration"],
+        "skipSumming": ["startTime"],
         "debugData": {
           "type": "debugdata",
           "urls": [
@@ -3180,11 +3168,7 @@
         "debugData": {
           "type": "debugdata",
           "impact": "serious",
-          "tags": [
-            "cat.sensory-and-visual-cues",
-            "wcag22aa",
-            "wcag258"
-          ]
+          "tags": ["cat.sensory-and-visual-cues", "wcag22aa", "wcag258"]
         }
       }
     },
@@ -3393,9 +3377,7 @@
             "totalBytes": 4506
           }
         ],
-        "sortedBy": [
-          "totalBytes"
-        ]
+        "sortedBy": ["totalBytes"]
       },
       "guidanceLevel": 1
     },
@@ -3419,9 +3401,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3471,9 +3451,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3504,9 +3482,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3536,9 +3512,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3568,9 +3542,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3601,9 +3573,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3634,9 +3604,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3666,9 +3634,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3698,9 +3664,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3730,9 +3694,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3762,9 +3724,7 @@
         "items": [],
         "overallSavingsMs": 0,
         "overallSavingsBytes": 0,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -3899,9 +3859,7 @@
         ],
         "overallSavingsMs": 150,
         "overallSavingsBytes": 10473,
-        "sortedBy": [
-          "wastedBytes"
-        ],
+        "sortedBy": ["wastedBytes"],
         "debugData": {
           "type": "debugdata",
           "metricSavings": {
@@ -4388,9 +4346,7 @@
         }
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "uses-long-cache-ttl"
-      ]
+      "replacesAudits": ["uses-long-cache-ttl"]
     },
     "cls-culprits-insight": {
       "id": "cls-culprits-insight",
@@ -4618,9 +4574,7 @@
         }
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "dom-size"
-      ]
+      "replacesAudits": ["dom-size"]
     },
     "duplicated-javascript-insight": {
       "id": "duplicated-javascript-insight",
@@ -4661,9 +4615,7 @@
         }
       },
       "guidanceLevel": 2,
-      "replacesAudits": [
-        "duplicated-javascript"
-      ]
+      "replacesAudits": ["duplicated-javascript"]
     },
     "font-display-insight": {
       "id": "font-display-insight",
@@ -4691,9 +4643,7 @@
         "items": []
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "font-display"
-      ]
+      "replacesAudits": ["font-display"]
     },
     "forced-reflow-insight": {
       "id": "forced-reflow-insight",
@@ -4783,9 +4733,7 @@
       "score": null,
       "scoreDisplayMode": "notApplicable",
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "work-during-interaction"
-      ]
+      "replacesAudits": ["work-during-interaction"]
     },
     "lcp-breakdown-insight": {
       "id": "lcp-breakdown-insight",
@@ -4845,9 +4793,7 @@
         ]
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "largest-contentful-paint-element"
-      ]
+      "replacesAudits": ["largest-contentful-paint-element"]
     },
     "lcp-discovery-insight": {
       "id": "lcp-discovery-insight",
@@ -4856,10 +4802,7 @@
       "score": null,
       "scoreDisplayMode": "notApplicable",
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "prioritize-lcp-image",
-        "lcp-lazy-loaded"
-      ]
+      "replacesAudits": ["prioritize-lcp-image", "lcp-lazy-loaded"]
     },
     "legacy-javascript-insight": {
       "id": "legacy-javascript-insight",
@@ -5170,10 +5113,7 @@
         ]
       },
       "guidanceLevel": 1,
-      "replacesAudits": [
-        "critical-request-chains",
-        "uses-rel-preconnect"
-      ]
+      "replacesAudits": ["critical-request-chains", "uses-rel-preconnect"]
     },
     "render-blocking-insight": {
       "id": "render-blocking-insight",
@@ -5212,9 +5152,7 @@
         ]
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "render-blocking-resources"
-      ]
+      "replacesAudits": ["render-blocking-resources"]
     },
     "third-parties-insight": {
       "id": "third-parties-insight",
@@ -5256,9 +5194,7 @@
         "items": []
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "third-party-summary"
-      ]
+      "replacesAudits": ["third-party-summary"]
     },
     "viewport-insight": {
       "id": "viewport-insight",
@@ -5300,16 +5236,11 @@
         ]
       },
       "guidanceLevel": 3,
-      "replacesAudits": [
-        "viewport"
-      ]
+      "replacesAudits": ["viewport"]
     }
   },
   "configSettings": {
-    "output": [
-      "html",
-      "json"
-    ],
+    "output": ["html", "json"],
     "maxWaitForFcp": 30000,
     "maxWaitForLoad": 45000,
     "pauseAfterFcpMs": 1000,
@@ -5362,11 +5293,7 @@
   "categories": {
     "performance": {
       "title": "Performance",
-      "supportedModes": [
-        "navigation",
-        "timespan",
-        "snapshot"
-      ],
+      "supportedModes": ["navigation", "timespan", "snapshot"],
       "auditRefs": [
         {
           "id": "first-contentful-paint",
@@ -5748,10 +5675,7 @@
       "title": "Accessibility",
       "description": "These checks highlight opportunities to [improve the accessibility of your web app](https://developer.chrome.com/docs/lighthouse/accessibility/). Automatic detection can only detect a subset of issues and does not guarantee the accessibility of your web app, so [manual testing](https://web.dev/articles/how-to-review) is also encouraged.",
       "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://web.dev/articles/how-to-review).",
-      "supportedModes": [
-        "navigation",
-        "snapshot"
-      ],
+      "supportedModes": ["navigation", "snapshot"],
       "auditRefs": [
         {
           "id": "accesskeys",
@@ -6114,11 +6038,7 @@
     },
     "best-practices": {
       "title": "Best Practices",
-      "supportedModes": [
-        "navigation",
-        "timespan",
-        "snapshot"
-      ],
+      "supportedModes": ["navigation", "timespan", "snapshot"],
       "auditRefs": [
         {
           "id": "is-on-https",
@@ -6238,10 +6158,7 @@
       "title": "SEO",
       "description": "These checks ensure that your page is following basic search engine optimization advice. There are many additional factors Lighthouse does not score here that may affect your search ranking, including performance on [Core Web Vitals](https://web.dev/explore/vitals). [Learn more about Google Search Essentials](https://support.google.com/webmasters/answer/35769).",
       "manualDescription": "Run these additional validators on your site to check additional SEO best practices.",
-      "supportedModes": [
-        "navigation",
-        "snapshot"
-      ],
+      "supportedModes": ["navigation", "snapshot"],
       "auditRefs": [
         {
           "id": "is-crawlable",
@@ -6378,9 +6295,7 @@
   "entities": [
     {
       "name": "vercel.app",
-      "origins": [
-        "https://dental-noriega.vercel.app"
-      ],
+      "origins": ["https://dental-noriega.vercel.app"],
       "isFirstParty": true,
       "isUnrecognized": true
     }
@@ -9233,9 +9148,7 @@
       "warningHeader": "Warnings: "
     },
     "icuMessagePaths": {
-      "core/audits/is-on-https.js | title": [
-        "audits[is-on-https].title"
-      ],
+      "core/audits/is-on-https.js | title": ["audits[is-on-https].title"],
       "core/audits/is-on-https.js | description": [
         "audits[is-on-https].description"
       ],
@@ -9245,18 +9158,12 @@
       "core/audits/is-on-https.js | columnResolution": [
         "audits[is-on-https].details.headings[1].label"
       ],
-      "core/audits/redirects-http.js | title": [
-        "audits[redirects-http].title"
-      ],
+      "core/audits/redirects-http.js | title": ["audits[redirects-http].title"],
       "core/audits/redirects-http.js | description": [
         "audits[redirects-http].description"
       ],
-      "core/audits/viewport.js | title": [
-        "audits.viewport.title"
-      ],
-      "core/audits/viewport.js | description": [
-        "audits.viewport.description"
-      ],
+      "core/audits/viewport.js | title": ["audits.viewport.title"],
+      "core/audits/viewport.js | description": ["audits.viewport.description"],
       "core/lib/i18n/i18n.js | firstContentfulPaintMetric": [
         "audits[first-contentful-paint].title"
       ],
@@ -9313,9 +9220,7 @@
       "core/audits/metrics/first-meaningful-paint.js | description": [
         "audits[first-meaningful-paint].description"
       ],
-      "core/lib/i18n/i18n.js | speedIndexMetric": [
-        "audits[speed-index].title"
-      ],
+      "core/lib/i18n/i18n.js | speedIndexMetric": ["audits[speed-index].title"],
       "core/audits/metrics/speed-index.js | description": [
         "audits[speed-index].description"
       ],
@@ -9434,15 +9339,11 @@
         "audits[network-rtt].details.headings[1].label",
         "audits[network-server-latency].details.headings[1].label"
       ],
-      "core/lib/i18n/i18n.js | interactiveMetric": [
-        "audits.interactive.title"
-      ],
+      "core/lib/i18n/i18n.js | interactiveMetric": ["audits.interactive.title"],
       "core/audits/metrics/interactive.js | description": [
         "audits.interactive.description"
       ],
-      "core/audits/user-timings.js | title": [
-        "audits[user-timings].title"
-      ],
+      "core/audits/user-timings.js | title": ["audits[user-timings].title"],
       "core/audits/user-timings.js | description": [
         "audits[user-timings].description"
       ],
@@ -9477,9 +9378,7 @@
           "path": "audits[critical-request-chains].displayValue"
         }
       ],
-      "core/audits/redirects.js | title": [
-        "audits.redirects.title"
-      ],
+      "core/audits/redirects.js | title": ["audits.redirects.title"],
       "core/audits/redirects.js | description": [
         "audits.redirects.description"
       ],
@@ -9510,9 +9409,7 @@
       "core/audits/image-size-responsive.js | columnExpected": [
         "audits[image-size-responsive].details.headings[4].label"
       ],
-      "core/audits/deprecations.js | title": [
-        "audits.deprecations.title"
-      ],
+      "core/audits/deprecations.js | title": ["audits.deprecations.title"],
       "core/audits/deprecations.js | description": [
         "audits.deprecations.description"
       ],
@@ -9578,9 +9475,7 @@
       "core/audits/uses-rel-preconnect.js | tooManyPreconnectLinksWarning": [
         "audits[uses-rel-preconnect].warnings[3]"
       ],
-      "core/audits/font-display.js | title": [
-        "audits[font-display].title"
-      ],
+      "core/audits/font-display.js | title": ["audits[font-display].title"],
       "core/audits/font-display.js | description": [
         "audits[font-display].description"
       ],
@@ -9590,9 +9485,7 @@
         "audits[font-display-insight].details.headings[1].label",
         "audits[image-delivery-insight].details.headings[2].label"
       ],
-      "core/audits/network-rtt.js | title": [
-        "audits[network-rtt].title"
-      ],
+      "core/audits/network-rtt.js | title": ["audits[network-rtt].title"],
       "core/audits/network-rtt.js | description": [
         "audits[network-rtt].description"
       ],
@@ -9696,9 +9589,7 @@
       "core/audits/lcp-lazy-loaded.js | description": [
         "audits[lcp-lazy-loaded].description"
       ],
-      "core/audits/layout-shifts.js | title": [
-        "audits[layout-shifts].title"
-      ],
+      "core/audits/layout-shifts.js | title": ["audits[layout-shifts].title"],
       "core/audits/layout-shifts.js | description": [
         "audits[layout-shifts].description"
       ],
@@ -9713,9 +9604,7 @@
       "core/audits/layout-shifts.js | columnScore": [
         "audits[layout-shifts].details.headings[1].label"
       ],
-      "core/audits/long-tasks.js | title": [
-        "audits[long-tasks].title"
-      ],
+      "core/audits/long-tasks.js | title": ["audits[long-tasks].title"],
       "core/audits/long-tasks.js | description": [
         "audits[long-tasks].description"
       ],
@@ -9733,9 +9622,7 @@
       "core/audits/non-composited-animations.js | description": [
         "audits[non-composited-animations].description"
       ],
-      "core/audits/unsized-images.js | title": [
-        "audits[unsized-images].title"
-      ],
+      "core/audits/unsized-images.js | title": ["audits[unsized-images].title"],
       "core/audits/unsized-images.js | description": [
         "audits[unsized-images].description"
       ],
@@ -9754,12 +9641,8 @@
       "core/audits/prioritize-lcp-image.js | description": [
         "audits[prioritize-lcp-image].description"
       ],
-      "core/audits/csp-xss.js | title": [
-        "audits[csp-xss].title"
-      ],
-      "core/audits/csp-xss.js | description": [
-        "audits[csp-xss].description"
-      ],
+      "core/audits/csp-xss.js | title": ["audits[csp-xss].title"],
+      "core/audits/csp-xss.js | description": ["audits[csp-xss].description"],
       "core/audits/csp-xss.js | columnDirective": [
         "audits[csp-xss].details.headings[1].label"
       ],
@@ -9775,12 +9658,8 @@
       "core/audits/csp-xss.js | noCsp": [
         "audits[csp-xss].details.items[0].description"
       ],
-      "core/audits/has-hsts.js | title": [
-        "audits[has-hsts].title"
-      ],
-      "core/audits/has-hsts.js | description": [
-        "audits[has-hsts].description"
-      ],
+      "core/audits/has-hsts.js | title": ["audits[has-hsts].title"],
+      "core/audits/has-hsts.js | description": ["audits[has-hsts].description"],
       "core/audits/has-hsts.js | columnDirective": [
         "audits[has-hsts].details.headings[1].label"
       ],
@@ -10000,9 +9879,7 @@
       "core/audits/accessibility/button-name.js | description": [
         "audits[button-name].description"
       ],
-      "core/audits/accessibility/bypass.js | title": [
-        "audits.bypass.title"
-      ],
+      "core/audits/accessibility/bypass.js | title": ["audits.bypass.title"],
       "core/audits/accessibility/bypass.js | description": [
         "audits.bypass.description"
       ],
@@ -10018,9 +9895,7 @@
       "core/audits/accessibility/definition-list.js | description": [
         "audits[definition-list].description"
       ],
-      "core/audits/accessibility/dlitem.js | title": [
-        "audits.dlitem.title"
-      ],
+      "core/audits/accessibility/dlitem.js | title": ["audits.dlitem.title"],
       "core/audits/accessibility/dlitem.js | description": [
         "audits.dlitem.description"
       ],
@@ -10114,9 +9989,7 @@
       "core/audits/accessibility/label-content-name-mismatch.js | description": [
         "audits[label-content-name-mismatch].description"
       ],
-      "core/audits/accessibility/label.js | title": [
-        "audits.label.title"
-      ],
+      "core/audits/accessibility/label.js | title": ["audits.label.title"],
       "core/audits/accessibility/label.js | description": [
         "audits.label.description"
       ],
@@ -10138,9 +10011,7 @@
       "core/audits/accessibility/link-in-text-block.js | description": [
         "audits[link-in-text-block].description"
       ],
-      "core/audits/accessibility/list.js | title": [
-        "audits.list.title"
-      ],
+      "core/audits/accessibility/list.js | title": ["audits.list.title"],
       "core/audits/accessibility/list.js | description": [
         "audits.list.description"
       ],
@@ -10358,21 +10229,15 @@
           "path": "audits[legacy-javascript-insight].displayValue"
         }
       ],
-      "core/audits/dobetterweb/doctype.js | title": [
-        "audits.doctype.title"
-      ],
+      "core/audits/dobetterweb/doctype.js | title": ["audits.doctype.title"],
       "core/audits/dobetterweb/doctype.js | description": [
         "audits.doctype.description"
       ],
-      "core/audits/dobetterweb/charset.js | title": [
-        "audits.charset.title"
-      ],
+      "core/audits/dobetterweb/charset.js | title": ["audits.charset.title"],
       "core/audits/dobetterweb/charset.js | description": [
         "audits.charset.description"
       ],
-      "core/audits/dobetterweb/dom-size.js | title": [
-        "audits[dom-size].title"
-      ],
+      "core/audits/dobetterweb/dom-size.js | title": ["audits[dom-size].title"],
       "core/audits/dobetterweb/dom-size.js | description": [
         "audits[dom-size].description"
       ],
@@ -10462,9 +10327,7 @@
       "core/audits/seo/http-status-code.js | description": [
         "audits[http-status-code].description"
       ],
-      "core/audits/seo/font-size.js | title": [
-        "audits[font-size].title"
-      ],
+      "core/audits/seo/font-size.js | title": ["audits[font-size].title"],
       "core/audits/seo/font-size.js | description": [
         "audits[font-size].description"
       ],
@@ -10488,9 +10351,7 @@
       "core/audits/seo/font-size.js | legibleText": [
         "audits[font-size].details.items[0].source.value"
       ],
-      "core/audits/seo/link-text.js | title": [
-        "audits[link-text].title"
-      ],
+      "core/audits/seo/link-text.js | title": ["audits[link-text].title"],
       "core/audits/seo/link-text.js | description": [
         "audits[link-text].description"
       ],
@@ -10503,27 +10364,19 @@
       "core/audits/seo/crawlable-anchors.js | columnFailingLink": [
         "audits[crawlable-anchors].details.headings[0].label"
       ],
-      "core/audits/seo/is-crawlable.js | title": [
-        "audits[is-crawlable].title"
-      ],
+      "core/audits/seo/is-crawlable.js | title": ["audits[is-crawlable].title"],
       "core/audits/seo/is-crawlable.js | description": [
         "audits[is-crawlable].description"
       ],
-      "core/audits/seo/robots-txt.js | title": [
-        "audits[robots-txt].title"
-      ],
+      "core/audits/seo/robots-txt.js | title": ["audits[robots-txt].title"],
       "core/audits/seo/robots-txt.js | description": [
         "audits[robots-txt].description"
       ],
-      "core/audits/seo/hreflang.js | title": [
-        "audits.hreflang.title"
-      ],
+      "core/audits/seo/hreflang.js | title": ["audits.hreflang.title"],
       "core/audits/seo/hreflang.js | description": [
         "audits.hreflang.description"
       ],
-      "core/audits/seo/canonical.js | title": [
-        "audits.canonical.title"
-      ],
+      "core/audits/seo/canonical.js | title": ["audits.canonical.title"],
       "core/audits/seo/canonical.js | description": [
         "audits.canonical.description"
       ],
@@ -10533,12 +10386,8 @@
       "core/audits/seo/manual/structured-data.js | description": [
         "audits[structured-data].description"
       ],
-      "core/audits/bf-cache.js | title": [
-        "audits[bf-cache].title"
-      ],
-      "core/audits/bf-cache.js | description": [
-        "audits[bf-cache].description"
-      ],
+      "core/audits/bf-cache.js | title": ["audits[bf-cache].title"],
+      "core/audits/bf-cache.js | description": ["audits[bf-cache].description"],
       "node_modules/@paulirish/trace_engine/models/trace/insights/Cache.js | title": [
         "audits[cache-insight].title"
       ],

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "engines": {
     "pnpm": "10",
-    "node": ">=20.19 <21"
+    "node": ">=20 <21"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,css,md,json}": [

--- a/src/components/ui/safe-area.module.css
+++ b/src/components/ui/safe-area.module.css
@@ -2,4 +2,3 @@
 .pbSafe {
   padding-bottom: calc(1rem + var(--safe-b, 0px));
 }
-

--- a/test-results/axe-A11y-Axe-a11y-tienda-chromium/error-context.md
+++ b/test-results/axe-A11y-Axe-a11y-tienda-chromium/error-context.md
@@ -2,138 +2,138 @@
 
 ```yaml
 - generic [active] [ref=e1]:
-  - banner [ref=e2]:
-    - navigation [ref=e3]:
-      - link "Logo Depósito Dental Noriega Depósito Dental Noriega" [ref=e4] [cursor=pointer]:
-        - /url: /
-        - generic [ref=e5]:
-          - img "Logo Depósito Dental Noriega" [ref=e7]
-          - generic [ref=e12]: Depósito Dental Noriega
-      - generic [ref=e14]:
-        - generic [ref=e15]:
-          - img [ref=e16]
-          - combobox "Buscar productos" [ref=e19]
-        - button "Buscar" [disabled] [ref=e20]:
-          - img [ref=e21]
-          - generic [ref=e24]: Buscar
-      - generic [ref=e25]:
-        - link "Catálogo" [ref=e26] [cursor=pointer]:
-          - /url: /catalogo
-          - generic [ref=e27]: Catálogo
-        - link "Destacados" [ref=e28] [cursor=pointer]:
-          - /url: /destacados
-          - generic [ref=e29]: Destacados
-        - generic [ref=e30]:
-          - button "Ir a checkout" [ref=e31] [cursor=pointer]: "0"
-          - button "Cuenta" [ref=e32] [cursor=pointer]:
-            - img [ref=e33]
-  - main [ref=e36]:
-    - generic [ref=e37]:
-      - generic [ref=e39]:
-        - heading "Catálogo Completo" [level=1] [ref=e40]
-        - paragraph [ref=e41]: Explora todas nuestras categorías
-      - generic [ref=e42]:
-        - heading "Destacados" [level=2] [ref=e43]
-        - generic [ref=e44]:
-          - paragraph [ref=e45]: No hay productos destacados en este momento.
-          - link "Buscar productos" [ref=e46] [cursor=pointer]:
-            - /url: /buscar
-      - generic [ref=e48]:
-        - link "Consumibles y Profilaxis" [ref=e49] [cursor=pointer]:
-          - /url: /tienda/consumibles
-          - heading "Consumibles y Profilaxis" [level=2] [ref=e51]
-        - link "Equipos" [ref=e52] [cursor=pointer]:
-          - /url: /tienda/equipos
-          - heading "Equipos" [level=2] [ref=e54]
-        - link "Instrumental Clínico" [ref=e55] [cursor=pointer]:
-          - /url: /tienda/instrumental-clinico
-          - heading "Instrumental Clínico" [level=2] [ref=e57]
-        - link "Instrumental Ortodoncia" [ref=e58] [cursor=pointer]:
-          - /url: /tienda/instrumental-ortodoncia
-          - heading "Instrumental Ortodoncia" [level=2] [ref=e60]
-        - 'link "Ortodoncia: Brackets y Tubos" [ref=e61] [cursor=pointer]':
-          - /url: /tienda/ortodoncia-brackets
-          - 'heading "Ortodoncia: Brackets y Tubos" [level=2] [ref=e63]'
-        - 'link "Ortodoncia: Arcos y Resortes" [ref=e64] [cursor=pointer]':
-          - /url: /tienda/ortodoncia-arcos
-          - 'heading "Ortodoncia: Arcos y Resortes" [level=2] [ref=e66]'
-        - 'link "Ortodoncia: Accesorios y Retenedores" [ref=e67] [cursor=pointer]':
-          - /url: /tienda/ortodoncia-accesorios
-          - 'heading "Ortodoncia: Accesorios y Retenedores" [level=2] [ref=e69]'
-    - generic [ref=e70]:
-      - generic [ref=e71]:
-        - heading "Gracias por revisar el catálogo" [level=2] [ref=e72]
-        - paragraph [ref=e73]: Estamos listos para ayudarte con tus compras y dudas técnicas. Escríbenos y con gusto te atendemos.
-        - list [ref=e74]:
-          - listitem [ref=e75]:
-            - strong [ref=e76]: "WhatsApp:"
-            - link "+52 553 103 3715" [ref=e77] [cursor=pointer]:
-              - /url: https://wa.me/525531033715?text=Hola%2C%20vengo%20desde%20Deposito%20Dental%20Noriega.
-          - listitem [ref=e78]:
-            - strong [ref=e79]: "Email:"
-            - link "dental.noriega721@gmail.com" [ref=e80] [cursor=pointer]:
-              - /url: mailto:dental.noriega721@gmail.com
-          - listitem [ref=e81]:
-            - strong [ref=e82]: "Ubicación:"
-            - link "Ver en Google Maps" [ref=e83] [cursor=pointer]:
-              - /url: https://maps.app.goo.gl/ruP2HHjLXtoKqnB57
-        - generic [ref=e84]:
-          - link "Escribir por WhatsApp" [ref=e85] [cursor=pointer]:
-            - /url: https://wa.me/525531033715?text=Hola%2C%20vengo%20desde%20Deposito%20Dental%20Noriega.
-            - generic [ref=e86]: Escribir por WhatsApp
-          - generic [ref=e87]:
-            - link "Facebook" [ref=e88] [cursor=pointer]:
-              - /url: https://www.facebook.com/dental.noriega/?locale=es_LA
-            - link "Instagram" [ref=e89] [cursor=pointer]:
-              - /url: https://www.instagram.com/deposito.dental.noriega
-      - generic [ref=e91]:
-        - img "Escanea para WhatsApp" [ref=e92]
-        - paragraph [ref=e93]: Escanéame para WhatsApp
-  - alert [ref=e94]
-  - button "Abrir carrito" [ref=e96] [cursor=pointer]:
-    - img [ref=e97]
-  - link "Chatear por WhatsApp" [ref=e102] [cursor=pointer]:
-    - /url: https://wa.me/525531033715?text=Hola%2C%20vengo%20desde%20Deposito%20Dental%20Noriega.%20P%C3%A1gina%3A%20%2Ftienda.%20%C2%BFMe%20ayudas%3F
-    - img [ref=e103]
-  - contentinfo [ref=e106]:
-    - generic [ref=e107]:
-      - generic [ref=e108]:
-        - heading "Deposito Dental Noriega" [level=3] [ref=e109]
-        - paragraph [ref=e110]: Insumos y equipos dentales. Servicio a clínicas, consultorios y mayoristas.
-      - generic [ref=e111]:
-        - heading "Información" [level=3] [ref=e112]
-        - list [ref=e113]:
-          - listitem [ref=e114]:
-            - link "Envíos" [ref=e115] [cursor=pointer]:
-              - /url: /envios
-          - listitem [ref=e116]:
-            - link "Devoluciones" [ref=e117] [cursor=pointer]:
-              - /url: /devoluciones
-          - listitem [ref=e118]:
-            - link "Aviso de privacidad" [ref=e119] [cursor=pointer]:
-              - /url: /aviso-privacidad
-          - listitem [ref=e120]:
-            - link "Términos y condiciones" [ref=e121] [cursor=pointer]:
-              - /url: /terminos-condiciones
-      - generic [ref=e122]:
-        - heading "Contacto" [level=3] [ref=e123]
-        - paragraph [ref=e124]:
-          - text: "WhatsApp:"
-          - link "+52 55 3103 3715" [ref=e125] [cursor=pointer]:
-            - /url: https://wa.me/525531033715
-        - paragraph [ref=e126]:
-          - text: "Email:"
-          - link "dental.noriega721@gmail.com" [ref=e127] [cursor=pointer]:
-            - /url: mailto:dental.noriega721@gmail.com
-        - paragraph [ref=e128]:
-          - link "Ver ubicación en Maps" [ref=e129] [cursor=pointer]:
-            - /url: https://maps.app.goo.gl/ruP2HHjLXtoKqnB57
-      - generic [ref=e130]:
-        - heading "Síguenos" [level=3] [ref=e131]
-        - generic [ref=e132]:
-          - link "Facebook" [ref=e133] [cursor=pointer]:
-            - /url: https://www.facebook.com/dental.noriega/?locale=es_LA
-          - link "Instagram" [ref=e134] [cursor=pointer]:
-            - /url: https://www.instagram.com/deposito.dental.noriega
-    - generic [ref=e135]: © 2025 Deposito Dental Noriega · Todos los derechos reservados
+    - banner [ref=e2]:
+        - navigation [ref=e3]:
+            - link "Logo Depósito Dental Noriega Depósito Dental Noriega" [ref=e4] [cursor=pointer]:
+                - /url: /
+                - generic [ref=e5]:
+                    - img "Logo Depósito Dental Noriega" [ref=e7]
+                    - generic [ref=e12]: Depósito Dental Noriega
+            - generic [ref=e14]:
+                - generic [ref=e15]:
+                    - img [ref=e16]
+                    - combobox "Buscar productos" [ref=e19]
+                - button "Buscar" [disabled] [ref=e20]:
+                    - img [ref=e21]
+                    - generic [ref=e24]: Buscar
+            - generic [ref=e25]:
+                - link "Catálogo" [ref=e26] [cursor=pointer]:
+                    - /url: /catalogo
+                    - generic [ref=e27]: Catálogo
+                - link "Destacados" [ref=e28] [cursor=pointer]:
+                    - /url: /destacados
+                    - generic [ref=e29]: Destacados
+                - generic [ref=e30]:
+                    - button "Ir a checkout" [ref=e31] [cursor=pointer]: "0"
+                    - button "Cuenta" [ref=e32] [cursor=pointer]:
+                        - img [ref=e33]
+    - main [ref=e36]:
+        - generic [ref=e37]:
+            - generic [ref=e39]:
+                - heading "Catálogo Completo" [level=1] [ref=e40]
+                - paragraph [ref=e41]: Explora todas nuestras categorías
+            - generic [ref=e42]:
+                - heading "Destacados" [level=2] [ref=e43]
+                - generic [ref=e44]:
+                    - paragraph [ref=e45]: No hay productos destacados en este momento.
+                    - link "Buscar productos" [ref=e46] [cursor=pointer]:
+                        - /url: /buscar
+            - generic [ref=e48]:
+                - link "Consumibles y Profilaxis" [ref=e49] [cursor=pointer]:
+                    - /url: /tienda/consumibles
+                    - heading "Consumibles y Profilaxis" [level=2] [ref=e51]
+                - link "Equipos" [ref=e52] [cursor=pointer]:
+                    - /url: /tienda/equipos
+                    - heading "Equipos" [level=2] [ref=e54]
+                - link "Instrumental Clínico" [ref=e55] [cursor=pointer]:
+                    - /url: /tienda/instrumental-clinico
+                    - heading "Instrumental Clínico" [level=2] [ref=e57]
+                - link "Instrumental Ortodoncia" [ref=e58] [cursor=pointer]:
+                    - /url: /tienda/instrumental-ortodoncia
+                    - heading "Instrumental Ortodoncia" [level=2] [ref=e60]
+                - 'link "Ortodoncia: Brackets y Tubos" [ref=e61] [cursor=pointer]':
+                    - /url: /tienda/ortodoncia-brackets
+                    - 'heading "Ortodoncia: Brackets y Tubos" [level=2] [ref=e63]'
+                - 'link "Ortodoncia: Arcos y Resortes" [ref=e64] [cursor=pointer]':
+                    - /url: /tienda/ortodoncia-arcos
+                    - 'heading "Ortodoncia: Arcos y Resortes" [level=2] [ref=e66]'
+                - 'link "Ortodoncia: Accesorios y Retenedores" [ref=e67] [cursor=pointer]':
+                    - /url: /tienda/ortodoncia-accesorios
+                    - 'heading "Ortodoncia: Accesorios y Retenedores" [level=2] [ref=e69]'
+        - generic [ref=e70]:
+            - generic [ref=e71]:
+                - heading "Gracias por revisar el catálogo" [level=2] [ref=e72]
+                - paragraph [ref=e73]: Estamos listos para ayudarte con tus compras y dudas técnicas. Escríbenos y con gusto te atendemos.
+                - list [ref=e74]:
+                    - listitem [ref=e75]:
+                        - strong [ref=e76]: "WhatsApp:"
+                        - link "+52 553 103 3715" [ref=e77] [cursor=pointer]:
+                            - /url: https://wa.me/525531033715?text=Hola%2C%20vengo%20desde%20Deposito%20Dental%20Noriega.
+                    - listitem [ref=e78]:
+                        - strong [ref=e79]: "Email:"
+                        - link "dental.noriega721@gmail.com" [ref=e80] [cursor=pointer]:
+                            - /url: mailto:dental.noriega721@gmail.com
+                    - listitem [ref=e81]:
+                        - strong [ref=e82]: "Ubicación:"
+                        - link "Ver en Google Maps" [ref=e83] [cursor=pointer]:
+                            - /url: https://maps.app.goo.gl/ruP2HHjLXtoKqnB57
+                - generic [ref=e84]:
+                    - link "Escribir por WhatsApp" [ref=e85] [cursor=pointer]:
+                        - /url: https://wa.me/525531033715?text=Hola%2C%20vengo%20desde%20Deposito%20Dental%20Noriega.
+                        - generic [ref=e86]: Escribir por WhatsApp
+                    - generic [ref=e87]:
+                        - link "Facebook" [ref=e88] [cursor=pointer]:
+                            - /url: https://www.facebook.com/dental.noriega/?locale=es_LA
+                        - link "Instagram" [ref=e89] [cursor=pointer]:
+                            - /url: https://www.instagram.com/deposito.dental.noriega
+            - generic [ref=e91]:
+                - img "Escanea para WhatsApp" [ref=e92]
+                - paragraph [ref=e93]: Escanéame para WhatsApp
+    - alert [ref=e94]
+    - button "Abrir carrito" [ref=e96] [cursor=pointer]:
+        - img [ref=e97]
+    - link "Chatear por WhatsApp" [ref=e102] [cursor=pointer]:
+        - /url: https://wa.me/525531033715?text=Hola%2C%20vengo%20desde%20Deposito%20Dental%20Noriega.%20P%C3%A1gina%3A%20%2Ftienda.%20%C2%BFMe%20ayudas%3F
+        - img [ref=e103]
+    - contentinfo [ref=e106]:
+        - generic [ref=e107]:
+            - generic [ref=e108]:
+                - heading "Deposito Dental Noriega" [level=3] [ref=e109]
+                - paragraph [ref=e110]: Insumos y equipos dentales. Servicio a clínicas, consultorios y mayoristas.
+            - generic [ref=e111]:
+                - heading "Información" [level=3] [ref=e112]
+                - list [ref=e113]:
+                    - listitem [ref=e114]:
+                        - link "Envíos" [ref=e115] [cursor=pointer]:
+                            - /url: /envios
+                    - listitem [ref=e116]:
+                        - link "Devoluciones" [ref=e117] [cursor=pointer]:
+                            - /url: /devoluciones
+                    - listitem [ref=e118]:
+                        - link "Aviso de privacidad" [ref=e119] [cursor=pointer]:
+                            - /url: /aviso-privacidad
+                    - listitem [ref=e120]:
+                        - link "Términos y condiciones" [ref=e121] [cursor=pointer]:
+                            - /url: /terminos-condiciones
+            - generic [ref=e122]:
+                - heading "Contacto" [level=3] [ref=e123]
+                - paragraph [ref=e124]:
+                    - text: "WhatsApp:"
+                    - link "+52 55 3103 3715" [ref=e125] [cursor=pointer]:
+                        - /url: https://wa.me/525531033715
+                - paragraph [ref=e126]:
+                    - text: "Email:"
+                    - link "dental.noriega721@gmail.com" [ref=e127] [cursor=pointer]:
+                        - /url: mailto:dental.noriega721@gmail.com
+                - paragraph [ref=e128]:
+                    - link "Ver ubicación en Maps" [ref=e129] [cursor=pointer]:
+                        - /url: https://maps.app.goo.gl/ruP2HHjLXtoKqnB57
+            - generic [ref=e130]:
+                - heading "Síguenos" [level=3] [ref=e131]
+                - generic [ref=e132]:
+                    - link "Facebook" [ref=e133] [cursor=pointer]:
+                        - /url: https://www.facebook.com/dental.noriega/?locale=es_LA
+                    - link "Instagram" [ref=e134] [cursor=pointer]:
+                        - /url: https://www.instagram.com/deposito.dental.noriega
+        - generic [ref=e135]: © 2025 Deposito Dental Noriega · Todos los derechos reservados
 ```


### PR DESCRIPTION
## Objetivo

Arreglar error "Multiple versions of pnpm specified" en GitHub Actions usando packageManager como única fuente de verdad.

## Cambios

### Workflows

- ci.yml y audit.yml:
  - Agregado paso Enable Corepack antes de setup de pnpm
  - Agregado paso Prepare pnpm from packageManager que lee la versión desde package.json
  - Removido version: 10.18.2 de pnpm/action-setup@v4
  - Mantenido pnpm/action-setup@v4 solo para cache (sin version)

### package.json

- Actualizado engines.node de ">=20.19 <21" a ">=20 <21"
- packageManager se mantiene como está: pnpm@10.18.2+sha512...

### Otros

- ci.yml ahora se dispara en main (antes era chore/wip-pre-restart)
- node-version actualizado a "20" (antes era "20.19.0" en ci.yml)

## Resultado Esperado

- CI y audit corren sin error "Multiple versions of pnpm specified"
- Los checks build y audit quedan disponibles para marcar en Branch Protection
- pnpm se obtiene desde packageManager vía Corepack como única fuente de verdad

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes pnpm via Corepack using packageManager in workflows (no pinned version), switches CI triggers to main, updates Node engine, and adds audit docs/artifacts.
> 
> - **CI/CD**:
>   - Enable Corepack and prepare `pnpm` from `packageManager` in `.github/workflows/{ci,audit}.yml`.
>   - Drop pinned `pnpm` version from `pnpm/action-setup`; keep for cache only.
>   - Set Node to `20` and trigger CI on `main`.
> - **Config**:
>   - Relax `engines.node` in `package.json` to `">=20 <21"`.
> - **Docs/Artifacts**:
>   - Update QA SEO docs with latest audit results and add Lighthouse artifacts under `docs/audits/2025-11-10/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 620e0594229889546610e2b8ee80ecee00240703. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->