### PR TITLE
fix(shop): correct stock logic and add related products to PDP

### DIFF
--- a/src/app/catalogo/[section]/[slug]/PdpRelatedSection.tsx
+++ b/src/app/catalogo/[section]/[slug]/PdpRelatedSection.tsx
@@ -1,0 +1,58 @@
+import "server-only";
+import { getProductsBySectionFromView } from "@/lib/catalog/getProductsBySectionFromView.server";
+import ProductCard from "@/components/catalog/ProductCard";
+import type { ProductCardProps } from "@/components/catalog/ProductCard";
+
+type Props = {
+  section: string;
+  currentProductId: string;
+};
+
+/**
+ * Componente server-side que muestra productos relacionados en la PDP
+ * Usa la misma lógica y helpers que el resto del catálogo
+ */
+export default async function PdpRelatedSection({
+  section,
+  currentProductId,
+}: Props) {
+  // Obtener productos de la misma sección (máximo 8 para tener opciones después de filtrar)
+  const products = await getProductsBySectionFromView(section, 8, 0);
+
+  // Filtrar el producto actual y tomar los primeros 4
+  const relatedProducts = products
+    .filter((p) => p.id !== currentProductId)
+    .slice(0, 4);
+
+  // Si no hay productos relacionados, no renderizar nada
+  if (relatedProducts.length === 0) {
+    return null;
+  }
+
+  // Convertir CatalogItem a ProductCardProps
+  const productCards: ProductCardProps[] = relatedProducts.map((product) => ({
+    id: product.id,
+    section: product.section,
+    product_slug: product.product_slug,
+    title: product.title,
+    price_cents: product.price_cents,
+    image_url: product.image_url,
+    in_stock: product.in_stock,
+    is_active: product.is_active,
+    description: product.description,
+    priority: false,
+    sizes: "(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw",
+  }));
+
+  return (
+    <section className="mt-12 pt-8 border-t border-gray-200">
+      <h2 className="text-xl font-semibold mb-4">También te puede interesar</h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {productCards.map((product) => (
+          <ProductCard key={product.id} {...product} />
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -8,6 +8,7 @@ import ProductViewTracker from "@/components/ProductViewTracker.client";
 import { ROUTES } from "@/lib/routes";
 import Link from "next/link";
 import { Package, Truck, Shield } from "lucide-react";
+import PdpRelatedSection from "./PdpRelatedSection";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -252,6 +253,12 @@ export default async function ProductDetailPage({ params }: Props) {
               </div>
             </div>
           </div>
+
+          {/* Productos relacionados */}
+          <PdpRelatedSection
+            section={product.section}
+            currentProductId={product.id}
+          />
         </div>
       </div>
     );

--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -70,7 +70,9 @@ export default function ProductCard({
   const price = priceCents > 0 ? mxnFromCents(priceCents) : null;
 
   // Estado de disponibilidad
-  const soldOut = !in_stock || !is_active;
+  // soldOut solo es true si explícitamente in_stock === false o is_active === false
+  // null/undefined en in_stock no significa agotado, significa "no especificado" (disponible por defecto)
+  const soldOut = in_stock === false || is_active === false;
   const canPurchase = hasPurchasablePrice({
     price_cents,
     in_stock,

--- a/src/lib/catalog/model.ts
+++ b/src/lib/catalog/model.ts
@@ -35,6 +35,11 @@ export function normalizePrice(value?: number | string | null): number {
 
 /**
  * Verifica si un item tiene un precio comprable (price_cents > 0 y stock disponible)
+ * 
+ * Reglas:
+ * - Si in_stock es null/undefined, se considera disponible si is_active es true
+ * - Si in_stock es false, está agotado
+ * - Si is_active es false, no está disponible
  */
 export function hasPurchasablePrice(
   item:
@@ -42,8 +47,15 @@ export function hasPurchasablePrice(
     | { price_cents?: number | null; in_stock?: boolean | null; is_active?: boolean | null },
 ): boolean {
   const priceCents = normalizePrice(item.price_cents);
-  // Usar in_stock e is_active
-  const in_stock = item.in_stock ?? false;
-  const is_active = item.is_active ?? true;
-  return priceCents > 0 && in_stock && is_active;
+  if (priceCents <= 0) return false;
+  
+  // Si is_active es false, no está disponible
+  if (item.is_active === false) return false;
+  
+  // Si in_stock es false, está agotado
+  if (item.in_stock === false) return false;
+  
+  // Si in_stock es null/undefined pero is_active es true (o null), considerar disponible
+  // (null significa "no especificado", no "agotado")
+  return true;
 }


### PR DESCRIPTION
## Objetivo

1. Arreglar que en `/checkout/gracias` la sección "También te puede interesar" marque todo como "Agotado" aunque haya stock.
2. Añadir una sección "También te puede interesar" al final de cada PDP.

## Problema identificado

La lógica de stock estaba tratando `null` como `false`, marcando productos como agotados cuando `in_stock` era `null` o `undefined`. En el catálogo, `null` significa "no especificado" (disponible por defecto), no "agotado".

## Cambios realizados

### 1. Corrección de lógica de stock

**Archivo:** `src/lib/catalog/model.ts`

- ✅ Corregida función `hasPurchasablePrice`:
  - `null` en `in_stock` ahora se trata como "disponible" si `is_active` es `true` o `null`
  - Solo `in_stock === false` o `is_active === false` marcan como no disponible
  - `null` significa "no especificado", no "agotado"

**Archivo:** `src/components/catalog/ProductCard.tsx`

- ✅ Corregida lógica de `soldOut`:
  - Cambiado de `!in_stock || !is_active` a `in_stock === false || is_active === false`
  - `null`/`undefined` ya no se tratan como agotado

### 2. Sección "También te puede interesar" en PDP

**Archivo:** `src/app/catalogo/[section]/[slug]/PdpRelatedSection.tsx` (nuevo)

- ✅ Componente server-side que muestra productos relacionados
- ✅ Usa el mismo helper `getProductsBySectionFromView` que el resto del catálogo
- ✅ Filtra el producto actual y muestra máximo 4 productos
- ✅ Usa `ProductCard` canónico con el mismo shape de datos que `/tienda` y `/destacados`
- ✅ Si no hay productos relacionados, no renderiza nada

**Archivo:** `src/app/catalogo/[section]/[slug]/page.tsx`

- ✅ Integrado `PdpRelatedSection` al final de la página PDP
- ✅ Mantiene el mismo contenedor y spacing consistente

## Resultado

### En `/checkout/gracias`:
- Los productos con stock disponible se muestran correctamente con botón "Agregar"
- Solo los productos realmente agotados (`in_stock === false`) se marcan como "Agotado"
- `null` en `in_stock` se trata como disponible si el producto está activo

### En PDP (`/catalogo/[section]/[slug]`):
- Cada PDP muestra una sección "También te puede interesar" al final
- Muestra hasta 4 productos de la misma sección (excluyendo el producto actual)
- Usa la misma lógica de stock y precio que el resto del sitio
- El CTA "Consultar por WhatsApp" se mantiene funcionando

## Archivos modificados

1. `src/lib/catalog/model.ts` - Corregida lógica de `hasPurchasablePrice`
2. `src/components/catalog/ProductCard.tsx` - Corregida lógica de `soldOut`
3. `src/app/catalogo/[section]/[slug]/PdpRelatedSection.tsx` - Nuevo componente
4. `src/app/catalogo/[section]/[slug]/page.tsx` - Integrado componente de relacionados

## Verificación

- ✅ `pnpm lint`: 0 errores
- ✅ `pnpm typecheck`: exitoso
- ✅ `pnpm build`: exitoso
- ✅ No se modificó código de Supabase ni Stripe
- ✅ Se respeta el componente `ProductCard` canónico

