### PR TITLE
feat(account): show shipping amount in orders list

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -379,7 +379,17 @@ export default function PedidosPage() {
                       </p>
                       {order.metadata?.shipping_method && (
                         <p className="text-sm text-gray-600 mt-1">
-                          {formatShippingMethod(order.metadata.shipping_method)}
+                          {(() => {
+                            const method = formatShippingMethod(order.metadata.shipping_method);
+                            const shippingCostCents = order.metadata.shipping_cost_cents;
+                            
+                            if (shippingCostCents !== undefined && shippingCostCents !== null && shippingCostCents > 0) {
+                              return `${method} · ${formatMXNFromCents(shippingCostCents)}`;
+                            }
+                            
+                            // Para "Recoger en tienda" con costo 0, solo mostrar el método
+                            return method;
+                          })()}
                         </p>
                       )}
                     </div>

--- a/src/lib/supabase/orders.server.ts
+++ b/src/lib/supabase/orders.server.ts
@@ -12,6 +12,7 @@ export type OrderSummary = {
   total_cents: number | null;
   metadata: {
     shipping_method?: string;
+    shipping_cost_cents?: number;
     coupon_code?: string;
     subtotal_cents?: number;
     discount_cents?: number;


### PR DESCRIPTION
## Show Shipping Amount in Orders List

### Cambios

Añade el precio del envío junto con el método de envío en la lista de pedidos en `/cuenta/pedidos`.

### Campo utilizado

- **`metadata.shipping_cost_cents`**: El costo de envío se almacena en centavos en el campo `shipping_cost_cents` dentro de `metadata` de la orden.

### Dónde se muestra

- En la lista de pedidos (`/cuenta/pedidos`), debajo del método de envío:
  - `Envío estándar · $20.00`
  - `Envío express · $30.00`
  - `Recoger en tienda` (sin precio si el costo es 0)

### Archivos modificados

1. **`src/lib/supabase/orders.server.ts`**:
   - Añadido `shipping_cost_cents?: number` al tipo `OrderSummary.metadata`

2. **`src/app/cuenta/pedidos/page.tsx`**:
   - Actualizado el render del método de envío para incluir el precio cuando está disponible
   - Usa `formatMXNFromCents` para formatear el precio consistentemente

### Verificación

- ✅ `pnpm lint` - Sin errores (solo warnings preexistentes)
- ✅ `pnpm typecheck` - Sin errores
- ✅ `pnpm build` - Exitoso

### Notas

- El precio solo se muestra si `shipping_cost_cents` está definido y es mayor a 0
- Para "Recoger en tienda" con costo 0, solo se muestra el método sin precio (más limpio)
- Mantiene el diseño consistente con el resto de la tarjeta

