### PR TITLE
fix(catalog): runtime supabase, no-cache, correct stock/active/price mapping

### DIFF
--- a/src/app/api/debug/search-health/route.ts
+++ b/src/app/api/debug/search-health/route.ts
@@ -1,20 +1,24 @@
 import { NextResponse } from "next/server";
-import { getPublicEnv } from "@/lib/env";
 import { getPublicSupabase } from "@/lib/supabase/public";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
-  const env = getPublicEnv();
-  let featuredCount = null;
-  try {
-    const s = getPublicSupabase();
-    const { data } = await s.from("featured").select("product_id");
-    featuredCount = data?.length ?? 0;
-  } catch {
-    // Silenciar errores
-  }
+  const s = getPublicSupabase();
+  const envOk =
+    !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+    !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  const feat = await s
+    .from("featured")
+    .select("product_slug", { count: "exact", head: true });
+  const cat = await s
+    .from("api_catalog_with_images")
+    .select("id", { count: "exact", head: true });
+
   return NextResponse.json({
-    envOk: env.ok,
-    nodeEnv: env.nodeEnv,
-    featuredCount,
+    envOk,
+    featuredCount: feat.count ?? 0,
+    catalogCount: cat.count ?? 0,
   });
 }

--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -1,16 +1,13 @@
 import "server-only";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { resolveProductBySlug } from "@/lib/catalog/resolveProductBySlug.server";
-import { getProductBySectionSlug } from "@/lib/catalog/getProduct.server";
-import { formatMXNFromCents } from "@/lib/utils/currency";
+import { getProduct } from "@/lib/catalog/getProduct.server";
 import ImageWithFallback from "@/components/ui/ImageWithFallback";
 import ProductActions from "@/components/product/ProductActions.client";
 import ProductViewTracker from "@/components/ProductViewTracker.client";
 import { ROUTES } from "@/lib/routes";
 import Link from "next/link";
 import { Package, Truck, Shield } from "lucide-react";
-import { normalizeSlug } from "@/lib/utils/slug";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -28,10 +25,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const section = decodeURIComponent(params.section ?? "");
   const slug = decodeURIComponent(params.slug ?? "");
 
-  // Intentar obtener producto (sin cookies, solo Supabase directo)
-  let product: Awaited<ReturnType<typeof getProductBySectionSlug>> = null;
+  // Intentar obtener producto
+  let product: Awaited<ReturnType<typeof getProduct>> = null;
   try {
-    product = await getProductBySectionSlug(section, slug);
+    product = await getProduct(section, slug);
   } catch {
     // Silenciar errores en build - usar fallback
   }
@@ -48,8 +45,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = `${product.title} | ${siteName}`;
   const description =
     product.description?.slice(0, 150) ?? `${product.title} en ${siteName}`;
