### PR TITLE
ci: disable SBOM artifact upload to fix workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -27,8 +27,7 @@ jobs:
           path: .
           format: cyclonedx-json
           output-file: sbom.cdx.json
-          artifact-name: sbom_pr
-          upload-artifact: true
+          upload-artifact: false
 
       # Sube el SBOM al Dependency Graph cuando es push a main
       - name: Upload to GitHub Dependency Graph


### PR DESCRIPTION
## Objetivo

Arreglar el workflow de SBOM desactivando completamente la subida de artifacts.

## Cambios

- Eliminado `artifact-name: sbom_pr` (causaba errores de validación)
- Cambiado `upload-artifact: true` a `upload-artifact: false`
- El archivo SBOM sigue generándose para el Dependency Graph en main

