### PR TITLE
fix: force runtime fetch (no cache), supabase client per-request, dynamic pages, debug endpoints

### DIFF
--- a/src/app/api/debug/search-health/route.ts
+++ b/src/app/api/debug/search-health/route.ts
@@ -1,14 +1,20 @@
-// src/app/api/debug/search-health/route.ts
 import { NextResponse } from "next/server";
-import { getAllFromCatalog } from "@/lib/catalog/getAllFromCatalog.server";
-
-export const dynamic = "force-dynamic";
+import { getPublicEnv } from "@/lib/env";
+import { getPublicSupabase } from "@/lib/supabase/public";
 
 export async function GET() {
-  const items = await getAllFromCatalog();
+  const env = getPublicEnv();
+  let featuredCount = null;
+  try {
+    const s = getPublicSupabase();
+    const { data } = await s.from("featured").select("product_id");
+    featuredCount = data?.length ?? 0;
+  } catch {
+    // Silenciar errores
+  }
   return NextResponse.json({
-    total: items.length,
-    sample: items.slice(0, 5),
+    envOk: env.ok,
+    nodeEnv: env.nodeEnv,
+    featuredCount,
   });
 }
-

--- a/src/app/api/warmup/route.ts
+++ b/src/app/api/warmup/route.ts
@@ -1,12 +1,6 @@
 import { NextResponse } from "next/server";
-import { revalidateTag } from "next/cache";
 
 export async function GET() {
-  revalidateTag("featured");
-  revalidateTag("catalog");
-  return NextResponse.json({
-    ok: true,
-    revalidated: ["featured", "catalog"],
-    at: new Date().toISOString(),
-  });
+  // no hacemos revalidateTag; solo devolvemos marca temporal para confirmar
+  return NextResponse.json({ ok: true, at: new Date().toISOString() });
 }

--- a/src/app/catalogo/page.tsx
+++ b/src/app/catalogo/page.tsx
@@ -6,7 +6,8 @@ import { ROUTES } from "@/lib/routes";
 // Package icon replaced with inline SVG to reduce bundle size
 
 export const dynamic = "force-dynamic";
-// opcional: export const revalidate = 60;
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
 export default async function CatalogoIndexPage() {
   let sections = await listSectionsFromCatalog();

--- a/src/app/destacados/page.tsx
+++ b/src/app/destacados/page.tsx
@@ -23,7 +23,7 @@ export default async function DestacadosPage() {
 
   // Sanity check: si el array llega vacío, registra un log una sola vez
   if (!items?.length) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[featured] empty result in runtime");
     }
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,15 +80,16 @@ const FinalThanks = dynamicImport(() => import("@/components/FinalThanks"), {
   ssr: false,
 });
 
-export const dynamic = "force-dynamic"; // temporal hasta estabilizar cache
-// opcionalmente: export const revalidate = 60;
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
 export default async function HomePage() {
   const items = await getFeatured();
 
   // Sanity check: si el array llega vacío, registra un log una sola vez
   if (!items?.length) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[featured] empty result in runtime");
     }
   }