-  const image = product.image_url ?? "/og/cover.jpg";
-  const url = `${base}/catalogo/${product.section}/${product.product_slug}`;
+      const image = product.image_url ?? "/og/cover.jpg";
+  const url = `${base}/catalogo/${product.section}/${product.slug}`;
 
   return {
     title,
@@ -84,27 +81,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ProductDetailPage({ params }: Props) {
   const section = decodeURIComponent(params.section ?? "");
   const slug = decodeURIComponent(params.slug ?? "");
-  const normalizedSlug = normalizeSlug(slug);
-  const normalizedSection = normalizeSlug(section);
 
-  try {
-    // Resolver producto por slug (con fallback a vista)
-    const product = await resolveProductBySlug(normalizedSlug);
+  const product = await getProduct(section, slug);
 
-    if (!product) {
-      return notFound(); // 404 limpio, no error
-    }
+  if (!product) {
+    return notFound(); // 404 limpio, no error
+  }
 
-    // Redirigir a la ruta canónica si la sección no coincide
-    if (normalizeSlug(product.section) !== normalizedSection) {
-      redirect(`/catalogo/${product.section}/${product.slug}`);
-    }
-
-    const image_url = product.image_url;
-    const price = formatMXNFromCents(product.price_cents);
-    const base =
-      process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app";
-    const canonicalUrl = `${base}/catalogo/${product.section}/${product.slug}`;
+  const image_url = product.image_url;
+  const price = new Intl.NumberFormat("es-MX", {
+    style: "currency",
+    currency: "MXN",
+  }).format(product.price);
+  const base =
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app";
+  const canonicalUrl = `${base}/catalogo/${product.section}/${product.slug}`;
+  const soldOut = !product.active || !product.inStock;
 
     // JSON-LD Product schema
     const jsonLd = {
@@ -117,14 +109,11 @@ export default async function ProductDetailPage({ params }: Props) {
       url: canonicalUrl,
       offers: {
         "@type": "Offer",
-        price: product.price_cents
-          ? (product.price_cents / 100).toFixed(2)
-          : "0",
+        price: product.price > 0 ? product.price.toFixed(2) : "0",
         priceCurrency: "MXN",
-        availability:
-          product.in_stock && product.price_cents && product.price_cents > 0
-            ? "https://schema.org/InStock"
-            : "https://schema.org/OutOfStock",
+        availability: !soldOut && product.price > 0
+          ? "https://schema.org/InStock"
+          : "https://schema.org/OutOfStock",
         url: canonicalUrl,
       },
     };
@@ -141,7 +130,7 @@ export default async function ProductDetailPage({ params }: Props) {
         <ProductViewTracker
           productId={product.id}
           productName={product.title}
-          priceCents={product.price_cents}
+          priceCents={Math.round(product.price * 100)}
         />
 
         {/* Breadcrumb */}
@@ -165,7 +154,7 @@ export default async function ProductDetailPage({ params }: Props) {
               >
                 {product.section
                   .replace(/-/g, " ")
-                  .replace(/\b\w/g, (l) => l.toUpperCase())}
+                  .replace(/\b\w/g, (l: string) => l.toUpperCase())}
               </Link>
               <span>/</span>
               <span className="text-gray-900 font-medium">{product.title}</span>
@@ -209,12 +198,12 @@ export default async function ProductDetailPage({ params }: Props) {
                 <div className="flex items-center space-x-2">
                   <span
                     className={`px-2 py-1 rounded-full text-xs font-medium ${
-                      product.in_stock
+                      !soldOut
                         ? "bg-green-100 text-green-800"
                         : "bg-red-100 text-red-800"
                     }`}
                   >
-                    {product.in_stock ? "En stock" : "Agotado"}
+                    {!soldOut ? "En stock" : "Agotado"}
                   </span>
                 </div>
               </div>
@@ -226,8 +215,8 @@ export default async function ProductDetailPage({ params }: Props) {
                   title: product.title,
                   section: product.section,
                   product_slug: product.slug,
-                  price_cents: product.price_cents,
-                  in_stock: product.in_stock ?? undefined,
+                  price_cents: Math.round(product.price * 100),
+                  in_stock: !soldOut,
                 }}
               />
 
@@ -264,44 +253,4 @@ export default async function ProductDetailPage({ params }: Props) {
         </div>
       </div>
     );
-  } catch (error) {
-    console.error("[PDP] Error:", error);
-    // Verificar si faltan envs
-    const hasEnvs = !!(
-      process.env.NEXT_PUBLIC_SUPABASE_URL &&
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    );
-
-    // No explotes: muestra vista amable en vez de exception
-    return (
-      <div className="p-6">
-        <h1 className="text-xl font-semibold">
-          {hasEnvs ? "No pudimos cargar el producto" : "Catálogo no disponible"}
-        </h1>
-        <p className="text-sm opacity-70 mt-1">
-          {hasEnvs ? (
-            <>
-              Intenta otra vez o visita{" "}
-              <Link href="/destacados" className="underline">
-                Destacados
-              </Link>
-              .
-            </>
-          ) : (
-            <>
-              Intenta en{" "}
-              <Link href="/destacados" className="underline">
-                Destacados
-              </Link>{" "}
-              o{" "}
-              <Link href="/buscar" className="underline">
-                buscar
-              </Link>
-              .
-            </>
-          )}
-        </p>
-      </div>
-    );
-  }
 }

--- a/src/app/destacados/page.tsx
+++ b/src/app/destacados/page.tsx
@@ -1,6 +1,6 @@
 // src/app/destacados/page.tsx
 import Link from "next/link";
-import { getFeatured } from "@/lib/catalog/getFeatured.server";
+import { getFeaturedItems } from "@/lib/catalog/getFeatured.server";
 import FeaturedGrid from "@/components/FeaturedGrid";
 
 export const dynamic = "force-dynamic";
@@ -18,7 +18,7 @@ function hasSupabaseEnvs(): boolean {
 }
 
 export default async function DestacadosPage() {
-  const items = await getFeatured();
+  const items = await getFeaturedItems();
   const hasEnvs = hasSupabaseEnvs();
 
   // Sanity check: si el array llega vacío, registra un log una sola vez

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import dynamicImport from "next/dynamic";
 import { ROUTES } from "@/lib/routes";
-import { getFeatured } from "@/lib/catalog/getFeatured.server";
+import { getFeaturedItems } from "@/lib/catalog/getFeatured.server";
 import FeaturedCarousel from "@/components/FeaturedCarousel";
 import FeaturedGrid from "@/components/FeaturedGrid";
 import { buttonBase, buttonPrimary } from "@/lib/styles/button";
@@ -85,7 +85,7 @@ export const revalidate = 0;
 export const fetchCache = "force-no-store";
 
 export default async function HomePage() {
-  const items = await getFeatured();
+  const items = await getFeaturedItems();
 
   // Sanity check: si el array llega vacío, registra un log una sola vez
   if (!items?.length) {

--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import FeaturedGrid from "@/components/FeaturedGrid";
-import { getFeatured } from "@/lib/catalog/getFeatured.server";
+import { getFeaturedItems } from "@/lib/catalog/getFeatured.server";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -33,7 +33,7 @@ function hasSupabaseEnvs(): boolean {
 }
 
 export default async function TiendaPage() {
-  const featured = await getFeatured();
+  const featured = await getFeaturedItems();
   const hasEnvs = hasSupabaseEnvs();
 
   return (

--- a/src/components/CatalogCardControls.tsx
+++ b/src/components/CatalogCardControls.tsx
@@ -5,7 +5,7 @@ import QuantityInput from "@/components/cart/QuantityInput";
 import { useCartStore } from "@/lib/store/cartStore";
 import { mxnFromCents } from "@/lib/utils/currency";
 // ShoppingCart icon replaced with inline SVG to reduce bundle size
-import type { CatalogItem } from "@/lib/supabase/catalog";
+import type { CatalogItem } from "@/lib/catalog/model";
 
 type Props = {
   item: CatalogItem;
@@ -15,10 +15,11 @@ export default function CatalogCardControls({ item }: Props) {
   const addToCart = useCartStore((s) => s.addToCart);
   const [qty, setQty] = useState(1);
   const busyRef = useRef(false);
-  const canBuy = item.in_stock !== false;
+  const soldOut = item.in_stock === false || (item.in_stock === null && (item.stock_qty ?? 0) <= 0);
+  const canBuy = !soldOut;
 
   function onAdd() {
-    if (!canBuy || busyRef.current) return;
+    if (!canBuy || busyRef.current || !item.price_cents) return;
     busyRef.current = true;
     addToCart({
       id: item.id,

--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -30,7 +30,8 @@ export default function ProductActions({ product }: Props) {
   const router = useRouter();
   const busyRef = useRef(false);
 
-  const canBuy = product.in_stock !== false;
+  const soldOut = product.in_stock === false || product.in_stock === null;
+  const canBuy = !soldOut;
   const price = mxnFromCents(product.price_cents);
   const formattedPrice = formatMXNFromCents(product.price_cents);
 
@@ -112,7 +113,7 @@ export default function ProductActions({ product }: Props) {
   return (
     <div className="space-y-4">
       {/* Badge de stock */}
-      {product.in_stock === false && (
+      {soldOut && (
         <div className="px-3 py-2 bg-red-100 text-red-800 rounded-lg text-sm font-medium">
           Agotado
         </div>

--- a/src/lib/catalog/getBySection.server.ts
+++ b/src/lib/catalog/getBySection.server.ts
@@ -2,61 +2,22 @@
 
 import { unstable_noStore as noStore } from "next/cache";
 import { getPublicSupabase } from "@/lib/supabase/public";
-import type { CatalogItem } from "./model";
+import { mapRow, Product } from "./mapDbToProduct";
 
-/**
- * Obtiene productos por sección desde la vista canónica api_catalog_with_images
- * Sin cache, runtime puro.
- */
-export async function getProductsBySection(
-  section: string,
-  limit = 100,
-  offset = 0
-): Promise<CatalogItem[]> {
+export async function getBySection(section: string): Promise<Product[]> {
   noStore();
-
-  const s = getPublicSupabase();
-  const { data, error } = await s
+  const supa = getPublicSupabase();
+  const { data, error } = await supa
     .from("api_catalog_with_images")
     .select(
-      "id, product_slug, section, title, description, price_cents, currency, stock_qty, image_url"
+      "id, product_slug, section, title, description, price, image_url, stock_qty, active"
     )
     .eq("section", section)
-    .eq("active", true)
-    .order("title", { ascending: true })
-    .range(offset, offset + limit - 1);
+    .order("created_at", { ascending: false });
 
-  if (error) throw error;
-
-  if (!data || data.length === 0) {
+  if (error) {
+    console.error("[bySection] supabase error", error);
     return [];
   }
-
-  type CatalogRow = {
-    id: string | number;
-    product_slug: string | null;
-    section: string;
-    title: string;
-    description: string | null;
-    price_cents: number | null;
-    currency: string | null;
-    stock_qty: number | null;
-    image_url: string | null;
-  };
-
-  return (data as CatalogRow[]).map((item) => ({
-    id: String(item.id),
-    product_slug: String(item.product_slug ?? ""),
-    section: String(item.section),
-    title: String(item.title),
-    description: item.description ?? null,
-    price_cents: item.price_cents ?? null,
-    currency: item.currency ?? "mxn",
-    stock_qty: item.stock_qty ?? null,
-    image_url: item.image_url ?? null,
-  })) as CatalogItem[];
-}
-
-export async function revalidateCatalog() {
-  // No-op: ya no usamos cache
+  return (data ?? []).map(mapRow).filter((p) => p.active);
 }

--- a/src/lib/catalog/getProduct.server.ts
+++ b/src/lib/catalog/getProduct.server.ts
@@ -1,108 +1,28 @@
-// src/lib/catalog/getProduct.server.ts
-import "server-only";
+"use server";
 
-import { createServerSupabase } from "@/lib/supabase/server";
-import { normalizeSlug } from "@/lib/utils/slug";
-import type { CatalogItem } from "./model";
+import { unstable_noStore as noStore } from "next/cache";
+import { getPublicSupabase } from "@/lib/supabase/public";
+import { mapRow, Product } from "./mapDbToProduct";
 
-/**
- * Verifica si las variables de entorno de Supabase están presentes
- */
-function hasSupabaseEnvs(): boolean {
-  return !!(
-    process.env.NEXT_PUBLIC_SUPABASE_URL &&
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  );
-}
-
-/**
- * Obtiene un producto por sección y slug
- */
-export async function getProductBySectionSlug(
+export async function getProduct(
   section: string,
-  slug: string,
-): Promise<CatalogItem | null> {
-  if (!hasSupabaseEnvs()) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[catalog] missing supabase envs (using null)");
-    }
+  slug: string
+): Promise<Product | null> {
+  noStore();
+  const supa = getPublicSupabase();
+  const { data, error } = await supa
+    .from("api_catalog_with_images")
+    .select(
+      "id, product_slug, section, title, description, price, image_url, stock_qty, active"
+    )
+    .eq("section", section)
+    .eq("product_slug", slug)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[getProduct] supabase error", error);
     return null;
   }
-
-  try {
-    const supabase = createServerSupabase();
-    const normalizedSlug = normalizeSlug(slug);
-    const { data, error } = await supabase
-      .from("api_catalog_with_images")
-      .select(
-        "id, product_slug, section, title, description, price_cents, currency, stock_qty, image_url",
-      )
-      .eq("section", section)
-      .eq("product_slug", normalizedSlug)
-      .single();
-
-    if (error || !data) {
-      return null;
-    }
-
-    return {
-      id: String(data.id),
-      product_slug: String(data.product_slug ?? ""),
-      section: String(data.section),
-      title: String(data.title),
-      description: data.description ?? null,
-      price_cents: data.price_cents ?? null,
-      currency: data.currency ?? "mxn",
-      stock_qty: data.stock_qty ?? null,
-      image_url: data.image_url ?? null,
-    } as CatalogItem;
-  } catch (error) {
-    console.warn("[getProductBySectionSlug] Error:", error);
-    return null;
-  }
-}
-
-/**
- * Obtiene un producto por slug (cualquier sección)
- */
-export async function getProductBySlug(
-  slug: string,
-): Promise<CatalogItem | null> {
-  if (!hasSupabaseEnvs()) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[catalog] missing supabase envs (using null)");
-    }
-    return null;
-  }
-
-  try {
-    const supabase = createServerSupabase();
-    const normalizedSlug = normalizeSlug(slug);
-    const { data, error } = await supabase
-      .from("api_catalog_with_images")
-      .select(
-        "id, product_slug, section, title, description, price_cents, currency, stock_qty, image_url",
-      )
-      .eq("product_slug", normalizedSlug)
-      .single();
-
-    if (error || !data) {
-      return null;
-    }
-
-    return {
-      id: String(data.id),
-      product_slug: String(data.product_slug ?? ""),
-      section: String(data.section),
-      title: String(data.title),
-      description: data.description ?? null,
-      price_cents: data.price_cents ?? null,
-      currency: data.currency ?? "mxn",
-      stock_qty: data.stock_qty ?? null,
-      image_url: data.image_url ?? null,
-    } as CatalogItem;
-  } catch (error) {
-    console.warn("[getProductBySlug] Error:", error);
-    return null;
-  }
+  return data ? mapRow(data) : null;
 }

--- a/src/lib/catalog/mapDbToProduct.ts
+++ b/src/lib/catalog/mapDbToProduct.ts
@@ -1,0 +1,39 @@
+export type Product = {
+  id: string;
+  section: string;
+  slug: string;
+  title: string;
+  description?: string;
+  price: number;
+  image_url?: string;
+  inStock: boolean;
+  active: boolean;
+};
+
+export function mapRow(r: {
+  id: string;
+  product_slug: string;
+  section: string;
+  title: string;
+  description?: string | null;
+  price: number | string | null;
+  image_url?: string | null;
+  stock_qty?: number | null;
+  active?: boolean | null;
+}): Product {
+  const price = Number(r.price ?? 0);
+  const stockQty = Number(r.stock_qty ?? 0);
+  const active = r.active ?? true;
+  return {
+    id: r.id,
+    section: r.section,
+    slug: r.product_slug,
+    title: r.title ?? "",
+    description: r.description ?? "",
+    price,
+    image_url: r.image_url ?? undefined,
+    inStock: active && stockQty > 0,
+    active,
+  };
+}
+

--- a/src/lib/catalog/model.ts
+++ b/src/lib/catalog/model.ts
@@ -13,6 +13,7 @@ export type CatalogItem = {
   currency?: string | null;
   stock_qty?: number | null;
   image_url?: string | null;
+  in_stock?: boolean | null;
 };
 
 /**
@@ -33,14 +34,18 @@ export function normalizePrice(value?: number | string | null): number {
 }
 
 /**
- * Verifica si un item tiene un precio comprable (price_cents > 0 y stock_qty > 0)
+ * Verifica si un item tiene un precio comprable (price_cents > 0 y stock disponible)
  */
 export function hasPurchasablePrice(
   item:
     | CatalogItem
-    | { price_cents?: number | null; stock_qty?: number | null },
+    | { price_cents?: number | null; stock_qty?: number | null; in_stock?: boolean | null },
 ): boolean {
   const priceCents = normalizePrice(item.price_cents);
+  // Si tiene in_stock explícito, usarlo; sino usar stock_qty
+  if (item.in_stock !== undefined && item.in_stock !== null) {
+    return priceCents > 0 && item.in_stock === true;
+  }
   const stockQty = normalizePrice(item.stock_qty);
   return priceCents > 0 && stockQty > 0;
 }

--- a/src/lib/supabase/public.ts
+++ b/src/lib/supabase/public.ts
@@ -1,13 +1,13 @@
 import "server-only";
 import { createClient } from "@supabase/supabase-js";
-import { getPublicEnv } from "@/lib/env";
 
 /**
- * Cliente público de Supabase sin cookies, creado por request.
+ * Cliente público de Supabase por request, sin cookies ni singleton global.
  * NO crea cliente en top-level para evitar lecturas de env en build.
  */
 export function getPublicSupabase() {
-  const { url, anon } = getPublicEnv();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  // No leer cookies, no singleton global
   return createClient(url, anon, { auth: { persistSession: false } });
 }
-

--- a/src/test/featured.home.test.ts
+++ b/src/test/featured.home.test.ts
@@ -22,8 +22,8 @@ vi.mock("@/lib/supabase/server", () => ({
 // test dummy: solo valida shape básico del helper
 describe("getFeatured", () => {
   it("returns at most 8 ordered by position", async () => {
-    const { getFeatured } = await import("@/lib/catalog/getFeatured.server");
-    const items = await getFeatured();
+    const { getFeaturedItems } = await import("@/lib/catalog/getFeatured.server");
+    const items = await getFeaturedItems();
     expect(Array.isArray(items)).toBe(true);
     expect(items.length).toBeLessThanOrEqual(8);
     const positions = items.map((i) => i.position);


### PR DESCRIPTION
Cambios:
- Cliente Supabase por request sin top-level
- Fetchers server-only sin cache (unstable_noStore)
- Mapeo correcto de stock/active/precio
- Paginas 100% dinamicas
- Logica de stock corregida en UI
- Debug endpoint actualizado
- Eliminado unstable_cache de getAllFromCatalog

Fixes:
- Listados vacios por cache evaluada en build
- Productos marcados como Agotado incorrectamente
- Lecturas de env en top-level

Post-merge:
1. Redeploy en Vercel con Clear build cache
2. GET /api/debug/search-health debe devolver envOk: true, catalogCount > 0
3. /destacados debe mostrar tarjetas y no todas Agotado
4. /catalogo/<seccion> debe listar productos
5. PDP /catalogo/<seccion>/<slug> debe renderizar