### PR TITLE
feat(account): basic orders history by email

### DIFF
--- a/src/app/api/account/orders/route.ts
+++ b/src/app/api/account/orders/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { unstable_noStore as noStore } from "next/cache";
+import { z } from "zod";
+import {
+  getOrdersByEmail,
+  getOrderWithItems,
+} from "@/lib/supabase/orders.server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const OrdersRequestSchema = z.object({
+  email: z.string().email("Email inválido"),
+  orderId: z.string().uuid().optional(),
+});
+
+type OrdersRequest = z.infer<typeof OrdersRequestSchema>;
+
+export async function POST(req: NextRequest) {
+  noStore();
+  try {
+    const body = await req.json().catch(() => null);
+
+    if (!body || typeof body !== "object") {
+      return NextResponse.json(
+        { error: "Datos inválidos: se espera un objeto JSON" },
+        { status: 422 },
+      );
+    }
+
+    // Validar con Zod
+    const validationResult = OrdersRequestSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      const errors = validationResult.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join(", ");
+      return NextResponse.json(
+        { error: `Datos inválidos: ${errors}` },
+        { status: 422 },
+      );
+    }
+
+    const { email, orderId } = validationResult.data;
+
+    // Si viene orderId, devolver detalle de una orden
+    if (orderId) {
+      const order = await getOrderWithItems(orderId, email);
+
+      if (!order) {
+        return NextResponse.json(
+          { error: "Orden no encontrada o no pertenece a este email" },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json({ order });
+    }
+
+    // Si no viene orderId, devolver lista de órdenes
+    const orders = await getOrdersByEmail(email, { limit: 20 });
+
+    return NextResponse.json({ orders });
+  } catch (error) {
+    console.error("[api/account/orders] Error:", error);
+    return NextResponse.json(
+      { error: "Error al obtener órdenes" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/lib/supabase/orders.server.ts
+++ b/src/lib/supabase/orders.server.ts
@@ -1,0 +1,136 @@
+import "server-only";
+import { createActionSupabase } from "./server-actions";
+
+/**
+ * Tipos para órdenes y items
+ */
+export type OrderSummary = {
+  id: string;
+  created_at: string;
+  status: string;
+  email: string;
+  total_cents: number | null;
+  metadata: {
+    shipping_method?: string;
+    coupon_code?: string;
+    subtotal_cents?: number;
+    discount_cents?: number;
+    contact_name?: string;
+    contact_email?: string;
+  } | null;
+};
+
+export type OrderItem = {
+  id: string;
+  product_id: string | null;
+  title: string;
+  qty: number;
+  unit_price_cents: number;
+  image_url: string | null;
+};
+
+export type OrderDetail = OrderSummary & {
+  items: OrderItem[];
+};
+
+/**
+ * Obtiene las órdenes de un email específico
+ * @param email - Email del usuario
+ * @param options - Opciones de consulta (limit por defecto 10)
+ * @returns Lista de órdenes resumidas (sin items)
+ */
+export async function getOrdersByEmail(
+  email: string,
+  options?: { limit?: number },
+): Promise<OrderSummary[]> {
+  const supabase = createActionSupabase();
+  const limit = options?.limit ?? 10;
+
+  const { data, error } = await supabase
+    .from("orders")
+    .select("id, created_at, status, email, total_cents, metadata")
+    .eq("email", email.toLowerCase().trim())
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error("[getOrdersByEmail] Error:", error);
+    throw new Error(`Error al obtener órdenes: ${error.message}`);
+  }
+
+  return (data || []).map((order) => ({
+    id: order.id,
+    created_at: order.created_at,
+    status: order.status,
+    email: order.email,
+    total_cents: order.total_cents,
+    metadata: (order.metadata as OrderSummary["metadata"]) || null,
+  }));
+}
+
+/**
+ * Obtiene una orden específica con sus items, verificando que pertenezca al email
+ * @param orderId - ID de la orden
+ * @param email - Email del usuario (para verificación de seguridad)
+ * @returns Orden completa con items, o null si no existe o no pertenece al email
+ */
+export async function getOrderWithItems(
+  orderId: string,
+  email: string,
+): Promise<OrderDetail | null> {
+  const supabase = createActionSupabase();
+
+  // Primero verificar que la orden existe y pertenece al email
+  const { data: orderData, error: orderError } = await supabase
+    .from("orders")
+    .select("id, created_at, status, email, total_cents, metadata")
+    .eq("id", orderId)
+    .eq("email", email.toLowerCase().trim())
+    .single();
+
+  if (orderError || !orderData) {
+    console.warn(
+      `[getOrderWithItems] Orden ${orderId} no encontrada o no pertenece a ${email}`,
+    );
+    return null;
+  }
+
+  // Obtener los items de la orden
+  const { data: itemsData, error: itemsError } = await supabase
+    .from("order_items")
+    .select("id, product_id, title, qty, unit_price_cents, image_url")
+    .eq("order_id", orderId)
+    .order("created_at", { ascending: true });
+
+  if (itemsError) {
+    console.error("[getOrderWithItems] Error al obtener items:", itemsError);
+    // Aún así devolver la orden sin items si hay error
+    return {
+      id: orderData.id,
+      created_at: orderData.created_at,
+      status: orderData.status,
+      email: orderData.email,
+      total_cents: orderData.total_cents,
+      metadata: (orderData.metadata as OrderSummary["metadata"]) || null,
+      items: [],
+    };
+  }
+
+  return {
+    id: orderData.id,
+    created_at: orderData.created_at,
+    status: orderData.status,
+    email: orderData.email,
+    total_cents: orderData.total_cents,
+    metadata: (orderData.metadata as OrderSummary["metadata"]) || null,
+    items: (itemsData || []).map((item) => ({
+      id: item.id,
+      product_id: item.product_id,
+      title: item.title,
+      qty: item.qty,
+      unit_price_cents: item.unit_price_cents,
+      image_url: item.image_url,
+    })),
+  };
+}
+


### PR DESCRIPTION
## Objetivo

Crear un flujo básico de "Mis pedidos" para que los usuarios puedan consultar su historial de órdenes por correo, sin implementar un sistema de login completo.

## Cambios realizados

### 1. Helper server-only para leer órdenes

**Archivo:** `src/lib/supabase/orders.server.ts`

- `getOrdersByEmail(email, options?)`: Obtiene lista de órdenes por email
  - Filtra por `email` (case-insensitive)
  - Ordena por `created_at` DESC
  - Limita resultados (default 10)
  - Devuelve: id, created_at, status, email, total_cents, metadata

- `getOrderWithItems(orderId, email)`: Obtiene detalle de una orden con items
  - Verifica que la orden pertenezca al email (seguridad)
  - Devuelve orden completa con items desde `order_items`
  - Retorna `null` si no existe o no pertenece al email

**Tipos exportados:**
- `OrderSummary`: Resumen de orden (sin items)
- `OrderItem`: Item individual de una orden
- `OrderDetail`: Orden completa con items

### 2. API route para consultar órdenes

**Archivo:** `src/app/api/account/orders/route.ts`

- Método: `POST`
- Input:
  - `email: string` (obligatorio, validado con Zod)
  - `orderId?: string` (opcional, UUID)
- Respuestas:
  - Si `orderId` está presente: devuelve detalle de una orden con items
  - Si no: devuelve lista de órdenes resumidas
  - 422 si input inválido
  - 404 si orden no encontrada o no pertenece al email
  - 500 si error del servidor

### 3. Página frontend "Mis pedidos"

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- Formulario simple con:
  - Input de email (obligatorio)
  - Input opcional de ID de pedido
  - Botón "Buscar pedidos"

- Lista de pedidos:
  - Tabla con fecha, ID corto, estado, total, método de envío
  - Botón "Ver detalle" para cada pedido
  - Estados con colores (pagado=verde, pendiente=amarillo)

- Detalle de pedido:
  - Información completa (ID, fecha, estado, email)
  - Tabla de items con nombre, cantidad, precio unitario, subtotal
  - Totales (subtotal, descuento, cupón si aplica, total)

- Manejo de estados:
  - Loading mientras se hace la petición
  - Mensajes de error claros
  - Mensaje cuando no se encuentran pedidos

### 4. Navegación

- ✅ Ya existían enlaces a `/cuenta/pedidos` en:
  - `ToothAccountMenu.tsx` (línea 123)
  - `TopNav.tsx` (líneas 92 y 169)
- No se requirieron cambios adicionales

## Seguridad

- Verificación de email: Solo se pueden consultar órdenes que pertenezcan al email proporcionado
- Validación con Zod: Email y orderId validados antes de consultar
- Server-only helpers: No se exponen credenciales ni lógica sensible al cliente

## Uso

1. Usuario navega a `/cuenta/pedidos`
2. Ingresa su email
3. Opcionalmente ingresa un ID de pedido específico
4. Hace clic en "Buscar pedidos"
5. Ve lista de pedidos o detalle según corresponda

## Checks técnicos

- ✅ `pnpm lint`: 0 errores
- ✅ `pnpm typecheck`: exitoso
- ✅ `pnpm build`: exitoso

## Notas

- No se modificó el flujo de checkout existente
- No se modificaron tablas de Supabase
- Reutiliza helpers existentes (`formatMXNFromCents`, `createActionSupabase`)
- Compatible con la estructura actual del proyecto

