### PR TITLE
fix(shop): remove duplicated cart actions from product cards

### DIFF
--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -8,7 +8,6 @@ type Props = {
   item: FeaturedItem;
   priority?: boolean;
   sizes?: string;
-  controls?: React.ReactNode; // Mantener compatibilidad con controles custom si se necesitan
 };
 
 /**
@@ -36,27 +35,14 @@ function toProductCardProps(
 
 /**
  * FeaturedCard: wrapper que usa ProductCard canónico
- * Si se pasa `controls`, se renderiza en lugar de los controles por defecto
+ * ProductCard ya incluye todos los controles necesarios (cantidad + agregar + WhatsApp)
  * @deprecated Usar ProductCard directamente cuando sea posible
  */
 export default function FeaturedCard({
   item,
   priority = false,
   sizes,
-  controls,
 }: Props) {
-  // Si hay controles custom, usar el layout antiguo (compatibilidad)
-  if (controls) {
-    // Mantener compatibilidad con código que pasa controles custom
-    const props = toProductCardProps(item, priority, sizes);
-    return (
-      <div className="border rounded-xl overflow-hidden flex flex-col">
-        <ProductCard {...props} />
-        {controls}
-      </div>
-    );
-  }
-
-  // Usar ProductCard directamente
+  // Siempre usar ProductCard directamente - ya incluye todos los controles
   return <ProductCard {...toProductCardProps(item, priority, sizes)} />;
 }

--- a/src/components/FeaturedCarousel.tsx
+++ b/src/components/FeaturedCarousel.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import FeaturedCard from "@/components/FeaturedCard";
-import FeaturedCardControlsLazy from "@/components/FeaturedCardControls.lazy.client";
-import { hasPurchasablePrice } from "@/lib/catalog/model";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
 
 export default function FeaturedCarousel({ items }: { items: FeaturedItem[] }) {
@@ -17,16 +15,6 @@ export default function FeaturedCarousel({ items }: { items: FeaturedItem[] }) {
               item={item}
               priority={index === 0}
               sizes="(max-width: 768px) 90vw, 50vw"
-              controls={
-                (() => {
-                  const soldOut = !item.in_stock || !item.is_active;
-                  return !soldOut && hasPurchasablePrice(item) ? (
-                    <FeaturedCardControlsLazy item={item} compact />
-                  ) : soldOut ? (
-                    <p className="text-sm text-muted-foreground">Agotado</p>
-                  ) : null;
-                })()
-              }
             />
           </div>
         ))}


### PR DESCRIPTION
## Problema resuelto

Las tarjetas de producto mostraban DOS filas de controles (cantidad + botón Agregar) una encima de la otra en producción.

## Cambios realizados

### 1. FeaturedCard.tsx
- ❌ Eliminada la prop `controls` que causaba duplicación
- ✅ Ahora siempre usa ProductCard directamente sin controles adicionales
- ProductCard ya incluye todos los controles necesarios

### 2. FeaturedCarousel.tsx
- ❌ Eliminados los controles duplicados (FeaturedCardControlsLazy)
- ✅ Ahora usa FeaturedCard sin pasar controles custom
- ProductCard renderiza una sola fila: cantidad + botón Agregar + WhatsApp

### 3. ProductCard.tsx
- ✅ Verificado: solo tiene UNA sección de controles (líneas 196-256)
- Estructura correcta:
  - Una fila con QuantityInput + botón "Agregar"
  - Link de WhatsApp debajo (si aplica)

## Páginas verificadas

- ✅ Home (`/`) - FeaturedCarousel y FeaturedGrid
- ✅ `/destacados` - FeaturedGrid
- ✅ `/tienda` - FeaturedGrid
- ✅ `/catalogo/[section]` - ProductCard directo
- ✅ `/buscar?q=...` - SearchResultCard (usa ProductCard)

## PDP no afectada

- ✅ `src/components/pdp/AddToCartControls.tsx` permanece sin cambios
- ✅ PDP sigue teniendo: cantidad + Agregar + Comprar ahora + WhatsApp

## Checks técnicos

- ✅ pnpm lint: 0 errores
- ✅ pnpm typecheck: exitoso
- ✅ pnpm build: exitoso

