### PR TITLE
fix(account): working order detail and autocomplete hints

### DIFF
--- a/src/app/api/account/orders/route.ts
+++ b/src/app/api/account/orders/route.ts
@@ -49,6 +49,16 @@ export async function POST(req: NextRequest) {
       try {
         const order = await getOrderWithItems(orderId, normalizedEmail);
 
+        // Log temporal para debugging
+        if (process.env.NODE_ENV === "development") {
+          console.log("[api/account/orders] getOrderWithItems result:", {
+            orderId,
+            email: normalizedEmail,
+            found: !!order,
+            itemsCount: order?.items?.length || 0,
+          });
+        }
+
         if (!order) {
           return NextResponse.json(
             { error: "Orden no encontrada o no pertenece a este email" },

--- a/src/app/cuenta/ClientPage.tsx
+++ b/src/app/cuenta/ClientPage.tsx
@@ -131,6 +131,7 @@ export default function CuentaClientPage() {
               required
               className="input"
               placeholder="tu@email.com"
+              autoComplete="email"
             />
           </div>
 
@@ -143,6 +144,7 @@ export default function CuentaClientPage() {
               className="input"
               placeholder="••••••••"
               minLength={6}
+              autoComplete={mode === "login" ? "current-password" : "new-password"}
             />
           </div>
 
@@ -156,6 +158,7 @@ export default function CuentaClientPage() {
                 className="input"
                 placeholder="••••••••"
                 minLength={6}
+                autoComplete="new-password"
               />
             </div>
           )}

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -66,6 +66,17 @@ export default function PedidosPage() {
     setLoadingDetail(true);
     setError(null);
     setSelectedOrderId(id);
+    setOrderDetail(null); // Limpiar detalle anterior
+
+    const requestBody = {
+      email: email.trim(),
+      orderId: id,
+    };
+
+    // Log temporal para debugging
+    if (process.env.NODE_ENV === "development") {
+      console.log("[handleViewDetail] Request:", requestBody);
+    }
 
     try {
       const response = await fetch("/api/account/orders", {
@@ -73,27 +84,46 @@ export default function PedidosPage() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          email: email.trim(),
-          orderId: id,
-        }),
+        body: JSON.stringify(requestBody),
       });
 
       const data = await response.json();
 
+      // Log temporal para debugging
+      if (process.env.NODE_ENV === "development") {
+        console.log("[handleViewDetail] Response:", {
+          status: response.status,
+          ok: response.ok,
+          data,
+        });
+      }
+
       if (!response.ok) {
         setError(data.error || "Error al obtener detalle del pedido");
         setSelectedOrderId(null);
+        setOrderDetail(null);
         return;
       }
 
       if (data.order) {
         setOrderDetail(data.order);
+        // Log temporal para debugging
+        if (process.env.NODE_ENV === "development") {
+          console.log("[handleViewDetail] Order detail set:", {
+            id: data.order.id,
+            itemsCount: data.order.items?.length || 0,
+          });
+        }
+      } else {
+        setError("No se recibió información del pedido");
+        setSelectedOrderId(null);
+        setOrderDetail(null);
       }
     } catch (err) {
       setError("Error de conexión. Intenta de nuevo.");
       setSelectedOrderId(null);
-      console.error(err);
+      setOrderDetail(null);
+      console.error("[handleViewDetail] Error:", err);
     } finally {
       setLoadingDetail(false);
     }
@@ -154,6 +184,7 @@ export default function PedidosPage() {
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 placeholder="tu@email.com"
+                autoComplete="email"
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               />
             </div>
@@ -171,6 +202,7 @@ export default function PedidosPage() {
                 value={orderId}
                 onChange={(e) => setOrderId(e.target.value)}
                 placeholder="UUID del pedido"
+                autoComplete="off"
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               />
               <p className="mt-1 text-sm text-gray-500">


### PR DESCRIPTION
## Problema

1. El botón "Ver detalle" mostraba "Cargando detalle..." pero luego no mostraba el detalle de la orden
2. Warning de DevTools: "An element doesn't have an autocomplete attribute" en inputs de formularios

## Cambios realizados

### 1. Fix del botón "Ver detalle"

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

**Problemas identificados y corregidos:**
- ❌ **Antes:** No se limpiaba `orderDetail` antes de cargar nuevo detalle, causando que el estado anterior persistiera
- ✅ **Ahora:** Se limpia explícitamente `orderDetail` al inicio de `handleViewDetail`

- ❌ **Antes:** Si `data.order` no existía, no se mostraba ningún error
- ✅ **Ahora:** Se muestra mensaje de error claro cuando no se recibe información del pedido

**Mejoras implementadas:**
- ✅ Limpieza explícita de estados (`setOrderDetail(null)`) antes de cargar nuevo detalle
- ✅ Manejo mejorado de errores cuando `data.order` no existe
- ✅ Logs temporales en desarrollo para debugging:
  - Request body enviado
  - Response status y data recibida
  - Order detail establecido con items count

**Archivo:** `src/app/api/account/orders/route.ts`

- ✅ Logs temporales en desarrollo para debugging:
  - Resultado de `getOrderWithItems` (found, itemsCount)

### 2. Fix del warning de autocomplete

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- ✅ Input de email: `autoComplete="email"`
- ✅ Input de orderId: `autoComplete="off"`

**Archivo:** `src/app/cuenta/ClientPage.tsx`

- ✅ Input de email: `autoComplete="email"`
- ✅ Input de contraseña (login): `autoComplete="current-password"`
- ✅ Input de contraseña (registro): `autoComplete="new-password"`
- ✅ Input de confirmar contraseña: `autoComplete="new-password"`

## Flujo corregido

1. Usuario busca pedidos por email → ve lista
2. Usuario hace clic en "Ver detalle":
   - Se limpia `orderDetail` anterior
   - Se establece `selectedOrderId` y `loadingDetail = true`
   - Se hace fetch a `/api/account/orders` con `email` y `orderId`
   - Si la respuesta es exitosa y tiene `data.order`:
     - Se establece `orderDetail` con el detalle completo
     - Se muestra el panel de detalle debajo de la lista
   - Si hay error o no se recibe `data.order`:
     - Se muestra mensaje de error claro
     - Se limpian los estados

## Archivos modificados

1. **`src/app/cuenta/pedidos/page.tsx`**
   - Mejorado `handleViewDetail` con limpieza de estados y mejor manejo de errores
   - Añadidos logs temporales en desarrollo
   - Añadidos atributos `autoComplete` a inputs

2. **`src/app/cuenta/ClientPage.tsx`**
   - Añadidos atributos `autoComplete` a todos los inputs de formulario

3. **`src/app/api/account/orders/route.ts`**
   - Añadidos logs temporales en desarrollo para debugging

## Verificación

- ✅ `pnpm lint`: 0 errores
- ✅ `pnpm typecheck`: exitoso
- ✅ `pnpm build`: exitoso

## Pruebas sugeridas

1. **Funcionalidad de detalle:**
   - En `/cuenta/pedidos`, ingresar email con órdenes (ej. `a@a.com`)
   - Hacer clic en "Buscar pedidos" → debe mostrar lista
   - Hacer clic en "Ver detalle" → debe mostrar "Cargando detalle..." y luego el detalle completo
   - El detalle debe mostrar: ID, fecha, estado, email, productos con cantidades y precios, totales

2. **Autocomplete:**
   - Abrir DevTools → Panel Issues
   - Verificar que no aparezcan warnings de autocomplete en:
     - `/cuenta` (login/registro)
     - `/cuenta/pedidos` (búsqueda de pedidos)

3. **Logs de desarrollo:**
   - En desarrollo, verificar en consola que aparezcan logs cuando se hace clic en "Ver detalle"
   - Los logs deben mostrar request, response y order detail establecido

## Notas

- Los logs temporales solo se muestran en `NODE_ENV === "development"`
- No se modificó el flujo de checkout ni Stripe
- No se modificó la pantalla de login en `/cuenta` (solo se añadieron atributos `autoComplete`)
- Mejoras de accesibilidad y UX añadidas

