### PR TITLE
fix(account): addresses crud and checkout integration

### DIFF
--- a/src/lib/utils/names.ts
+++ b/src/lib/utils/names.ts
@@ -1,0 +1,49 @@
+/**
+ * Divide un nombre completo en nombre y apellidos
+ * @param fullName - Nombre completo (ej: "Juan Pérez García")
+ * @returns Objeto con firstName y lastName
+ */
+export function splitFullName(fullName: string): { firstName: string; lastName: string } {
+  const trimmed = fullName.trim();
+  if (!trimmed) {
+    return { firstName: "", lastName: "" };
+  }
+
+  const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
+
+  if (parts.length === 0) {
+    return { firstName: "", lastName: "" };
+  }
+
+  if (parts.length === 1) {
+    return { firstName: parts[0], lastName: "" };
+  }
+
+  // Primera palabra es el nombre, el resto son apellidos
+  return {
+    firstName: parts[0],
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+/**
+ * Construye un nombre completo a partir de nombre y apellidos
+ * @param firstName - Nombre
+ * @param lastName - Apellidos
+ * @returns Nombre completo normalizado (trim)
+ */
+export function buildFullName(firstName: string, lastName: string): string {
+  const first = firstName.trim();
+  const last = lastName.trim();
+
+  if (!first && !last) {
+    return "";
+  }
+
+  if (!last) {
+    return first;
+  }
+
+  return `${first} ${last}`.trim();
+}
+

--- a/src/lib/validation/email.ts
+++ b/src/lib/validation/email.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const emailSchema = z.string().email();
+
+/**
+ * Valida si un email es válido antes de hacer la llamada a la API
+ * @param value - Email a validar
+ * @returns true si el email es válido, false en caso contrario
+ */
+export function isValidEmail(value: string | undefined | null): boolean {
+  if (!value) return false;
+  const parsed = emailSchema.safeParse(value.trim());
+  return parsed.success;
+}
+


### PR DESCRIPTION
Fix issues with address management and checkout integration.

## Problems Fixed

### /cuenta/direcciones
- ✅ No more 422 errors while typing invalid emails (a, a@, a@a., etc.)
- ✅ Button 'Buscar' now works correctly
- ✅ Delete button now works and refreshes UI
- ✅ Set default button updates UI correctly with badges
- ✅ Enter key support to search addresses

### /checkout/datos
- ✅ Proper name/lastName split when loading saved addresses
- ✅ Correct full_name construction when saving new address from checkout
- ✅ Email validation and debounce still working (from PR #169)

## Changes

### New Shared Helpers
- src/lib/validation/email.ts: isValidEmail() using Zod
- src/lib/utils/names.ts: splitFullName() and uildFullName()

### DireccionesClient.tsx
- Removed automatic loading on email change (was causing 422 spam)
- Added email validation before API calls
- Button 'Buscar' validates email and loads addresses
- Enter key support in email input
- Optimistic updates for delete/setDefault operations
- Better error messages and empty states

### ClientPage.tsx (checkout)
- Uses splitFullName() when autocompleting from saved address
- Uses uildFullName() when saving new address
- Maintains existing email validation and debounce

## Testing

- ✅ pnpm lint: 0 errors
- ✅ pnpm typecheck: successful
- ✅ pnpm build: successful

## Acceptance Criteria

### /cuenta/direcciones
- ✅ No 422 errors while typing invalid emails
- ✅ Button 'Buscar' loads addresses for valid email
- ✅ Delete removes address and refreshes list
- ✅ Set default updates UI with badges correctly
- ✅ Empty state shows when no addresses found

### /checkout/datos
- ✅ Saved addresses autocomplete name and lastName correctly
- ✅ New addresses saved with correct full_name
- ✅ No email validation spam (maintains PR #169 behavior)