### PR TITLE
fix(checkout): ensure Stripe redirects to /gracias and bypass guards correctly

### DIFF
--- a/src/app/api/checkout/order-status/route.ts
+++ b/src/app/api/checkout/order-status/route.ts
@@ -38,13 +38,11 @@ export async function GET(request: NextRequest) {
       .single();
 
     if (error) {
-      console.error("[order-status] Error:", error);
       return NextResponse.json({ error: "Order not found" }, { status: 404 });
     }
 
     return NextResponse.json({ status: data?.status || "pending" });
   } catch (err) {
-    console.error("[order-status] Unexpected error:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Fix: Stripe redirect to /checkout/gracias and guard bypass

### Cambios principales:
- ✅ return_url dinámico usando runtimeOrigin
- ✅ orderId robusto (prop > query > localStorage)
- ✅ Guard bypass mejorado (pathname + Stripe flow)
- ✅ Polling en /checkout/gracias hasta paid/failed
- ✅ Limpieza de carrito solo cuando status === 'paid'
- ✅ Removidos console.log de producción

### Archivos modificados:
- `src/components/checkout/StripePaymentForm.tsx`
- `src/app/checkout/pago/PagoClient.tsx`
- `src/app/checkout/pago/page.tsx`
- `src/app/checkout/pago/GuardsClient.tsx`
- `src/app/api/checkout/order-status/route.ts`

### QA en Preview:
1. `/catalogo/.../PDP` → "Comprar ahora" → `/checkout/pago`
2. Método "Tarjeta de crédito/débito (Stripe)"
3. Completar con `4242 4242 4242 4242`, fecha futura, CVC `123`
4. Al confirmar: debe ir a `/checkout/gracias?order=...`
5. Ver "Confirmando pago...", luego `paid` y carrito vacío
6. Repetir con botón "Link / Pagar de otra manera"

### Endpoints de QA:
- `GET /api/checkout/order-status?order_id=...` → `{status: "pending"|"paid"|"failed"}`
- `POST /api/checkout/create-order` → `{order_id: "...", total_cents: ...}`
- `POST /api/stripe/create-payment-intent` → `{client_secret: "pi_..."}`

