### PR TITLE
fix(account): add menu entry and working order details

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -11,9 +11,11 @@ export default function PedidosPage() {
   const [email, setEmail] = useState("");
   const [orderId, setOrderId] = useState("");
   const [loading, setLoading] = useState(false);
+  const [loadingDetail, setLoadingDetail] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [orders, setOrders] = useState<OrderSummary[] | null>(null);
   const [orderDetail, setOrderDetail] = useState<OrderDetail | null>(null);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,9 +63,9 @@ export default function PedidosPage() {
   const handleViewDetail = async (id: string) => {
     if (!email.trim()) return;
 
-    setLoading(true);
+    setLoadingDetail(true);
     setError(null);
-    setOrderDetail(null);
+    setSelectedOrderId(id);
 
     try {
       const response = await fetch("/api/account/orders", {
@@ -81,6 +83,7 @@ export default function PedidosPage() {
 
       if (!response.ok) {
         setError(data.error || "Error al obtener detalle del pedido");
+        setSelectedOrderId(null);
         return;
       }
 
@@ -89,9 +92,10 @@ export default function PedidosPage() {
       }
     } catch (err) {
       setError("Error de conexión. Intenta de nuevo.");
+      setSelectedOrderId(null);
       console.error(err);
     } finally {
-      setLoading(false);
+      setLoadingDetail(false);
     }
   };
 
@@ -240,10 +244,15 @@ export default function PedidosPage() {
                         </p>
                       )}
                       <button
+                        type="button"
                         onClick={() => handleViewDetail(order.id)}
-                        className="mt-2 text-sm text-primary-600 hover:text-primary-700 underline"
+                        disabled={loadingDetail}
+                        className="mt-2 text-sm text-primary-600 hover:text-primary-700 underline disabled:opacity-50 disabled:cursor-not-allowed"
+                        aria-label={`Ver detalle del pedido ${order.id.substring(0, 8)}`}
                       >
-                        Ver detalle
+                        {loadingDetail && selectedOrderId === order.id
+                          ? "Cargando detalle..."
+                          : "Ver detalle"}
                       </button>
                     </div>
                   </div>

--- a/src/components/ToothAccountMenu.tsx
+++ b/src/components/ToothAccountMenu.tsx
@@ -159,6 +159,13 @@ export function ToothAccountMenu() {
               >
                 Crear cuenta
               </Link>
+              <Link
+                href="/cuenta/pedidos"
+                className="block rounded-xl px-3 py-2 hover:bg-neutral-50"
+                onClick={() => setOpen(false)}
+              >
+                Mis pedidos
+              </Link>
             </>
           )}
         </div>

--- a/src/components/navigation/TopNav.tsx
+++ b/src/components/navigation/TopNav.tsx
@@ -190,13 +190,22 @@ export function TopNav() {
                 </button>
               </>
             ) : (
-              <Link
-                href={ROUTES.cuenta()}
-                className="block text-primary-600 font-medium"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                <span>Iniciar Sesión</span>
-              </Link>
+              <>
+                <Link
+                  href={ROUTES.cuenta()}
+                  className="block text-primary-600 font-medium"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  <span>Iniciar Sesión</span>
+                </Link>
+                <Link
+                  href="/cuenta/pedidos"
+                  className="block text-gray-700 hover:text-primary-600"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  <span>Mis Pedidos</span>
+                </Link>
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Objetivo

Arreglar el flujo de "Mis pedidos" para que:
1. Haya un acceso claro desde la navegación (sin escribir `/cuenta/pedidos` a mano)
2. El botón "Ver detalle" realmente muestre el detalle de la orden

## Cambios realizados

### 1. Acceso visible a "Mis pedidos"

**Archivo:** `src/components/ToothAccountMenu.tsx`

- ✅ Añadido link "Mis pedidos" al dropdown cuando el usuario **NO está logueado**
- ✅ El link funciona sin autenticación (como se requiere)
- ✅ Mantiene los links existentes: "Entrar" y "Crear cuenta"

**Archivo:** `src/components/navigation/TopNav.tsx`

- ✅ Añadido link "Mis pedidos" al menú móvil cuando el usuario **NO está logueado**
- ✅ Consistencia entre desktop y mobile

### 2. Arreglo del botón "Ver detalle"

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

**Problemas corregidos:**
- ❌ **Antes:** El botón no tenía `type="button"`, lo que podía causar que recargara el formulario
- ✅ **Ahora:** Botón con `type="button"` explícito

**Mejoras implementadas:**
- ✅ Estado `loadingDetail` separado de `loading` para mejor UX
- ✅ Estado `selectedOrderId` para rastrear qué orden se está cargando
- ✅ Indicador visual "Cargando detalle..." mientras se carga el detalle
- ✅ Botón deshabilitado mientras se carga (`disabled={loadingDetail}`)
- ✅ Mejor accesibilidad con `aria-label` en los botones

**Flujo mejorado:**
1. Usuario busca pedidos por email → ve lista
2. Usuario hace clic en "Ver detalle" → botón muestra "Cargando detalle..."
3. Detalle se carga → se muestra debajo de la lista sin recargar la página
4. Si hay error, se muestra mensaje claro

### 3. Mejoras de UX

- Estado de carga separado para lista vs detalle
- Mensajes claros durante la carga
- Botones deshabilitados durante operaciones para evitar clicks duplicados
- Mejor feedback visual

## Archivos modificados

1. **`src/components/ToothAccountMenu.tsx`**
   - Añadido link "Mis pedidos" cuando usuario NO está logueado

2. **`src/components/navigation/TopNav.tsx`**
   - Añadido link "Mis pedidos" en menú móvil cuando usuario NO está logueado

3. **`src/app/cuenta/pedidos/page.tsx`**
   - Añadido `type="button"` al botón "Ver detalle"
   - Añadido estado `loadingDetail` y `selectedOrderId`
   - Mejorado `handleViewDetail` para usar estados separados
   - Mejorado feedback visual durante carga

## Verificación

- ✅ `pnpm lint`: 0 errores
- ✅ `pnpm typecheck`: exitoso
- ✅ `pnpm build`: exitoso

## Pruebas sugeridas

1. **Navegación:**
   - Sin estar logueado, abrir menú de cuenta → debe aparecer "Mis pedidos"
   - En mobile, abrir menú hamburguesa → debe aparecer "Mis pedidos"
   - Hacer clic en "Mis pedidos" → debe navegar a `/cuenta/pedidos`

2. **Funcionalidad:**
   - En `/cuenta/pedidos`, ingresar email con órdenes (ej. `a@a.com`)
   - Hacer clic en "Buscar pedidos" → debe mostrar lista
   - Hacer clic en "Ver detalle" → debe mostrar "Cargando detalle..." y luego el detalle
   - El detalle debe mostrar productos, cantidades, precios y totales correctamente

## Notas

- No se modificó el flujo de checkout ni Stripe
- No se modificó la pantalla de login en `/cuenta`
- El acceso a "Mis pedidos" funciona sin autenticación (como se requiere)
- Mejoras de accesibilidad añadidas

