### PR TITLE
feat(shop): show WhatsApp CTA below add-to-cart in ProductCard

### DIFF
--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -241,8 +241,8 @@ export default function ProductCard({
           </div>
         )}
 
-        {/* Botón WhatsApp para consultas */}
-        {waHref && (!canPurchase || soldOut) && (
+        {/* Botón WhatsApp para consultas - SIEMPRE visible si hay link */}
+        {waHref && (
           <a
             href={waHref}
             target="_blank"


### PR DESCRIPTION
## Objetivo

Hacer que todas las tarjetas de producto (`ProductCard`) muestren **SIEMPRE** el link de "Consultar por WhatsApp" debajo del botón "Agregar", incluso para productos normales con precio y stock.

## Cambio realizado

### ProductCard.tsx

**Antes:**
- El link de WhatsApp solo se mostraba cuando `(!canPurchase || soldOut)`
- Productos normales con precio y stock no mostraban WhatsApp

**Ahora:**
- El link de WhatsApp se muestra **SIEMPRE** si existe `waHref` (línea 245)
- Todos los productos muestran:
  - Fila con cantidad + botón "Agregar"
  - Debajo: link "Consultar por WhatsApp"

## Estructura final de la card

```
┌─────────────────────────┐
│      [Imagen]           │
│      [Título]          │
│      [Precio]          │
│      [Estado stock]    │
│                        │
│  [-] [cantidad] [+]    │
│  [Agregar]            │
│  Consultar por WhatsApp│ ← SIEMPRE visible
└─────────────────────────┘
```

## Comportamiento por caso

### Caso normal (producto con precio y stock)
- ✅ Muestra: cantidad + botón "Agregar" (activo)
- ✅ Muestra: "Consultar por WhatsApp" debajo

### Caso sin precio o no vendible
- ✅ Muestra: mensaje "Consultar precio" o "Agotado"
- ✅ Muestra: "Consultar por WhatsApp" debajo

### Caso agotado
- ✅ Muestra: badge "Agotado"
- ✅ Muestra: "Consultar por WhatsApp" debajo

## Páginas afectadas

Todas las páginas que usan `ProductCard` ahora muestran WhatsApp:
- ✅ Home (`/`) - FeaturedCarousel y FeaturedGrid
- ✅ `/destacados` - FeaturedGrid
- ✅ `/tienda` - FeaturedGrid
- ✅ `/catalogo/[section]` - ProductCard directo
- ✅ `/buscar?q=...` - SearchResultCard (usa ProductCard)

## PDP no afectada

- ✅ `src/components/pdp/AddToCartControls.tsx` permanece sin cambios
- ✅ PDP mantiene su propio flujo de WhatsApp (si lo tiene)

## Helper de WhatsApp

- ✅ Reutiliza `getWhatsAppHref()` de `src/lib/whatsapp.ts`
- ✅ Mensaje: "Hola, me interesa el producto: {title} ({product_slug}). ¿Lo tienes disponible?"
- ✅ Mismo helper usado en otras partes del proyecto

## Checks técnicos

- ✅ `pnpm lint`: 0 errores
- ✅ `pnpm typecheck`: exitoso
- ✅ `pnpm build`: exitoso

