### PR TITLE
chore(a11y): aria/alt on shared components

### DIFF
--- a/src/app/buscar/loading.tsx
+++ b/src/app/buscar/loading.tsx
@@ -1,10 +1,10 @@
 // src/app/buscar/loading.tsx
 export default function BuscarLoading() {
   return (
-    <section className="space-y-6">
+    <section className="space-y-6" role="status" aria-live="polite">
       <div>
         <h1 className="text-3xl font-bold mb-4">Buscar Productos</h1>
-        <div className="border rounded-lg pl-9 pr-3 py-2 text-sm w-full min-h-[44px] bg-gray-100 animate-pulse" />
+        <div className="border rounded-lg pl-9 pr-3 py-2 text-sm w-full min-h-[44px] bg-gray-100 animate-pulse" aria-hidden="true" />
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
@@ -12,6 +12,7 @@ export default function BuscarLoading() {
           <div
             key={i}
             className="rounded-2xl border p-3 flex flex-col animate-pulse"
+            aria-hidden="true"
           >
             <div className="w-full aspect-square bg-gray-200 rounded" />
             <div className="mt-2 h-4 bg-gray-200 rounded w-3/4" />
@@ -19,6 +20,7 @@ export default function BuscarLoading() {
           </div>
         ))}
       </div>
+      <span className="sr-only">Cargando resultados de búsqueda...</span>
     </section>
   );
 }