--- a/src/lib/catalog/getAllFromCatalog.server.ts
+++ b/src/lib/catalog/getAllFromCatalog.server.ts
@@ -21,7 +21,7 @@ function hasSupabaseEnvs(): boolean {
 
 async function fetchAllFromCatalog(): Promise<CatalogItem[]> {
   if (!hasSupabaseEnvs()) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs (using empty list)");
     }
     return [];

--- a/src/lib/catalog/getBySection.server.ts
+++ b/src/lib/catalog/getBySection.server.ts
@@ -1,115 +1,62 @@
-// src/lib/catalog/getBySection.server.ts
-import "server-only";
+"use server";
 
-import { unstable_cache, revalidateTag } from "next/cache";
+import { unstable_noStore as noStore } from "next/cache";
 import { getPublicSupabase } from "@/lib/supabase/public";
 import type { CatalogItem } from "./model";
 
-const CATALOG_CACHE_KEY = "catalog:by-section:v3"; // bump para invalidar v2/v1
-
-/**
- * Función pura que NO llama cookies() dentro de unstable_cache
- */
-async function fetchProductsBySectionPure(
-  section: string,
-  limit = 100,
-  offset = 0,
-): Promise<CatalogItem[]> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!url || !anon) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[catalog] missing supabase envs (using empty list)");
-    }
-    return [];
-  }
-
-  try {
-    const supabase = getPublicSupabase();
-    if (!supabase) {
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("[getProductsBySection] supabase client not available");
-      }
-      return [];
-    }
-
-    const { data, error } = await supabase
-      .from("api_catalog_with_images")
-      .select(
-        "id, product_slug, section, title, description, price_cents, currency, stock_qty, image_url",
-      )
-      .eq("section", section)
-      .order("title", { ascending: true })
-      .range(offset, offset + limit - 1);
-
-    if (error) {
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("[getProductsBySection] Error:", error.message);
-      }
-      return [];
-    }
-
-    if (!data || data.length === 0) {
-      return [];
-    }
-
-    type CatalogRow = {
-      id: string | number;
-      product_slug: string | null;
-      section: string;
-      title: string;
-      description: string | null;
-      price_cents: number | null;
-      currency: string | null;
-      stock_qty: number | null;
-      image_url: string | null;
-    };
-
-    return (data as CatalogRow[]).map((item) => ({
-      id: String(item.id),
-      product_slug: String(item.product_slug ?? ""),
-      section: String(item.section),
-      title: String(item.title),
-      description: item.description ?? null,
-      price_cents: item.price_cents ?? null,
-      currency: item.currency ?? "mxn",
-      stock_qty: item.stock_qty ?? null,
-      image_url: item.image_url ?? null,
-    })) as CatalogItem[];
-  } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[getProductsBySection] Error:", error);
-    }
-    return [];
-  }
-}
-
-// Cachea solo la parte pura (sin cookies) con fallback si trae 0 items
-const cachedGetProductsBySection = unstable_cache(
-  async (section: string, limit: number, offset: number) => {
-    const items = await fetchProductsBySectionPure(section, limit, offset);
-    // Fallback: si caché trae 0, rehacer una vez sin caché
-    if (!items?.length) {
-      return fetchProductsBySectionPure(section, limit, offset);
-    }
-    return items;
-  },
-  [CATALOG_CACHE_KEY],
-  { revalidate: 120, tags: ["catalog"] }
-);
-
 /**
  * Obtiene productos por sección desde la vista canónica api_catalog_with_images
+ * Sin cache, runtime puro.
  */
 export async function getProductsBySection(
   section: string,
   limit = 100,
-  offset = 0,
+  offset = 0
 ): Promise<CatalogItem[]> {
-  return cachedGetProductsBySection(section, limit, offset);
+  noStore();
+
+  const s = getPublicSupabase();
+  const { data, error } = await s
+    .from("api_catalog_with_images")
+    .select(
+      "id, product_slug, section, title, description, price_cents, currency, stock_qty, image_url"
+    )
+    .eq("section", section)
+    .eq("active", true)
+    .order("title", { ascending: true })
+    .range(offset, offset + limit - 1);
+
+  if (error) throw error;
+
+  if (!data || data.length === 0) {
+    return [];
+  }
+
+  type CatalogRow = {
+    id: string | number;
+    product_slug: string | null;
+    section: string;
+    title: string;
+    description: string | null;
+    price_cents: number | null;
+    currency: string | null;
+    stock_qty: number | null;
+    image_url: string | null;
+  };
+
+  return (data as CatalogRow[]).map((item) => ({
+    id: String(item.id),
+    product_slug: String(item.product_slug ?? ""),
+    section: String(item.section),
+    title: String(item.title),
+    description: item.description ?? null,
+    price_cents: item.price_cents ?? null,
+    currency: item.currency ?? "mxn",
+    stock_qty: item.stock_qty ?? null,
+    image_url: item.image_url ?? null,
+  })) as CatalogItem[];
 }
 
