### PR TITLE
feat(account): smooth scroll and highlight for order detail

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { formatMXNFromCents } from "@/lib/utils/currency";
 import type {
   OrderSummary,
@@ -16,6 +16,7 @@ export default function PedidosPage() {
   const [orders, setOrders] = useState<OrderSummary[] | null>(null);
   const [orderDetail, setOrderDetail] = useState<OrderDetail | null>(null);
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+  const detailRef = useRef<HTMLDivElement | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -162,6 +163,21 @@ export default function PedidosPage() {
     return methodMap[method || ""] || method || "No especificado";
   };
 
+  // Scroll suave al panel de detalle cuando se carga
+  useEffect(() => {
+    if (!orderDetail || !detailRef.current) return;
+    
+    // Pequeño delay para asegurar que el DOM se actualizó
+    const timeoutId = setTimeout(() => {
+      detailRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }, 100);
+
+    return () => clearTimeout(timeoutId);
+  }, [orderDetail]);
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-4xl mx-auto px-4 py-12">
@@ -237,11 +253,17 @@ export default function PedidosPage() {
               </h2>
             </div>
             <div className="divide-y divide-gray-200">
-              {orders.map((order) => (
-                <div
-                  key={order.id}
-                  className="px-6 py-4 hover:bg-gray-50 transition-colors"
-                >
+              {orders.map((order) => {
+                const isSelected = selectedOrderId === order.id;
+                return (
+                  <div
+                    key={order.id}
+                    className={`px-6 py-4 transition-colors ${
+                      isSelected
+                        ? "bg-blue-50 border-l-4 border-blue-500"
+                        : "hover:bg-gray-50"
+                    }`}
+                  >
                   <div className="flex items-center justify-between">
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
@@ -278,7 +300,7 @@ export default function PedidosPage() {
                       <button
                         type="button"
                         onClick={() => handleViewDetail(order.id)}
-                        disabled={loadingDetail}
+                        disabled={loadingDetail && selectedOrderId === order.id}
                         className="mt-2 text-sm text-primary-600 hover:text-primary-700 underline disabled:opacity-50 disabled:cursor-not-allowed"
                         aria-label={`Ver detalle del pedido ${order.id.substring(0, 8)}`}
                       >
@@ -288,8 +310,9 @@ export default function PedidosPage() {
                       </button>
                     </div>
                   </div>
-                </div>
-              ))}
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}
@@ -304,7 +327,7 @@ export default function PedidosPage() {
 
         {/* Detalle de orden */}
         {orderDetail && (
-          <div className="bg-white rounded-lg shadow overflow-hidden mt-8">
+          <div ref={detailRef} className="bg-white rounded-lg shadow overflow-hidden mt-8">
             <div className="px-6 py-4 border-b border-gray-200">
               <h2 className="text-xl font-semibold">Detalle del Pedido</h2>
             </div>


### PR DESCRIPTION
## Objetivo

Pulir la UX de la página de "Mis pedidos" (`/cuenta/pedidos`) para mejorar la experiencia al ver el detalle de un pedido.

## Cambios realizados

### 1. Scroll suave al panel de detalle

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- ✅ Añadido `useRef` para el contenedor del panel de detalle (`detailRef`)
- ✅ Añadido `useEffect` que escucha cambios en `orderDetail`
- ✅ Cuando se carga el detalle, hace scroll suave hasta el panel
- ✅ Delay de 100ms para asegurar que el DOM se actualizó antes del scroll

**Implementación:**
```tsx
const detailRef = useRef<HTMLDivElement | null>(null);

useEffect(() => {
  if (!orderDetail || !detailRef.current) return;
  
  const timeoutId = setTimeout(() => {
    detailRef.current?.scrollIntoView({
      behavior: "smooth",
      block: "start",
    });
  }, 100);

  return () => clearTimeout(timeoutId);
}, [orderDetail]);
```

### 2. Resaltar fila del pedido seleccionado

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- ✅ Añadida lógica para detectar si una fila está seleccionada (`isSelected`)
- ✅ Clases condicionales usando Tailwind:
  - Fila seleccionada: `bg-blue-50 border-l-4 border-blue-500`
  - Fila normal: `hover:bg-gray-50`
- ✅ Transición suave con `transition-colors`

**Implementación:**
```tsx
const isSelected = selectedOrderId === order.id;

<div
  className={`px-6 py-4 transition-colors ${
    isSelected
      ? "bg-blue-50 border-l-4 border-blue-500"
      : "hover:bg-gray-50"
  }`}
>
```

### 3. Estados de carga coherentes

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- ✅ Botón "Ver detalle" solo se deshabilita para el pedido seleccionado
- ✅ Otros pedidos mantienen su botón habilitado mientras se carga el detalle de otro
- ✅ Indicador "Cargando detalle..." solo aparece en el pedido seleccionado

**Mejora:**
- Antes: `disabled={loadingDetail}` (deshabilitaba todos los botones)
- Ahora: `disabled={loadingDetail && selectedOrderId === order.id}` (solo el seleccionado)

## Flujo mejorado

1. Usuario busca pedidos por email → ve lista
2. Usuario hace clic en "Ver detalle" en un pedido:
   - La fila se resalta inmediatamente (fondo azul claro, borde izquierdo azul)
   - El botón muestra "Cargando detalle..." y se deshabilita
   - Se hace fetch del detalle
   - Cuando el detalle se carga:
     - Se muestra el panel de detalle
     - Se hace scroll suave hasta el panel
3. Usuario hace clic en "Ver detalle" en otro pedido:
   - El resaltado cambia a la nueva fila
   - El detalle anterior se reemplaza
   - Se hace scroll suave al nuevo detalle

## Archivos modificados

1. **`src/app/cuenta/pedidos/page.tsx`**
   - Añadidos imports: `useRef`, `useEffect`
   - Añadido `detailRef` para el panel de detalle
   - Añadido `useEffect` para scroll suave
   - Añadida lógica de resaltado condicional en filas
   - Mejorado estado de deshabilitado del botón

## Verificación

- ✅ `pnpm lint`: 0 errores
- ✅ `pnpm typecheck`: exitoso
- ✅ `pnpm build`: exitoso

## Pruebas sugeridas

1. **Scroll suave:**
   - Buscar pedidos con un email que tenga órdenes
   - Hacer clic en "Ver detalle" en un pedido
   - Verificar que la página hace scroll suave hasta el panel de detalle

2. **Resaltado de fila:**
   - Buscar pedidos
   - Hacer clic en "Ver detalle" en un pedido
   - Verificar que la fila se resalta con fondo azul claro y borde izquierdo azul
   - Hacer clic en "Ver detalle" en otro pedido
   - Verificar que el resaltado cambia a la nueva fila

3. **Estados de carga:**
   - Hacer clic en "Ver detalle"
   - Verificar que solo el botón del pedido seleccionado muestra "Cargando detalle..."
   - Verificar que los otros botones siguen habilitados

## Notas

- El scroll suave usa `behavior: "smooth"` y `block: "start"` para alinear el panel al inicio de la vista
- El delay de 100ms asegura que el DOM se actualizó antes del scroll
- El resaltado usa colores de Tailwind estándar (`blue-50`, `blue-500`)
- No se modificó el flujo de checkout ni Stripe
- No se modificó la pantalla de login en `/cuenta`
- Mejoras de UX y accesibilidad añadidas

