### PR TITLE
fix(checkout): hydration, order status and post-payment cleanup

### DIFF
--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -28,7 +28,6 @@ export default function FeaturedCard({
       : `/catalogo`;
   const priceCents = item.price_cents ?? 0;
   const price = priceCents > 0 ? mxnFromCents(priceCents) : null;
-  const soldOut = !item.in_stock || !item.is_active;
 
   return (
     <div className="border rounded-xl overflow-hidden flex flex-col">
@@ -63,9 +62,7 @@ export default function FeaturedCard({
             {price !== null ? formatMXN(price) : "—"}
           </div>
           {controls}
-          {!controls && soldOut ? (
-            <p className="text-sm text-muted-foreground">Agotado</p>
-          ) : null}
+          {/* NO mostrar "Agotado" si controls es null (hideSoldOutLabel=true) */}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problemas corregidos

### 1. React error #300 en /checkout/pago (primer acceso)
**Causa**: Acceso a `window.location.origin` durante el render inicial causaba mismatch SSR/CSR.
**Solución**: 
- Movido acceso a `window` dentro de `useEffect` con flag `isMounted`
- Todos los hooks ahora se llaman siempre en el mismo orden
- `useSearchParams` solo se usa después de mount en `GraciasContent`

### 2. Estado de la orden en /checkout/gracias
**Causa**: Cuando `redirect_status=succeeded`, el estado local se actualizaba pero no `localStorage` ni el backend.
**Solución**:
- Actualizar `localStorage` con `status: "paid"` después de actualizar backend
- Aplicar mismo patrón en los 3 puntos donde se detecta éxito (redirect_status, PaymentIntent, polling)

### 3. Carrito no se vacía después del pago
**Causa**: `clearCart()` se llamaba múltiples veces en diferentes `useEffect`.
**Solución**:
- Introducido flag `cartCleared` para asegurar que `clearCart()` se llama solo una vez
- Flag se resetea solo cuando se inicia un nuevo checkout

### 4. "También te puede interesar" muestra "Agotado"
**Causa**: `FeaturedCard` mostraba "Agotado" cuando `controls` era null, incluso con `hideSoldOutLabel=true`.
**Solución**:
- Eliminada renderización condicional de "Agotado" en `FeaturedCard` cuando `controls` es null
- `FeaturedGrid` ya pasa `hideSoldOutLabel=true` correctamente

## Verificaciones técnicas
- ✅ `pnpm typecheck`: PASS
- ✅ `pnpm build`: PASS
- ⚠️ `pnpm lint`: Algunos warnings de complejidad cognitiva (no críticos)

## QA manual requerido
1. Flujo completo: catálogo → carrito → /checkout/datos → /checkout/pago
2. Verificar que NO aparece error "Algo salió mal" en primer acceso a /checkout/pago
3. Verificar que después de pagar con 4242..., el estado muestra "paid" en /checkout/gracias
4. Verificar que el carrito se vacía después del pago (badge en header = 0)
5. Verificar que "También te puede interesar" NO muestra "Agotado"
6. Verificar que `DDN_LAST_ORDER_V1` en localStorage tiene `status: "paid"` después del pago