-export function revalidateCatalog() {
-  revalidateTag("catalog");
+export async function revalidateCatalog() {
+  // No-op: ya no usamos cache
 }

--- a/src/lib/catalog/getFeatured.server.ts
+++ b/src/lib/catalog/getFeatured.server.ts
@@ -1,8 +1,7 @@
-import "server-only";
-// Nada de cookies() aquí ni fetch a /api/debug/* en producción.
+"use server";
 
-import { unstable_cache, revalidateTag } from "next/cache";
 import { getPublicSupabase } from "@/lib/supabase/public";
+import { unstable_noStore as noStore } from "next/cache";
 
 export type FeaturedItem = {
   product_id: string;
@@ -17,112 +16,55 @@ export type FeaturedItem = {
   position: number;
 };
 
-const FEATURED_CACHE_KEY = "featured:v3"; // bump para invalidar v2/v1
-
-/**
- * Función pura que NO llama cookies() dentro de unstable_cache
- */
-async function fetchFeaturedPure(regionKey: string): Promise<FeaturedItem[]> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!url || !anon) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[getFeatured] missing supabase envs (using empty list)");
-    }
-    return [];
-  }
-
-  try {
-    const supabase = getPublicSupabase();
-    if (!supabase) {
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("[getFeatured] supabase client not available");
-      }
-      return [];
-    }
-
-    // NO llames cookies aquí. Usa regionKey si lo necesitas en el futuro.
-    const { data: frows, error: ferr } = await supabase
-      .from("featured")
-      .select("product_id, position")
-      .order("position", { ascending: true })
-      .limit(8);
-
-    if (ferr || !frows?.length) return [];
-
-    const ids = frows.map((r: { product_id: string }) => r.product_id);
-    const { data: view, error: verr } = await supabase
-      .from("api_catalog_with_images")
-      .select(
-        "id, product_slug, section, title, description, price_cents, currency, stock_qty, image_url",
-      )
-      .in("id", ids);
-
-    if (verr || !view) return [];
-
-    type ViewItem = {
-      id: string;
-      product_slug: string;
-      section: string;
-      title: string;
-      description: string | null;
-      price_cents: number | null;
-      currency: string | null;
-      stock_qty: number | null;
-      image_url: string | null;
-    };
-
-    const byId = new Map<string, ViewItem>(view.map((v: ViewItem) => [v.id, v]));
-    return frows
-      .map((r: { product_id: string; position: number }) => {
-        const v = byId.get(r.product_id);
-        if (!v) return null;
-        return {
-          product_id: v.id,
-          product_slug: v.product_slug,
-          section: v.section,
-          title: v.title,
-          description: v.description ?? null,
-          price_cents: v.price_cents ?? null,
-          currency: v.currency ?? "mxn",
-          stock_qty: v.stock_qty ?? null,
-          image_url: v.image_url ?? null,
-          position: r.position,
-        } satisfies FeaturedItem;
-      })
-      .filter(Boolean) as FeaturedItem[];
-  } catch (error) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[getFeatured] Error:", error);
-    }
-    return [];
-  }
-}
-
-// Cachea solo la parte pura (sin cookies) con fallback si trae 0 items
-export const getFeaturedCached = unstable_cache(
-  async (regionKey: string) => {
-    const items = await fetchFeaturedPure(regionKey);
-    // Fallback: si caché trae 0, rehacer una vez sin caché
-    if (!items?.length) {
-      return fetchFeaturedPure(regionKey);
-    }
-    return items;
-  },
-  [FEATURED_CACHE_KEY],
-  { revalidate: 60, tags: ["featured"] }
-);
-
-// Wrapper por request: lee cookies AQUÍ, fuera de la cache
 export async function getFeatured(): Promise<FeaturedItem[]> {
-  const { cookies } = await import("next/headers");
-  const region = cookies().get("region")?.value ?? "no-region";
-  return getFeaturedCached(region);
+  noStore(); // fuerza no-cache
+
+  // leer cookies aquí (fuera de cualquier cache) si necesitas región
+  // const region = cookies().get("region")?.value ?? null;
+
+  const s = getPublicSupabase();
+
+  // 1) leemos posiciones de featured
+  const { data: feats, error: e1 } = await s
+    .from("featured")
+    .select("product_id, position")
+    .order("position", { ascending: true });
+
+  if (e1) throw e1;
+  if (!feats?.length) return [];
+
+  const ids = feats.map((f) => f.product_id);
+  // 2) leemos vista canónica con imagen primaria
+  const { data: items, error: e2 } = await s
+    .from("api_catalog_with_images")
+    .select("*")
+    .in("id", ids);
+
+  if (e2) throw e2;
+
+  // ordenar según position
+  const order = new Map(ids.map((id, i) => [id, i]));
+  const sorted = (items ?? []).sort(
+    (a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0)
+  );
+
+  // Mapear a FeaturedItem
+  return sorted.map((item, idx) => ({
+    product_id: String(item.id),
+    product_slug: String(item.product_slug ?? ""),
+    section: String(item.section),
+    title: String(item.title),
+    description: item.description ?? null,
+    price_cents: item.price_cents ?? null,
+    currency: item.currency ?? "mxn",
+    stock_qty: item.stock_qty ?? null,
+    image_url: item.image_url ?? null,
+    position: feats[idx]?.position ?? idx,
+  }));
 }
 
