### PR TITLE
chore(seo): robots, manifest, default metas

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,32 +56,31 @@ export const metadata: Metadata = {
     process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app",
   ),
   title: {
-    default: process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega",
-    template: `%s | ${process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega"}`,
+    default: "Depósito Dental Noriega",
+    template: "%s · Dental Noriega",
   },
-  description: "Insumos dentales a mejor precio. Envíos a todo México.",
-  robots: { index: true, follow: true },
+  description: "Suministros dentales con envío y asesoría.",
   openGraph: {
     type: "website",
     url: "/",
-    locale: "es_MX",
     siteName: process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega",
-    title: process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega",
-    description: "Insumos dentales a mejor precio. Envíos a todo México.",
+    title: "Depósito Dental Noriega",
+    description: "Suministros dentales con envío y asesoría.",
     images: [
       {
-        url: "/og/cover.jpg",
+        url: "/og-default.jpg",
         width: 1200,
         height: 630,
-        alt: "Catálogo",
+        alt: "Depósito Dental Noriega",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega",
-    description: "Insumos dentales a mejor precio. Envíos a todo México.",
-    images: ["/og/cover.jpg"],
+    creator: "@dentalnoriega",
+    title: "Depósito Dental Noriega",
+    description: "Suministros dentales con envío y asesoría.",
+    images: ["/og-default.jpg"],
   },
 };
 

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Depósito Dental Noriega",
+    short_name: "Dental Noriega",
+    description: "Catálogo dental y compra asistida.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#0ea5e9",
+    icons: [
+      { src: "/icons/icon-192.png", sizes: "192x192", type: "image/png" },
+      { src: "/icons/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}
+

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,18 +1,8 @@
-// src/app/robots.ts
 import { MetadataRoute } from "next";
 
-export const dynamic = "force-static";
-
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app";
   return {
-    rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-      },
-    ],
-    sitemap: `${baseUrl}/sitemap.xml`,
+    rules: [{ userAgent: "*", allow: ["/"], disallow: ["/api/"] }],
+    sitemap: "https://dental-noriega.vercel.app/sitemap.xml",
   };
 }


### PR DESCRIPTION
## Objetivo

Añadir robots.txt, manifest.json y metadatos por defecto para SEO.

## Cambios

- robots.ts: allow /, disallow /api/, sitemap
- manifest.ts: PWA manifest con icons
- layout.tsx: metadataBase, default og:title/image, twitter:card

## Notas

- public/icons/icon-192.png y icon-512.png deben crearse manualmente
- public/og-default.jpg debe crearse manualmente o usar placeholder existente

## Verificaciones

- robots.txt servido en /robots.txt
- manifest.json servido en /manifest.json
- Metadatos por defecto en layout.tsx