### PR TITLE
fix(checkout): render Stripe Elements only with clientSecret

### DIFF
--- a/src/lib/stripe/stripeClient.ts
+++ b/src/lib/stripe/stripeClient.ts
@@ -1,0 +1,9 @@
+// src/lib/stripe/stripeClient.ts
+// Nota: este módulo NO lleva "use client" y no usa hooks
+
+import { loadStripe } from '@stripe/stripe-js';
+
+export const stripePromise = loadStripe(
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!
+);
+


### PR DESCRIPTION
Fix: Checkout estable con Stripe - reparar render del Payment Element (React #300). Creado stripeClient.ts sin use client. Refactorizado StripePaymentForm para crear PaymentIntent internamente. Eliminada creación de PaymentIntent en PagoClient. Persistencia inmediata de orderId. Guard bypass con localStorage.