### PR TITLE
feat(cart): buy-now + qty in lists

### DIFF
--- a/src/components/CatalogCardControls.tsx
+++ b/src/components/CatalogCardControls.tsx
@@ -1,7 +1,7 @@
 // src/components/CatalogCardControls.tsx
 "use client";
 import { useState, useRef } from "react";
-import QtyStepper from "@/components/ui/QtyStepper";
+import QuantityInput from "@/components/cart/QuantityInput";
 import { useCartStore } from "@/lib/store/cartStore";
 import { mxnFromCents } from "@/lib/utils/currency";
 import { ShoppingCart } from "lucide-react";
@@ -54,17 +54,21 @@ export default function CatalogCardControls({ item }: Props) {
   return (
     <div className="mt-auto pt-2 space-y-2">
       <div className="flex items-center gap-2">
-        <QtyStepper
+        <QuantityInput
           value={qty}
-          onValueChange={setQty}
+          onChange={setQty}
           min={1}
-          max={99}
+          max={999}
           disabled={!canBuy}
+          compact
+          ariaLabel="Cantidad"
         />
         <button
           onClick={onAdd}
           disabled={!canBuy}
-          className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm bg-black text-white disabled:opacity-50"
+          aria-label="Agregar al carrito"
+          className="flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm bg-black text-white disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+          title="Agregar al carrito"
         >
           <ShoppingCart size={16} />
           <span>Agregar</span>

--- a/src/components/FeaturedCardControls.tsx
+++ b/src/components/FeaturedCardControls.tsx
@@ -7,6 +7,7 @@ import { normalizePrice, hasPurchasablePrice } from "@/lib/catalog/model";
 import { getWhatsAppHref } from "@/lib/whatsapp";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
 import { useCartStore } from "@/lib/store/cartStore";
+import QuantityInput from "@/components/cart/QuantityInput";
 
 type Props = {
   item: FeaturedItem;
@@ -115,55 +116,26 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
     setQty(Math.min(maxQty, Math.max(1, next)));
   };
 
-  const qtyInput = (
-    <input
-      aria-label="Cantidad"
-      className={
-        compact
-          ? "w-10 text-center outline-none text-base"
-          : "w-10 text-center outline-none"
-      }
-      inputMode="numeric"
-      value={qty}
-      onChange={(e) => {
-        const v = parseInt(e.target.value.replace(/[^\d]/g, "") || "1", 10);
-        handleQtyChange(v);
-      }}
-      disabled={isAdding}
-    />
-  );
-
   if (!compact) {
     return (
       <div className="mt-auto pt-3 space-y-2">
         <div className="flex items-center gap-3">
-          <div className="flex items-center rounded-lg border px-2 py-1">
-            <button
-              type="button"
-              className="h-8 w-6 text-xl"
-              aria-label="Disminuir cantidad"
-              onClick={() => handleQtyChange(qty - 1)}
-              disabled={isAdding || qty <= 1}
-            >
-              –
-            </button>
-            {qtyInput}
-            <button
-              type="button"
-              className="h-8 w-6 text-xl"
-              aria-label="Aumentar cantidad"
-              onClick={() => handleQtyChange(qty + 1)}
-              disabled={isAdding || qty >= maxQty}
-            >
-              +
-            </button>
-          </div>
+          <QuantityInput
+            value={qty}
+            onChange={handleQtyChange}
+            min={1}
+            max={maxQty}
+            disabled={isAdding}
+            ariaLabel="Cantidad"
+          />
           <button
             type="button"
             onClick={onAdd}
             aria-busy={isAdding}
-            className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-white hover:bg-black/90 disabled:opacity-60"
+            aria-label="Agregar al carrito"
+            className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-white hover:bg-black/90 disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
             disabled={isAdding}
+            title="Agregar al carrito"
           >
             <ShoppingCartIcon className="h-4 w-4" />
             Agregar
@@ -176,6 +148,7 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm underline text-muted-foreground"
+              aria-label="Consultar por WhatsApp"
             >
               Consultar por WhatsApp
             </a>
@@ -188,34 +161,24 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
   return (
     <div className="mt-2 space-y-2">
       <div className="flex items-center gap-3">
-        <div className="flex items-center rounded-lg border h-9 px-3">
-          <button
-            type="button"
-            className="h-9 w-6 text-base font-medium"
-            aria-label="Disminuir cantidad"
-            onClick={() => handleQtyChange(qty - 1)}
-            disabled={isAdding || qty <= 1}
-          >
-            –
-          </button>
-          {qtyInput}
-          <button
-            type="button"
-            className="h-9 w-6 text-base font-medium"
-            aria-label="Aumentar cantidad"
-            onClick={() => handleQtyChange(qty + 1)}
-            disabled={isAdding || qty >= maxQty}
-          >
-            +
-          </button>
-        </div>
+        <QuantityInput
+          value={qty}
+          onChange={handleQtyChange}
+          min={1}
+          max={maxQty}
+          disabled={isAdding}
+          compact
+          ariaLabel="Cantidad"
+        />
 
         <button
           type="button"
           onClick={onAdd}
           aria-busy={isAdding}
-          className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-white hover:bg-black/90 disabled:opacity-60 h-9"
+          aria-label="Agregar al carrito"
+          className="inline-flex items-center gap-2 rounded-xl bg-black px-4 py-2 text-white hover:bg-black/90 disabled:opacity-60 h-9 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
           disabled={isAdding}
+          title="Agregar al carrito"
         >
           <ShoppingCartIcon className="h-4 w-4" />
           <span>Agregar</span>
@@ -228,6 +191,7 @@ export default function FeaturedCardControls({ item, compact = false }: Props) {
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm underline text-muted-foreground block"
+          aria-label="Consultar por WhatsApp"
         >
           Consultar por WhatsApp
         </a>

--- a/src/components/cart/QuantityInput.tsx
+++ b/src/components/cart/QuantityInput.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, { useState, useEffect, KeyboardEvent } from "react";
+
+type Props = {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  disabled?: boolean;
+  compact?: boolean;
+  ariaLabel?: string;
+};
+
+export default function QuantityInput({
+  value,
+  onChange,
+  min = 1,
+  max = 999,
+  disabled = false,
+  compact = false,
+  ariaLabel = "Cantidad",
+}: Props) {
+  const [localValue, setLocalValue] = useState(value);
+
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const handleChange = (next: number) => {
+    const clamped = Math.min(max, Math.max(min, next));
+    setLocalValue(clamped);
+    onChange(clamped);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^\d]/g, "");
+    if (raw === "") {
+      setLocalValue(min);
+      onChange(min);
+      return;
+    }
+    const num = parseInt(raw, 10);
+    if (!isNaN(num)) {
+      handleChange(num);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      handleChange(localValue + 1);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      handleChange(localValue - 1);
+    }
+  };
+
+  const decrement = () => {
+    handleChange(localValue - 1);
+  };
+
+  const increment = () => {
+    handleChange(localValue + 1);
+  };
+
+  const inputClasses = compact
+    ? "w-10 text-center outline-none text-base"
+    : "w-10 text-center outline-none";
+  const buttonClasses = compact
+    ? "h-9 w-6 text-base font-medium"
+    : "h-8 w-6 text-xl";
+  const containerClasses = compact
+    ? "flex items-center rounded-lg border h-9 px-3"
+    : "flex items-center rounded-lg border px-2 py-1";
+
+  return (
+    <div className={containerClasses}>
+      <button
+        type="button"
+        className={buttonClasses}
+        aria-label="Disminuir cantidad"
+        onClick={decrement}
+        disabled={disabled || localValue <= min}
+        title="Disminuir cantidad"
+      >
+        –
+      </button>
+      <input
+        type="text"
+        inputMode="numeric"
+        aria-label={ariaLabel}
+        value={localValue}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={inputClasses}
+        min={min}
+        max={max}
+      />
+      <button
+        type="button"
+        className={buttonClasses}
+        aria-label="Aumentar cantidad"
+        onClick={increment}
+        disabled={disabled || localValue >= max}
+        title="Aumentar cantidad"
+      >
+        +
+      </button>
+    </div>
+  );
+}
+

--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import QtyStepper from "@/components/ui/QtyStepper";
+import QuantityInput from "@/components/cart/QuantityInput";
 import { useCartStore } from "@/lib/store/cartStore";
+import { useCheckoutStore } from "@/lib/store/checkoutStore";
 import { mxnFromCents, formatMXNFromCents } from "@/lib/utils/currency";
 
 type Product = {
@@ -23,6 +24,9 @@ type Props = {
 export default function ProductActions({ product }: Props) {
   const [qty, setQty] = useState(1);
   const addToCart = useCartStore((s) => s.addToCart);
+  const upsertSingleToCheckout = useCheckoutStore(
+    (s) => s.upsertSingleToCheckout,
+  );
   const router = useRouter();
   const busyRef = useRef(false);
 
@@ -70,14 +74,13 @@ export default function ProductActions({ product }: Props) {
     if (!canBuy || busyRef.current) return;
 
     busyRef.current = true;
-    // Agregar al carrito primero
-    addToCart({
+    // Guardar en checkoutStore directamente
+    upsertSingleToCheckout({
       id: product.id,
       title: product.title,
       price,
       qty,
       image_url: product.image_url ?? undefined,
-      selected: true,
     });
 
     // Analítica: buy_now
@@ -121,12 +124,13 @@ export default function ProductActions({ product }: Props) {
           <label htmlFor="qty" className="text-sm font-medium text-gray-700">
             Cantidad:
           </label>
-          <QtyStepper
+          <QuantityInput
             value={qty}
-            onValueChange={setQty}
+            onChange={setQty}
             min={1}
-            max={99}
+            max={999}
             disabled={!canBuy}
+            ariaLabel="Cantidad de producto"
           />
         </div>
 
@@ -134,7 +138,9 @@ export default function ProductActions({ product }: Props) {
           <button
             onClick={handleAddToCart}
             disabled={!canBuy}
-            className="w-full bg-primary-600 text-white px-6 py-3 rounded-md hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Agregar al carrito"
+            className="w-full bg-primary-600 text-white px-6 py-3 rounded-md hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+            title="Agregar al carrito"
           >
             Agregar al carrito
           </button>
@@ -142,9 +148,11 @@ export default function ProductActions({ product }: Props) {
           <button
             onClick={handleBuyNow}
             disabled={!canBuy}
-            className="w-full bg-green-600 text-white px-6 py-3 rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
+            aria-label="Comprar ahora"
+            className="w-full bg-green-600 text-white px-6 py-3 rounded-md hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+            title="Comprar ahora"
           >
-            Comprar ya
+            Comprar ahora
           </button>
 
           <a

--- a/src/test/cart.QuantityInput.test.tsx
+++ b/src/test/cart.QuantityInput.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import QuantityInput from "@/components/cart/QuantityInput";
+
+describe("QuantityInput", () => {
+  it("renders with initial value", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={5} onChange={onChange} />);
+    const input = screen.getByLabelText("Cantidad");
+    expect(input).toHaveValue(5);
+  });
+
+  it("calls onChange when incrementing", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={1} onChange={onChange} />);
+    const incrementBtn = screen.getByLabelText("Aumentar cantidad");
+    fireEvent.click(incrementBtn);
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onChange when decrementing", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={5} onChange={onChange} />);
+    const decrementBtn = screen.getByLabelText("Disminuir cantidad");
+    fireEvent.click(decrementBtn);
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it("respects min value", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={1} onChange={onChange} min={1} />);
+    const decrementBtn = screen.getByLabelText("Disminuir cantidad");
+    expect(decrementBtn).toBeDisabled();
+    fireEvent.click(decrementBtn);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("respects max value", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={999} onChange={onChange} max={999} />);
+    const incrementBtn = screen.getByLabelText("Aumentar cantidad");
+    expect(incrementBtn).toBeDisabled();
+    fireEvent.click(incrementBtn);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("handles ArrowUp key", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={5} onChange={onChange} />);
+    const input = screen.getByLabelText("Cantidad");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(onChange).toHaveBeenCalledWith(6);
+  });
+
+  it("handles ArrowDown key", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={5} onChange={onChange} />);
+    const input = screen.getByLabelText("Cantidad");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it("handles input change", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={1} onChange={onChange} />);
+    const input = screen.getByLabelText("Cantidad") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "10" } });
+    expect(onChange).toHaveBeenCalledWith(10);
+  });
+
+  it("clamps values to min/max", () => {
+    const onChange = vi.fn();
+    render(<QuantityInput value={1} onChange={onChange} min={1} max={99} />);
+    const input = screen.getByLabelText("Cantidad") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "999" } });
+    expect(onChange).toHaveBeenCalledWith(99);
+  });
+});
+


### PR DESCRIPTION
## Objetivo

Añadir selector de cantidad en todas las listas de productos y botón "Comprar ahora" en PDP.

## Cambios

- Creado QuantityInput component accesible con aria-labels, ArrowUp/Down keys, límites [1..999]
- Actualizado FeaturedCardControls para usar QuantityInput
- Actualizado CatalogCardControls para usar QuantityInput
- Actualizado ProductActions para usar QuantityInput y checkoutStore en "Comprar ahora"
- Tests básicos para QuantityInput

## Verificaciones

- QuantityInput incrementa/decrementa y llama onChange
- "Comprar ahora" redirige a /checkout y setea checkoutStore
- Qty visible en Featured, /tienda, /catalogo