### PR TITLE
Fix checkout orderId reuse and email in Stripe

### DIFF
--- a/src/app/checkout/pago/PagoClient.tsx
+++ b/src/app/checkout/pago/PagoClient.tsx
@@ -337,7 +337,11 @@ export default function PagoClient() {
 
     try {
       // Crear orden primero - usar price_cents directamente si existe
+      // IMPORTANTE: Incluir email del checkout para que se guarde en la orden y se use en Stripe
       const orderPayload = {
+        email: datos.email, // Email del checkout para la orden y Stripe
+        name: datos.name, // Nombre para metadata
+        shippingMethod: selectedShippingMethod || "pickup", // Método de envío
         items: itemsForOrder.map((item) => {
           const qty = item.qty ?? 1;
           const priceCents =


### PR DESCRIPTION
## Cambios implementados

### 1. Prevenir reutilización de ORDER ID entre compras distintas
- Eliminada lógica de hash que reutilizaba órdenes entre compras diferentes
- Cada llamada a create-order ahora crea SIEMPRE una nueva orden con id único

### 2. Usar email del checkout en Stripe
- Obtener email de orden desde Supabase y usarlo como receipt_email en PaymentIntent
- Asegurar que email del checkout se pasa al crear orden

## QA
- Hacer 3 compras seguidas: cada una debe tener orderId diferente
- Hacer compras con emails distintos: cada cargo en Stripe debe mostrar el email correcto