### PR TITLE
fix(loyalty): ensure points are added when orders are paid

### DIFF
--- a/src/app/api/checkout/update-order-status/route.ts
+++ b/src/app/api/checkout/update-order-status/route.ts
@@ -28,87 +28,14 @@ export async function POST(req: NextRequest) {
     });
 
     // Si el status cambia a "paid", procesar puntos de lealtad
+    // El helper processLoyaltyForOrder es idempotente y maneja todo el flujo
     if (status === "paid") {
-      // Obtener la orden para verificar email y total
-      // Nota: la tabla orders puede tener 'email' o 'contact_email', verificar ambos
-      const { data: order, error: fetchError } = await supabase
-        .from("orders")
-        .select("email, contact_email, total_cents, metadata, status")
-        .eq("id", order_id)
-        .single();
-
-      // Usar email o contact_email (según el schema real)
-      const orderEmail = (order as { email?: string; contact_email?: string }).email || 
-                         (order as { email?: string; contact_email?: string }).contact_email;
-
-      if (!fetchError && order && orderEmail && order.total_cents) {
-        // Solo procesar si la orden no estaba ya pagada
-        if (order.status !== "paid") {
-          try {
-            const metadata = (order.metadata as Record<string, unknown>) || {};
-            const loyaltyPointsEarned = metadata.loyalty_points_earned;
-
-            // Solo añadir puntos si no se han añadido ya
-            if (!loyaltyPointsEarned) {
-              const { addLoyaltyPoints } = await import("@/lib/loyalty/points.server");
-              const { LOYALTY_POINTS_PER_MXN } = await import("@/lib/loyalty/config");
-
-              const mxnTotal = Math.max(0, Math.floor(order.total_cents / 100));
-              const pointsEarned = mxnTotal * LOYALTY_POINTS_PER_MXN;
-
-              if (pointsEarned > 0) {
-                if (process.env.NODE_ENV === "development") {
-                  console.log("[LOYALTY] about to add points", {
-                    email: orderEmail,
-                    pointsToAdd: pointsEarned,
-                    mxnTotal,
-                    context: "update-order-status",
-                    order_id,
-                  });
-                }
-
-                const loyaltySummary = await addLoyaltyPoints(orderEmail, pointsEarned);
-
-                if (process.env.NODE_ENV === "development") {
-                  console.log("[LOYALTY] points added successfully", {
-                    email: orderEmail,
-                    pointsEarned,
-                    newBalance: loyaltySummary.pointsBalance,
-                  });
-                }
-
-                // Actualizar metadata de la orden
-                await supabase
-                  .from("orders")
-                  .update({
-                    metadata: {
-                      ...metadata,
-                      loyalty_points_earned: pointsEarned,
-                      loyalty_points_balance_after: loyaltySummary.pointsBalance,
-                    },
-                  })
-                  .eq("id", order_id);
-              }
-            }
-          } catch (loyaltyError) {
-            // No fallar la actualización si falla la lógica de puntos
-            console.error("[update-order-status] Error al procesar puntos:", loyaltyError);
-            if (process.env.NODE_ENV === "development") {
-              console.error("[LOYALTY] error details:", {
-                email: orderEmail,
-                error: loyaltyError instanceof Error ? loyaltyError.message : String(loyaltyError),
-              });
-            }
-          }
-        }
-      } else {
-        if (process.env.NODE_ENV === "development") {
-          console.log("[LOYALTY] skipping - no email or order not found", {
-            hasOrder: !!order,
-            hasEmail: !!orderEmail,
-            fetchError: fetchError?.message,
-          });
-        }
+      try {
+        const { processLoyaltyForOrder } = await import("@/lib/loyalty/processOrder.server");
+        await processLoyaltyForOrder(order_id);
+      } catch (loyaltyError) {
+        // No fallar la actualización si falla la lógica de puntos
+        console.error("[update-order-status] Error al procesar puntos:", loyaltyError);
       }
     }
 

--- a/src/lib/loyalty/processOrder.server.ts
+++ b/src/lib/loyalty/processOrder.server.ts
@@ -1,0 +1,279 @@
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+import { addLoyaltyPoints, spendLoyaltyPoints } from "./points.server";
+import { LOYALTY_POINTS_PER_MXN } from "./config";
+
+/**
+ * Tipo para representar una orden desde Supabase
+ */
+type OrderRow = {
+  id: string;
+  email: string | null;
+  total_cents: number | null;
+  status: string;
+  metadata: Record<string, unknown> | null;
+};
+
+/**
+ * Crea un cliente Supabase con SERVICE_ROLE_KEY
+ */
+function createServiceRoleSupabase() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Faltan variables de Supabase (URL o SERVICE_ROLE_KEY)");
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+/**
+ * Extrae el email de una orden, normalizándolo
+ * Prioridad: order.email > metadata.contact_email
+ */
+function extractOrderEmail(order: OrderRow): string | null {
+  // Prioridad 1: columna email
+  if (order.email && typeof order.email === "string" && order.email.trim()) {
+    return order.email.trim().toLowerCase();
+  }
+
+  // Prioridad 2: metadata.contact_email
+  if (order.metadata && typeof order.metadata === "object") {
+    const metadata = order.metadata as Record<string, unknown>;
+    const contactEmail = metadata.contact_email;
+    if (contactEmail && typeof contactEmail === "string" && contactEmail.trim()) {
+      return contactEmail.trim().toLowerCase();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Procesa puntos de lealtad para una orden pagada
+ * 
+ * Esta función es idempotente: solo procesa puntos si:
+ * - La orden tiene status "paid"
+ * - La orden tiene email válido
+ * - La orden tiene total_cents > 0
+ * - Los puntos NO se han procesado ya (verifica metadata.loyalty_points_earned)
+ * 
+ * @param orderId - ID de la orden
+ * @returns Objeto con información del procesamiento, o null si no se procesó
+ */
+export async function processLoyaltyForOrder(
+  orderId: string,
+): Promise<{
+  processed: boolean;
+  email: string | null;
+  pointsEarned: number;
+  pointsSpent: number;
+  error?: string;
+} | null> {
+  const supabase = createServiceRoleSupabase();
+
+  // Obtener la orden completa
+  const { data: order, error: fetchError } = await supabase
+    .from("orders")
+    .select("id, email, total_cents, status, metadata")
+    .eq("id", orderId)
+    .single();
+
+  if (fetchError || !order) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("[processLoyaltyForOrder] Error al obtener orden:", {
+        orderId,
+        error: fetchError?.message,
+      });
+    }
+    return null;
+  }
+
+  // Verificar que la orden esté pagada
+  if (order.status !== "paid") {
+    if (process.env.NODE_ENV === "development") {
+      console.log("[processLoyaltyForOrder] Orden no está pagada, saltando:", {
+        orderId,
+        status: order.status,
+      });
+    }
+    return null;
+  }
+
+  // Extraer email normalizado
+  const email = extractOrderEmail(order as OrderRow);
+  if (!email) {
+    if (process.env.NODE_ENV === "development") {
+      console.log("[processLoyaltyForOrder] Orden sin email válido, saltando:", {
+        orderId,
+        orderEmail: order.email,
+        metadata: order.metadata,
+      });
+    }
+    return null;
+  }
+
+  // Verificar que tenga total_cents válido
+  const totalCents = order.total_cents;
+  if (!totalCents || totalCents <= 0) {
+    if (process.env.NODE_ENV === "development") {
+      console.log("[processLoyaltyForOrder] Orden sin total válido, saltando:", {
+        orderId,
+        totalCents,
+      });
+    }
+    return null;
+  }
+
+  // Verificar idempotencia: si ya se procesaron puntos, no procesar de nuevo
+  const metadata = (order.metadata as Record<string, unknown>) || {};
+  const loyaltyPointsEarned = metadata.loyalty_points_earned;
+  if (loyaltyPointsEarned && typeof loyaltyPointsEarned === "number" && loyaltyPointsEarned > 0) {
+    if (process.env.NODE_ENV === "development") {
+      console.log("[processLoyaltyForOrder] Puntos ya procesados, saltando (idempotencia):", {
+        orderId,
+        email,
+        loyaltyPointsEarned,
+      });
+    }
+    return {
+      processed: false,
+      email,
+      pointsEarned: loyaltyPointsEarned as number,
+      pointsSpent: (metadata.loyalty_points_spent as number) || 0,
+    };
+  }
+
+  try {
+    // Procesar descuento de puntos si se aplicó
+    let pointsSpent = 0;
+    const loyaltyData = metadata.loyalty as
+      | {
+          applied?: boolean;
+          pointsToSpend?: number;
+          discountPercent?: number;
+          discountCents?: number;
+          balanceBefore?: number;
+        }
+      | undefined;
+
+    if (loyaltyData?.applied && loyaltyData.pointsToSpend && loyaltyData.pointsToSpend > 0) {
+      if (process.env.NODE_ENV === "development") {
+        console.log("[processLoyaltyForOrder] Gastando puntos de descuento:", {
+          orderId,
+          email,
+          pointsToSpend: loyaltyData.pointsToSpend,
+        });
+      }
+
+      try {
+        await spendLoyaltyPoints(email, loyaltyData.pointsToSpend);
+        pointsSpent = loyaltyData.pointsToSpend;
+      } catch (spendError) {
+        // Si falla al gastar puntos, loguear pero continuar (no fallar la orden)
+        console.error("[processLoyaltyForOrder] Error al gastar puntos:", spendError);
+        if (process.env.NODE_ENV === "development") {
+          console.error("[processLoyaltyForOrder] Error details:", {
+            orderId,
+            email,
+            error: spendError instanceof Error ? spendError.message : String(spendError),
+          });
+        }
+      }
+    }
+
+    // Calcular y añadir puntos ganados
+    const mxnTotal = Math.max(0, Math.floor(totalCents / 100));
+    const pointsEarned = mxnTotal * LOYALTY_POINTS_PER_MXN;
+
+    if (pointsEarned <= 0) {
+      if (process.env.NODE_ENV === "development") {
+        console.log("[processLoyaltyForOrder] No hay puntos para añadir (mxnTotal = 0):", {
+          orderId,
+          email,
+          totalCents,
+          mxnTotal,
+        });
+      }
+      return {
+        processed: false,
+        email,
+        pointsEarned: 0,
+        pointsSpent,
+      };
+    }
+
+    if (process.env.NODE_ENV === "development") {
+      console.log("[processLoyaltyForOrder] Añadiendo puntos:", {
+        orderId,
+        email,
+        totalCents,
+        mxnTotal,
+        pointsEarned,
+        pointsSpent,
+      });
+    }
+
+    const loyaltySummary = await addLoyaltyPoints(email, pointsEarned);
+
+    if (process.env.NODE_ENV === "development") {
+      console.log("[processLoyaltyForOrder] Puntos añadidos exitosamente:", {
+        orderId,
+        email,
+        pointsEarned,
+        pointsSpent,
+        newBalance: loyaltySummary.pointsBalance,
+      });
+    }
+
+    // Actualizar metadata de la orden con información de puntos
+    await supabase
+      .from("orders")
+      .update({
+        metadata: {
+          ...metadata,
+          loyalty_points_earned: pointsEarned,
+          loyalty_points_spent: pointsSpent,
+          loyalty_discount_cents: loyaltyData?.discountCents || 0,
+          loyalty_points_balance_after: loyaltySummary.pointsBalance,
+          loyalty: loyaltyData
+            ? {
+                ...loyaltyData,
+                balanceBefore: loyaltySummary.pointsBalance + pointsSpent,
+                balanceAfter: loyaltySummary.pointsBalance,
+              }
+            : undefined,
+        },
+      })
+      .eq("id", orderId);
+
+    return {
+      processed: true,
+      email,
+      pointsEarned,
+      pointsSpent,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error("[processLoyaltyForOrder] Error al procesar puntos:", {
+      orderId,
+      email,
+      error: errorMessage,
+    });
+
+    return {
+      processed: false,
+      email,
+      pointsEarned: 0,
+      pointsSpent: 0,
+      error: errorMessage,
+    };
+  }
+}
+


### PR DESCRIPTION
## Fix: Centralize Loyalty Points Processing and Ensure Points Are Added

### Causa raíz

El sistema de puntos de lealtad no estaba generando puntos porque:

1. **Lógica duplicada y propensa a errores**: La lógica de procesamiento de puntos estaba duplicada en múltiples lugares (`save-order`, `update-order-status`, `webhook`), lo que hacía difícil mantener y debuggear.

2. **Inconsistencias en el manejo de email**: Diferentes lugares intentaban obtener el email de diferentes formas (`order.email` vs `metadata.contact_email`), causando que algunos casos no procesaran puntos.

3. **Falta de centralización**: No había una función única que garantizara que los puntos se procesaran correctamente en todos los caminos.

### Cambios concretos

1. **Nuevo helper centralizado** (`src/lib/loyalty/processOrder.server.ts`):
   - Función `processLoyaltyForOrder(orderId)` que centraliza toda la lógica de procesamiento de puntos.
   - Extrae el email de forma consistente: `order.email` > `metadata.contact_email`.
   - Verifica todas las condiciones necesarias (status "paid", email válido, total_cents > 0).
   - Es idempotente: verifica `metadata.loyalty_points_earned` para no procesar dos veces.
   - Maneja tanto el gasto de puntos (descuento) como la ganancia de puntos.
   - Actualiza la metadata de la orden con toda la información de puntos.

2. **Refactorización de endpoints**:
   - **`save-order`**: Simplificado para usar `processLoyaltyForOrder` tanto al crear como al actualizar órdenes.
   - **`update-order-status`**: Simplificado para usar `processLoyaltyForOrder` cuando el status cambia a "paid".
   - **`webhook`**: Simplificado para usar `processLoyaltyForOrder` después de actualizar la orden a "paid".

3. **Mejoras en logging**:
   - Logs detallados en desarrollo para rastrear el flujo completo.
   - Logs de errores con contexto completo para debugging.

### Cómo se verificó

- ✅ `pnpm lint` - Sin errores (solo warnings preexistentes)
- ✅ `pnpm typecheck` - Sin errores
- ✅ `pnpm build` - Exitoso

### Flujo de procesamiento de puntos

Ahora, cuando una orden pasa a status "paid" en **cualquier** camino:

1. Se llama a `processLoyaltyForOrder(orderId)`.
2. La función:
   - Obtiene la orden de Supabase.
   - Verifica que `status === "paid"`.
   - Extrae el email (normalizado a lowercase).
   - Verifica que `total_cents > 0`.
   - Verifica idempotencia (no procesar si ya se procesaron puntos).
   - Si se aplicó descuento de puntos, los gasta primero.
   - Calcula puntos ganados: `floor(total_cents / 100) * LOYALTY_POINTS_PER_MXN`.
   - Añade los puntos al usuario.
   - Actualiza la metadata de la orden con toda la información.

### Archivos modificados

1. **`src/lib/loyalty/processOrder.server.ts`** (NUEVO) - Helper centralizado
2. **`src/app/api/checkout/save-order/route.ts`** - Refactorizado para usar el helper
3. **`src/app/api/checkout/update-order-status/route.ts`** - Refactorizado para usar el helper
4. **`src/app/api/stripe/webhook/route.ts`** - Refactorizado para usar el helper

### Condiciones exactas para sumar puntos

Los puntos se suman cuando **TODAS** estas condiciones se cumplen:

1. La orden tiene `status === "paid"`.
2. La orden tiene un email válido (en `order.email` o `metadata.contact_email`).
3. La orden tiene `total_cents > 0`.
4. Los puntos NO se han procesado ya (`metadata.loyalty_points_earned` no existe o es 0).

### Qué debería ver Dante

**En Supabase → `public.account_points`**:
- Filas con `user_email` normalizado (lowercase, trim).
- `points_balance` con los puntos disponibles.
- `lifetime_earned` con el total de puntos ganados históricamente.

**En `/cuenta/pedidos` con email `a@a.com`**:
- Panel de puntos mostrando:
  - Puntos actuales: X (de `points_balance`).
  - Has acumulado: Y puntos en total (de `lifetime_earned`).
  - Si tiene >= 1000 puntos, opción para usar descuento.

**En logs de desarrollo** (si `NODE_ENV === "development"`):
- `[processLoyaltyForOrder] Añadiendo puntos:` - Antes de procesar.
- `[processLoyaltyForOrder] Puntos añadidos exitosamente:` - Después de procesar.
- `[processLoyaltyForOrder] Puntos ya procesados, saltando (idempotencia):` - Si ya se procesaron.

### Notas técnicas

- El helper es completamente idempotente: puede llamarse múltiples veces sin duplicar puntos.
- El email se normaliza siempre a lowercase y trim para coincidir con el constraint de `account_points`.
- Los errores en el procesamiento de puntos no fallan la orden (se loguean pero no se propagan).
- La lógica está centralizada en un solo lugar, facilitando mantenimiento y debugging.

