### PR TITLE
fix(checkout): save-order and cleanup after payment

### DIFF
--- a/src/app/api/checkout/save-order/route.ts
+++ b/src/app/api/checkout/save-order/route.ts
@@ -58,10 +58,18 @@ export async function POST(req: NextRequest) {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-    if (!supabaseUrl || !serviceRoleKey) {
-      console.error("[save-order] Supabase no está configurado");
+    if (!supabaseUrl) {
+      console.error("[save-order] NEXT_PUBLIC_SUPABASE_URL no está configurado");
       return NextResponse.json(
-        { error: "Servidor no configurado correctamente" },
+        { error: "No se pudo guardar la orden: configuración de Supabase incompleta" },
+        { status: 500 },
+      );
+    }
+
+    if (!serviceRoleKey) {
+      console.error("[save-order] SUPABASE_SERVICE_ROLE_KEY no está configurado");
+      return NextResponse.json(
+        { error: "No se pudo guardar la orden: falta clave de servicio de Supabase" },
         { status: 500 },
       );
     }
@@ -121,9 +129,15 @@ export async function POST(req: NextRequest) {
         .eq("id", orderData.order_id);
 
       if (updateError) {
-        console.error("[save-order] Error al actualizar orden:", updateError);
+        console.error("[save-order] Error al actualizar orden:", {
+          message: updateError.message,
+          details: updateError.details,
+          hint: updateError.hint,
+          code: updateError.code,
+          order_id: orderData.order_id,
+        });
         return NextResponse.json(
-          { error: `Error al actualizar orden: ${updateError.message}` },
+          { error: "No se pudo guardar la orden" },
           { status: 500 },
         );
       }
@@ -149,9 +163,16 @@ export async function POST(req: NextRequest) {
         });
 
       if (insertError) {
-        console.error("[save-order] Error al crear orden:", insertError);
+        console.error("[save-order] Error al crear orden:", {
+          message: insertError.message,
+          details: insertError.details,
+          hint: insertError.hint,
+          code: insertError.code,
+          order_id: orderData.order_id,
+          email: orderData.email,
+        });
         return NextResponse.json(
-          { error: `Error al crear orden: ${insertError.message}` },
+          { error: "No se pudo guardar la orden" },
           { status: 500 },
         );
       }
@@ -172,9 +193,16 @@ export async function POST(req: NextRequest) {
       .insert(orderItems);
 
     if (itemsError) {
-      console.error("[save-order] Error al crear items:", itemsError);
+      console.error("[save-order] Error al crear items:", {
+        message: itemsError.message,
+        details: itemsError.details,
+        hint: itemsError.hint,
+        code: itemsError.code,
+        order_id: orderData.order_id,
+        items_count: orderItems.length,
+      });
       return NextResponse.json(
-        { error: `Error al crear items: ${itemsError.message}` },
+        { error: "No se pudo guardar la orden" },
         { status: 500 },
       );
     }

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -9,6 +9,7 @@ import {
   selectSelectedCount,
   selectSelectedTotal,
 } from "@/lib/store/checkoutStore";
+import { useCartStore } from "@/lib/store/cartStore";
 import CheckoutItemRow from "@/components/CheckoutItemRow";
 import CheckoutSummary from "@/components/CheckoutSummary";
 
@@ -33,15 +34,25 @@ export default function CheckoutIndex() {
   const router = useRouter();
   const did = useRef(false);
 
-  // Selectores primitivos
+  // Sincronizar con cartStore: fuente única de verdad
+  const cartItems = useCartStore((s) => s.cartItems);
   const checkoutItems = useCheckoutStore(selectCheckoutItems);
   const selectedCount = useCheckoutStore(selectSelectedCount);
   const selectedTotal = useCheckoutStore(selectSelectedTotal);
+  const clearCheckout = useCheckoutStore((s) => s.clearCheckout);
+  const clearSelection = useCheckoutStore((s) => s.clearSelection);
 
   // Acciones del store
   const selectAllCheckout = useCheckoutStore((s) => s.selectAllCheckout);
   const deselectAllCheckout = useCheckoutStore((s) => s.deselectAllCheckout);
-  const clearCheckout = useCheckoutStore((s) => s.clearCheckout);
+
+  // Guard: si el carrito está vacío, limpiar checkout también
+  useEffect(() => {
+    if (cartItems.length === 0 && checkoutItems.length > 0) {
+      clearCheckout();
+      clearSelection();
+    }
+  }, [cartItems.length, checkoutItems.length, clearCheckout, clearSelection]);
 
   // Redirect once if no items
   useEffect(() => {

--- a/src/lib/store/checkoutStore.ts
+++ b/src/lib/store/checkoutStore.ts
@@ -300,22 +300,27 @@ export const useCheckoutStore = create<State>()(
 
     clearSelection: () => {
       set((state) => {
-        const next = state.checkoutItems.map((i) => ({ ...i, selected: false }));
-        if (next.every((i) => !i.selected) && state.checkoutItems.every((i) => !i.selected)) {
-          return state;
-        }
+        // Limpiar completamente checkoutItems y selección después de pago exitoso
+        const next = {
+          ...state,
+          checkoutItems: [],
+          couponCode: undefined,
+          discount: undefined,
+          discountScope: undefined,
+          // Mantener datos y shipping por si el usuario quiere hacer otra compra
+        };
         persistCheckout({
-          step: state.step,
-          datos: state.datos,
-          checkoutItems: next,
-          shippingMethod: state.shippingMethod,
-          shippingCost: state.shippingCost,
-          couponCode: state.couponCode,
-          discount: state.discount,
-          discountScope: state.discountScope,
-          lastAppliedCoupon: state.lastAppliedCoupon,
+          step: "datos",
+          datos: next.datos,
+          checkoutItems: [],
+          shippingMethod: next.shippingMethod,
+          shippingCost: next.shippingCost,
+          couponCode: undefined,
+          discount: undefined,
+          discountScope: undefined,
+          lastAppliedCoupon: next.lastAppliedCoupon,
         });
-        return { checkoutItems: next };
+        return next;
       });
     },
 


### PR DESCRIPTION
Fix de /api/checkout/save-order para usar el cliente correcto y no fallar por config. Sincronizacion fuerte carrito-checkout usando solo cartStore.items. Limpieza completa de seleccion y estado de checkout despues de pago exitoso. Cupones solo en /checkout/pago (DDN10, 10%).