### PR TITLE
fix(checkout): resolve production bugs - React 300, pending status, sold out label, cart cleanup

### DIFF
--- a/src/app/checkout/pago/PagoClient.tsx
+++ b/src/app/checkout/pago/PagoClient.tsx
@@ -100,7 +100,23 @@ export default function PagoClient() {
 
       const urlParams = new URLSearchParams(window.location.search);
       const orderFromUrl = urlParams.get("order");
-      const orderFromStorage = localStorage.getItem("DDN_LAST_ORDER_V1");
+      
+      // Leer de localStorage (puede ser string o JSON)
+      let orderFromStorage: string | null = null;
+      try {
+        const stored = localStorage.getItem("DDN_LAST_ORDER_V1");
+        if (stored) {
+          // Intentar parsear como JSON, si falla usar como string
+          try {
+            const parsed = JSON.parse(stored);
+            orderFromStorage = parsed.order_id || parsed.orderRef || stored;
+          } catch {
+            orderFromStorage = stored;
+          }
+        }
+      } catch {
+        // Ignorar errores de localStorage
+      }
 
       if (orderFromUrl || orderFromStorage) {
         setOrderId(orderFromUrl || orderFromStorage);

--- a/src/components/FeaturedGrid.tsx
+++ b/src/components/FeaturedGrid.tsx
@@ -16,11 +16,14 @@ export default function FeaturedGrid({
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
       {items.map((item, index) => {
         const soldOut = !item.in_stock || !item.is_active;
-        const controls = !soldOut && hasPurchasablePrice(item) ? (
-          <FeaturedCardControlsLazy item={item} compact />
-        ) : soldOut && !hideSoldOutLabel ? (
-          <p className="text-sm text-muted-foreground">Agotado</p>
-        ) : null;
+        // Si hideSoldOutLabel es true, nunca mostrar "Agotado" ni controls
+        const controls = hideSoldOutLabel ? null : (
+          !soldOut && hasPurchasablePrice(item) ? (
+            <FeaturedCardControlsLazy item={item} compact />
+          ) : soldOut ? (
+            <p className="text-sm text-muted-foreground">Agotado</p>
+          ) : null
+        );
 
         return (
           <FeaturedCard


### PR DESCRIPTION
## Fix: Resolver bugs de producción en checkout

### Bugs corregidos

#### BUG 1: React error #300 en primer acceso a /checkout/pago
**Problema**: Primer acceso mostraba error "Algo salió mal" con React #300
**Causa**: `useSearchParams()` usado durante render causaba mismatch SSR/CSR
**Solución**:
- Eliminado `useSearchParams()` de `StripePaymentForm`
- Leer `window.location.search` directamente en `useEffect`
- Agregado estado `isMounted` para ejecución solo en cliente
- Parsear `localStorage.DDN_LAST_ORDER_V1` como JSON cuando sea posible
- Actualizado `PagoClient` para parsear JSON de localStorage también

#### BUG 2: Estado se queda en pending aunque redirect_status=succeeded
**Problema**: Orden mostraba "pending" aunque Stripe reportaba "succeeded"
**Causa**: Polling sobrescribía el estado exitoso antes de que se estableciera
**Solución**:
- Establecer `orderStatus="paid"` inmediatamente cuando `redirect_status=succeeded`
- Agregar early return en polling `useEffect` cuando `redirect_status=succeeded`
- Prevenir que polling sobrescriba estado exitoso
- Agregar logs de debug para seguimiento

#### BUG 3: Recomendados siguen mostrando "Agotado"
**Problema**: Etiqueta "Agotado" aparecía aunque `hideSoldOutLabel={true}`
**Causa**: Lógica condicional no cubría todos los casos
**Solución**:
- Actualizar `FeaturedGrid`: cuando `hideSoldOutLabel=true`, `controls=null`
- Esto previene tanto "Agotado" como controles de mostrar
- Productos se muestran sin etiquetas ni botones

#### BUG 4: Carrito no se vacía después de pagar
**Problema**: Carrito mantenía items después de pago exitoso
**Causa**: `clearCart()` no se llamaba en todos los casos de éxito
**Solución**:
- Llamar `clearCart()` cuando `redirect_status=succeeded`
- Llamar `clearCart()` cuando PaymentIntent status es succeeded
- Llamar `clearCart()` cuando API retorna `status=paid`
- Agregar logs de debug para operaciones de limpieza

### Archivos modificados

1. `src/components/checkout/StripePaymentForm.tsx`
   - Eliminado `useSearchParams()` hook
   - Leer URL directamente en `useEffect`
   - Agregado `isMounted` state
   - Parsear localStorage como JSON

2. `src/app/checkout/pago/PagoClient.tsx`
   - Parsear localStorage como JSON cuando sea posible

3. `src/app/checkout/gracias/GraciasContent.tsx`
   - Establecer `paid` inmediatamente cuando `redirect_status=succeeded`
   - Prevenir polling cuando ya hay éxito detectado
   - Llamar `clearCart()` en todos los casos de éxito
   - Agregar logs de debug

4. `src/components/FeaturedGrid.tsx`
   - Actualizar lógica: `hideSoldOutLabel=true` → `controls=null`
   - Prevenir mostrar "Agotado" y controles

### QA técnico

#### ✅ pnpm typecheck
```
PASS - Sin errores de TypeScript
```

#### ✅ pnpm build
```
PASS - Build exitoso
```

#### ✅ Linter
```
PASS - Sin errores de lint
```

### QA manual requerido

#### Checklist para verificar en producción:

1. **BUG 1: Primer acceso a /checkout/pago**
   - Agregar producto al carrito
   - Completar `/checkout/datos`
   - Navegar a `/checkout/pago` (primera vez)
   - ✅ **VERIFICAR**: NO aparece página de error "Algo salió mal"
   - ✅ **VERIFICAR**: NO aparece React error #300 en consola
   - ✅ **VERIFICAR**: PaymentElement se renderiza correctamente

2. **BUG 2: Estado en /checkout/gracias**
   - Completar pago con tarjeta de prueba (4242 4242 4242 4242)
   - Llegar a `/checkout/gracias?order=...&redirect_status=succeeded`
   - ✅ **VERIFICAR**: Estado muestra "paid" (no "pending")
   - ✅ **VERIFICAR**: NO aparece barra azul "Confirmando pago..."
   - ✅ **VERIFICAR**: Debug muestra `DDN_LAST_ORDER_V1` con objeto válido

3. **BUG 3: Recomendados sin "Agotado"**
   - En `/checkout/gracias`, sección "También te puede interesar"
   - ✅ **VERIFICAR**: Productos NO muestran etiqueta "Agotado"
   - ✅ **VERIFICAR**: Productos se muestran sin controles ni etiquetas

4. **BUG 4: Carrito vacío**
   - Después de pago exitoso en `/checkout/gracias`
   - ✅ **VERIFICAR**: Badge del carrito en header muestra 0
   - ✅ **VERIFICAR**: Carrito está vacío (verificar desde header)
   - ✅ **VERIFICAR**: No hay items en localStorage del carrito

### Notas

- Todos los cambios son compatibles con formato legacy de localStorage
- Logs de debug protegidos por `NEXT_PUBLIC_CHECKOUT_DEBUG`
- No se modificó lógica de negocio de Stripe (amount, idempotency, etc.)
- Cambios son mínimos y enfocados en resolver bugs específicos

