### PR TITLE
fix(image): avoid priority + loading=lazy conflict

### DIFF
--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -31,6 +31,7 @@ export default function ProductImage({
       height={height}
       sizes={sizes}
       priority={priority}
+      loading={priority ? undefined : "lazy"}
       data-testid={dataTestId || "product-image"}
       onError={(e) => {
         const img = e.currentTarget as HTMLImageElement;

--- a/src/components/ui/ImageWithFallback.tsx
+++ b/src/components/ui/ImageWithFallback.tsx
@@ -21,6 +21,7 @@ export default function ImageWithFallback({
   height = 512,
   sizes,
   loading,
+  priority = false,
   ...rest
 }: Props) {
   const norm = useMemo(() => normalizeImageUrl(src), [src]);
@@ -30,8 +31,8 @@ export default function ImageWithFallback({
   const wrapperStyle = square ? { aspectRatio: "1 / 1" } : undefined;
   const resolvedSizes =
     sizes ?? "(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw";
-  // Lazy loading por defecto si no se especifica
-  const resolvedLoading = loading ?? "lazy";
+  // Si priority es true, no usar loading (undefined). Si no, usar loading explícito o "lazy" por defecto
+  const resolvedLoading = priority ? undefined : (loading ?? "lazy");
 
   return (
     <div
@@ -45,6 +46,7 @@ export default function ImageWithFallback({
         height={Number(height)}
         sizes={resolvedSizes}
         loading={resolvedLoading}
+        priority={priority}
         // object-contain evita corte. Cambia a object-cover si prefieres recorte.
         className={`w-full h-auto object-contain ${className ?? ""}`}
         onError={() => {


### PR DESCRIPTION
## Cambios

Se centraliza la lógica en `ImageWithFallback` y `ProductImage` para evitar el conflicto entre `priority` y `loading="lazy"`.

- `ImageWithFallback`: `loading={priority ? undefined : (loading ?? 'lazy')}`
- `ProductImage`: `loading={priority ? undefined : 'lazy'}`

## Problema resuelto

Corrige el runtime error local: "Image has both priority and loading='lazy'", manteniendo el comportamiento en producción.

## Checklist

- [x] Lint/Typecheck/Build OK (errores preexistentes en archivos no relacionados)
- [x] Home/Destacados/PDP/Buscar sin errores de imagen
- [x] Sin cambios fuera del fix (solo 2 archivos)