--- a/src/app/cuenta/puntos/ClientPage.tsx
+++ b/src/app/cuenta/puntos/ClientPage.tsx
@@ -93,8 +93,9 @@ export default function PuntosPageClient() {
   if (isLoading) {
     return (
       <AuthGuard>
-        <div className="min-h-screen flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+        <div className="min-h-screen flex items-center justify-center" role="status" aria-live="polite">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" aria-hidden="true"></div>
+          <span className="sr-only">Cargando...</span>
         </div>
       </AuthGuard>
     );

--- a/src/components/CartBubble.tsx
+++ b/src/components/CartBubble.tsx
@@ -173,6 +173,7 @@ function CartDrawer({ onClose }: { onClose: () => void }) {
                           Number(e.target.value) || 1,
                         )
                       }
+                      aria-label={`Cantidad de ${it.title}`}
                       className="w-16 border rounded px-2 py-1 text-sm min-h-[44px]"
                     />
                     <button
@@ -200,7 +201,8 @@ function CartDrawer({ onClose }: { onClose: () => void }) {
           <div className="flex gap-2">
             <button
               onClick={clearCart}
-              className="border rounded-lg px-4 py-2 text-sm hover:bg-gray-100 min-h-[44px]"
+              aria-label="Vaciar carrito"
+              className="border rounded-lg px-4 py-2 text-sm hover:bg-gray-100 min-h-[44px] focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
               type="button"
             >
               <span>Vaciar</span>

--- a/src/components/ProductResolver.tsx
+++ b/src/components/ProductResolver.tsx
@@ -57,8 +57,8 @@ export default function ProductResolver({ section, slug, children }: Props) {
     return (
       <div className="min-h-screen bg-gray-50">
         <div className="max-w-7xl mx-auto px-4 py-8">
-          <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto mb-4"></div>
+          <div className="text-center py-12" role="status" aria-live="polite">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto mb-4" aria-hidden="true"></div>
             <p className="text-gray-600">Cargando producto...</p>
           </div>
         </div>

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -29,8 +29,9 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+      <div className="min-h-screen flex items-center justify-center" role="status" aria-live="polite">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" aria-hidden="true"></div>
+        <span className="sr-only">Cargando...</span>
       </div>
     );
   }

--- a/src/components/cart/CartSticky.tsx
+++ b/src/components/cart/CartSticky.tsx
@@ -28,10 +28,11 @@ export default function CartSticky() {
       {/* Móvil: barra inferior */}
       <Link
         href="/carrito"
-        className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-black text-white px-4 py-3 flex items-center justify-between shadow-lg"
+        aria-label={`Ver carrito con ${count} ${count === 1 ? "producto" : "productos"}`}
+        className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-black text-white px-4 py-3 flex items-center justify-between shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
       >
         <div className="flex items-center gap-3">
-          <ShoppingCart className="h-5 w-5" />
+          <ShoppingCart className="h-5 w-5" aria-hidden="true" />
           <span className="font-medium">
             {count} {count === 1 ? "producto" : "productos"}
           </span>
@@ -42,10 +43,11 @@ export default function CartSticky() {
       {/* Desktop: burbuja flotante abajo-derecha */}
       <Link
         href="/carrito"
-        className="hidden md:flex fixed bottom-6 right-6 z-50 bg-black text-white px-6 py-4 rounded-full shadow-xl hover:bg-black/90 transition-all items-center gap-3"
+        aria-label={`Ver carrito con ${count} ${count === 1 ? "producto" : "productos"}`}
+        className="hidden md:flex fixed bottom-6 right-6 z-50 bg-black text-white px-6 py-4 rounded-full shadow-xl hover:bg-black/90 transition-all items-center gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
       >
         <div className="relative">
-          <ShoppingCart className="h-6 w-6" />
+          <ShoppingCart className="h-6 w-6" aria-hidden="true" />
           {count > 0 && (
             <span className="absolute -top-2 -right-2 bg-white text-black text-xs font-bold rounded-full min-w-[20px] h-5 px-1.5 flex items-center justify-center">
               {count}

--- a/src/components/ui/ImageWithFallback.tsx
+++ b/src/components/ui/ImageWithFallback.tsx
@@ -5,7 +5,7 @@ import { normalizeImageUrl } from "@/lib/utils/images";
 
 type Props = Omit<ImageProps, "src" | "alt"> & {
   src?: string | null;
-  alt?: string;
+  alt: string; // Obligatorio
   fallbackSrc?: string;
   // opcional: forzar cuadrado en cards
   square?: boolean;
@@ -13,13 +13,14 @@ type Props = Omit<ImageProps, "src" | "alt"> & {
 
 export default function ImageWithFallback({
   src,
-  alt = "Producto",
+  alt,
   fallbackSrc = "/images/fallback-product.png",
   square = true,
   className,
   width = 512,
   height = 512,
   sizes,
+  loading,
   ...rest
 }: Props) {
   const norm = useMemo(() => normalizeImageUrl(src), [src]);
@@ -29,6 +30,8 @@ export default function ImageWithFallback({
   const wrapperStyle = square ? { aspectRatio: "1 / 1" } : undefined;
   const resolvedSizes =
     sizes ?? "(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw";
+  // Lazy loading por defecto si no se especifica
+  const resolvedLoading = loading ?? "lazy";
 
   return (
     <div
@@ -41,6 +44,7 @@ export default function ImageWithFallback({
         width={Number(width)}
         height={Number(height)}
         sizes={resolvedSizes}
+        loading={resolvedLoading}
         // object-contain evita corte. Cambia a object-cover si prefieres recorte.
         className={`w-full h-auto object-contain ${className ?? ""}`}
         onError={() => {


### PR DESCRIPTION
## Objetivo

Mejorar accesibilidad en componentes compartidos con aria-labels, alt defaults, roles y focus visible.

## Cambios

- ImageWithFallback: alt obligatorio, loading='lazy' por defecto
- Loaders: role='status' + aria-live='polite' + sr-only text
- CartBubble: aria-label en input qty y botón Vaciar
- CartSticky: aria-label en links + focus visible
- BuscarLoading: role='status' + aria-hidden en skeletons
- ProductResolver: role='status' + aria-live
- AuthGuard: role='status' + sr-only text
- PuntosPageClient: role='status' + sr-only text

## Verificaciones

- Todos los botones icónicos tienen aria-label
- Todos los loaders tienen role='status'
- ImageWithFallback requiere alt obligatorio
- Focus visible mejorado en botones y links