### PR TITLE
fix: featured/catalog runtime fetch, cache tags + warmup, dynamic pages

### DIFF
--- a/src/app/api/warmup/route.ts
+++ b/src/app/api/warmup/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
-
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
+import { revalidateTag } from "next/cache";
 
 export async function GET() {
-  return NextResponse.json({ ok: true, at: Date.now() });
+  revalidateTag("featured");
+  revalidateTag("catalog");
+  return NextResponse.json({
+    ok: true,
+    revalidated: ["featured", "catalog"],
+    at: new Date().toISOString(),
+  });
 }

--- a/src/app/catalogo/page.tsx
+++ b/src/app/catalogo/page.tsx
@@ -5,7 +5,8 @@ import { getSectionsFromCatalogView } from "@/lib/catalog/getSectionsFromCatalog
 import { ROUTES } from "@/lib/routes";
 // Package icon replaced with inline SVG to reduce bundle size
 
-export const revalidate = 300; // Cache 5 minutos
+export const dynamic = "force-dynamic";
+// opcional: export const revalidate = 60;
 
 export default async function CatalogoIndexPage() {
   let sections = await listSectionsFromCatalog();

--- a/src/lib/supabase/public.ts
+++ b/src/lib/supabase/public.ts
@@ -10,9 +10,8 @@ export function getPublicSupabase() {
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!url || !anon) {
-    // No truenes en build. Solo avisa en runtime.
-    if (process.env.NEXT_RUNTIME) {
-      console.warn("[supabase] missing NEXT_PUBLIC_SUPABASE_* envs");
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[supabase] missing envs");
     }
     // Devuelve un client fake que nunca se usa si no lo llamas.
     // En runtime, esto causará errores si se intenta usar, pero no rompe el build.


### PR DESCRIPTION
Cambios:
- Eliminar uso de cookies() dentro de funciones cacheadas
- Cache v3 con tags 'featured' y 'catalog' para invalidación
- Fallback runtime si cache regresa 0 items
- Endpoint /api/warmup para invalidar cache post-deploy
- Paginas del catalogo marcadas como dinamicas temporalmente
- Logs silenciados en build (NODE_ENV check)

Fixes:
- Choque unstable_cache + cookies
- Build cacheando vacio
- Cache vieja no invalidada

Nota: El error de /icon en build es un problema separado y no esta relacionado con estos cambios.