### PR TITLE
fix(shop): correct stock state in related products

### DIFF
--- a/src/app/api/products/by-section/route.ts
+++ b/src/app/api/products/by-section/route.ts
@@ -13,6 +13,8 @@ type Response = {
     title: string;
     price_cents: number | null;
     image_url: string | null;
+    in_stock: boolean | null;
+    is_active: boolean | null;
   }>;
 };
 
@@ -39,6 +41,8 @@ export async function GET(req: Request) {
         title: p.title,
         price_cents: p.price_cents ?? null,
         image_url: p.image_url ?? null,
+        in_stock: p.in_stock ?? null,
+        is_active: p.is_active ?? null,
       }));
 
     return NextResponse.json<Response>({ items: filtered });

--- a/src/app/checkout/gracias/Recommended.client.tsx
+++ b/src/app/checkout/gracias/Recommended.client.tsx
@@ -36,11 +36,13 @@ function mapToFeaturedItem(
     section: p.section || section,
     title: p.title,
     description: p.description || null,
-    price_cents: p.price_cents || 0,
+    // No usar || 0, mantener null si no hay precio para que ProductCard lo maneje correctamente
+    price_cents: p.price_cents ?? null,
     currency: p.currency || "mxn",
     image_url: p.image_url || null,
+    // Mantener los valores reales de la API, no forzar valores por defecto
     in_stock: p.in_stock ?? null,
-    is_active: p.is_active ?? true,
+    is_active: p.is_active ?? null,
     position: 0,
   };
 }

--- a/src/lib/catalog/getProductsBySectionFromView.server.ts
+++ b/src/lib/catalog/getProductsBySectionFromView.server.ts
@@ -59,7 +59,8 @@ export async function getProductsBySectionFromView(
       currency: item.currency ?? "mxn",
       image_url: item.image_url ?? null,
       in_stock: item.in_stock ?? null,
-      is_active: item.active ?? true,
+      // La vista puede tener 'active' o 'is_active', mapear correctamente
+      is_active: item.is_active ?? item.active ?? null,
     })) as CatalogItem[];
   } catch (error) {
     console.warn("[getProductsBySectionFromView] Error:", error);


### PR DESCRIPTION
## Objetivo

Corregir la sección "También te puede interesar" en la PDP para que no marque todos los productos como "Agotado" y use correctamente los datos de precio y stock.

## Problema

La sección "También te puede interesar" mostraba todos los productos como "Agotado" porque:
1. La API `/api/products/by-section` no estaba devolviendo `in_stock` ni `is_active`
2. El mapeo en `Recommended.client.tsx` estaba usando valores por defecto incorrectos (`price_cents || 0`, `is_active ?? true`)

## Cambios realizados

### 1. API `/api/products/by-section`
- ✅ Añadidos campos `in_stock` e `is_active` al tipo de respuesta
- ✅ Actualizado el mapeo para incluir estos campos en la respuesta

### 2. Mapeo en `Recommended.client.tsx`
- ✅ Cambiado `price_cents: p.price_cents || 0` a `price_cents: p.price_cents ?? null`
- ✅ Cambiado `is_active: p.is_active ?? true` a `is_active: p.is_active ?? null`
- ✅ Mantiene los valores reales de la API en lugar de forzar valores por defecto

### 3. Helper `getProductsBySectionFromView.server.ts`
- ✅ Actualizado para mapear correctamente `is_active` desde la vista (soporta tanto `is_active` como `active`)

## Resultado

- Los productos con precio y stock disponible se muestran correctamente con botón "Agregar"
- Solo los productos realmente agotados se marcan como "Agotado"
- El CTA "Consultar por WhatsApp" se mantiene funcionando
- El diseño canónico de `ProductCard` se preserva

## Archivos modificados

1. `src/app/api/products/by-section/route.ts` - Añadidos campos `in_stock` e `is_active`
2. `src/app/checkout/gracias/Recommended.client.tsx` - Corregido mapeo de datos
3. `src/lib/catalog/getProductsBySectionFromView.server.ts` - Mejorado mapeo de `is_active`