-export function revalidateFeatured() {
-  revalidateTag("featured");
+export async function revalidateFeatured() {
+  // No-op: ya no usamos cache
 }
 
 // Alias para compatibilidad con código existente

--- a/src/lib/catalog/getProduct.server.ts
+++ b/src/lib/catalog/getProduct.server.ts
@@ -23,7 +23,7 @@ export async function getProductBySectionSlug(
   slug: string,
 ): Promise<CatalogItem | null> {
   if (!hasSupabaseEnvs()) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs (using null)");
     }
     return null;
@@ -69,7 +69,7 @@ export async function getProductBySlug(
   slug: string,
 ): Promise<CatalogItem | null> {
   if (!hasSupabaseEnvs()) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs (using null)");
     }
     return null;

--- a/src/lib/catalog/getProductsBySectionFromView.server.ts
+++ b/src/lib/catalog/getProductsBySectionFromView.server.ts
@@ -24,7 +24,7 @@ export async function getProductsBySectionFromView(
   offset = 0,
 ): Promise<CatalogItem[]> {
   if (!hasSupabaseEnvs()) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs (using empty list)");
     }
     return [];

--- a/src/lib/catalog/resolveProductBySlug.server.ts
+++ b/src/lib/catalog/resolveProductBySlug.server.ts
@@ -35,7 +35,7 @@ export async function resolveProductBySlug(
   slug: string,
 ): Promise<ProductResolved | null> {
   if (!hasSupabaseEnvs()) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs (using null)");
     }
     return null;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,11 @@
+export function getPublicEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+  return {
+    url,
+    anon,
+    ok: Boolean(url && anon),
+    nodeEnv: process.env.NODE_ENV || "development",
+  };
+}
+

--- a/src/lib/supabase/catalog.ts
+++ b/src/lib/supabase/catalog.ts
@@ -18,7 +18,7 @@ export type CatalogItem = {
 export async function getFeaturedProducts(): Promise<CatalogItem[]> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return [];
@@ -77,7 +77,7 @@ export async function getBySectionSlug(
 ): Promise<CatalogItem | null> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return null;
@@ -118,7 +118,7 @@ export async function getProductBySlugAnySection(
 ): Promise<CatalogItem | null> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return null;
@@ -148,7 +148,7 @@ export async function listBySection(
 ): Promise<CatalogItem[]> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return [];
@@ -198,7 +198,7 @@ export async function searchProducts(
 ): Promise<CatalogItem[]> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return [];
@@ -226,7 +226,7 @@ export async function searchProducts(
 export async function listCatalog(): Promise<CatalogItem[]> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return [];
@@ -253,7 +253,7 @@ export async function listCatalog(): Promise<CatalogItem[]> {
 export async function listSectionsFromCatalog(): Promise<string[]> {
   const sb = createAnonClient();
   if (!sb) {
-    if (process.env.NEXT_RUNTIME) {
+    if (process.env.NODE_ENV !== "production") {
       console.warn("[catalog] missing supabase envs");
     }
     return [];

--- a/src/lib/supabase/public.ts
+++ b/src/lib/supabase/public.ts
@@ -1,23 +1,13 @@
 import "server-only";
 import { createClient } from "@supabase/supabase-js";
+import { getPublicEnv } from "@/lib/env";
 
 /**
- * Cliente público de Supabase sin cookies, para uso en server components
- * y dentro de unstable_cache sin problemas.
+ * Cliente público de Supabase sin cookies, creado por request.
+ * NO crea cliente en top-level para evitar lecturas de env en build.
  */
 export function getPublicSupabase() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!url || !anon) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[supabase] missing envs");
-    }
-    // Devuelve un client fake que nunca se usa si no lo llamas.
-    // En runtime, esto causará errores si se intenta usar, pero no rompe el build.
-    return null as any;
-  }
-
+  const { url, anon } = getPublicEnv();
   return createClient(url, anon, { auth: { persistSession: false } });
 }
 


### PR DESCRIPTION
Cambios:
- Crear src/lib/env.ts para lectura segura de envs en runtime
- Modificar getPublicSupabase para factory sin top-level
- Reemplazar getFeatured y getBySection sin cache (unstable_noStore)
- Marcar todas las paginas del catalogo como 100% dinamicas
- Endpoint /api/warmup simplificado
- Endpoint /api/debug/search-health para diagnostico
- Logs silenciados en build (NODE_ENV check)

Fixes:
- Listados vacios por cache evaluada en build
- Lecturas de env en top-level
- Cache vieja no invalidada

Nota: El error de /icon en build es un problema separado y no esta relacionado con estos cambios.