### PR TITLE
feat(account): show loyalty points per order

### DIFF
--- a/pr_body_loyalty_breakdown.md
+++ b/pr_body_loyalty_breakdown.md
@@ -1,0 +1,84 @@
+## Show Loyalty Points Per Order
+
+### Resumen de cambios
+
+Muestra el desglose de puntos de lealtad por pedido en `/cuenta/pedidos`, tanto en la lista como en el detalle.
+
+### Campos utilizados
+
+Los campos se guardan en `orders.metadata` cuando la orden está en estado `paid`:
+
+- `metadata.loyalty_points_earned` → Puntos ganados en ese pedido (número entero)
+- `metadata.loyalty_points_spent` → Puntos gastados en el descuento (número entero, 0 si no aplica)
+
+Estos campos son guardados por el helper centralizado `processLoyaltyForOrder` que ya está integrado en:
+- `src/app/api/checkout/save-order/route.ts`
+- `src/app/api/checkout/update-order-status/route.ts`
+- `src/app/api/stripe/webhook/route.ts`
+
+### Cambios realizados
+
+#### 1. Tipos actualizados
+
+**Archivo:** `src/lib/supabase/orders.server.ts`
+
+- Añadidos `loyalty_points_earned`, `loyalty_points_spent`, y `loyalty_points_balance_after` al tipo `OrderSummary.metadata`
+- Estos campos se leen correctamente del JSONB de Supabase
+
+#### 2. Panel de detalle de pedido
+
+**Archivo:** `src/app/cuenta/pedidos/page.tsx`
+
+- Nueva sección "Puntos de lealtad" en el panel de detalle
+- Muestra:
+  - **Puntos ganados:** +XX (en verde)
+  - **Puntos usados:** -YY (en naranja, solo si se usó descuento)
+  - **Puntos netos:** ZZ (ganados - gastados)
+- Solo se muestra si:
+  - La orden está en estado `paid`
+  - Hay datos válidos de puntos (no null/undefined)
+
+#### 3. Resumen en lista de pedidos
+
+**Archivo:** `src/app/cuenta/pedidos/page.tsx`
+
+- Línea pequeña debajo del método de envío mostrando:
+  - `Puntos: +90` (si solo ganó puntos)
+  - `Puntos: +90 / -50` (si ganó y gastó puntos)
+- Solo se muestra si:
+  - La orden está en estado `paid`
+  - Hay datos válidos de puntos
+
+### Reglas de visualización
+
+- Solo mostrar puntos si la orden está `paid`
+- Si `loyalty_points_earned` y `loyalty_points_spent` vienen `null` o `undefined`, ocultar el bloque
+- Si viene `0`, no mostrar esa línea (solo mostrar si > 0)
+- Los puntos netos siempre se calculan y muestran si hay al menos un valor válido
+
+### Verificación técnica
+
+- ✅ `pnpm lint` - Sin errores (solo warnings preexistentes)
+- ✅ `pnpm typecheck` - Sin errores
+- ✅ `pnpm build` - Exitoso
+
+### Cómo probar
+
+1. **Hacer compras de prueba:**
+   - Compra sin usar puntos: verificar que se muestre "Puntos ganados: +XX"
+   - Compra usando puntos: verificar que se muestre "Puntos ganados: +XX", "Puntos usados: -1000", "Puntos netos: YY"
+
+2. **Verificar en `/cuenta/pedidos`:**
+   - En la lista: verificar que aparezca el resumen de puntos (ej: "Puntos: +90")
+   - En el detalle: verificar que aparezca la sección completa de puntos con desglose
+
+3. **Verificar casos edge:**
+   - Pedidos pendientes: no deben mostrar puntos
+   - Pedidos sin datos de puntos: no deben mostrar la sección
+
+### Notas técnicas
+
+- Los campos se guardan automáticamente por `processLoyaltyForOrder` cuando la orden pasa a `paid`
+- La idempotencia está garantizada por el helper (no duplica puntos si se reintenta)
+- El diseño mantiene consistencia con el resto de la UI (Tailwind, tipografía, espaciados)
+

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -390,6 +390,27 @@ export default function PedidosPage() {
                           })()}
                         </p>
                       )}
+                      {/* Resumen de puntos en la lista (solo si está paid y tiene info) */}
+                      {order.status === "paid" && (() => {
+                        const earned = order.metadata?.loyalty_points_earned;
+                        const spent = order.metadata?.loyalty_points_spent;
+                        const hasEarned = earned !== null && earned !== undefined && earned > 0;
+                        const hasSpent = spent !== null && spent !== undefined && spent > 0;
+                        
+                        if (!hasEarned && !hasSpent) return null;
+                        
+                        return (
+                          <p className="text-xs text-gray-500 mt-1">
+                            {hasEarned && hasSpent && earned && spent
+                              ? `Puntos: +${earned.toLocaleString()} / -${spent.toLocaleString()}`
+                              : hasEarned && earned
+                                ? `Puntos: +${earned.toLocaleString()}`
+                                : hasSpent && spent
+                                  ? `Puntos: -${spent.toLocaleString()}`
+                                  : null}
+                          </p>
+                        );
+                      })()}
                     </div>
                     <div className="text-right ml-4">
                       {order.total_cents !== null && (
@@ -559,6 +580,54 @@ export default function PedidosPage() {
                   </div>
                 </div>
               </div>
+
+              {/* Puntos de lealtad por pedido */}
+              {orderDetail.status === "paid" && (() => {
+                const earned = orderDetail.metadata?.loyalty_points_earned;
+                const spent = orderDetail.metadata?.loyalty_points_spent;
+                const hasEarned = earned !== null && earned !== undefined && earned > 0;
+                const hasSpent = spent !== null && spent !== undefined && spent > 0;
+                
+                if (!hasEarned && !hasSpent) return null;
+                
+                const netPoints = (earned || 0) - (spent || 0);
+                
+                return (
+                  <div className="mt-6 pt-4 border-t border-gray-200">
+                    <h3 className="text-sm font-semibold text-gray-700 mb-3">
+                      Puntos de lealtad
+                    </h3>
+                    <div className="flex justify-end">
+                      <div className="w-full md:w-64 space-y-2">
+                        {hasEarned && earned && (
+                          <div className="flex justify-between text-sm">
+                            <span className="text-gray-600">Puntos ganados:</span>
+                            <span className="text-green-600 font-medium">
+                              +{earned.toLocaleString()}
+                            </span>
+                          </div>
+                        )}
+                        {hasSpent && spent && (
+                          <div className="flex justify-between text-sm">
+                            <span className="text-gray-600">Puntos usados:</span>
+                            <span className="text-orange-600 font-medium">
+                              -{spent.toLocaleString()}
+                            </span>
+                          </div>
+                        )}
+                        {(hasEarned || hasSpent) && (
+                          <div className="flex justify-between text-sm font-semibold pt-2 border-t border-gray-200">
+                            <span className="text-gray-700">Puntos netos:</span>
+                            <span className="text-gray-900">
+                              {netPoints.toLocaleString()}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
             </div>
           </div>
         )}

--- a/src/lib/supabase/orders.server.ts
+++ b/src/lib/supabase/orders.server.ts
@@ -18,6 +18,9 @@ export type OrderSummary = {
     discount_cents?: number;
     contact_name?: string;
     contact_email?: string;
+    loyalty_points_earned?: number | null;
+    loyalty_points_spent?: number | null;
+    loyalty_points_balance_after?: number | null;
   } | null;
 };
 


### PR DESCRIPTION
## Show Loyalty Points Per Order

### Resumen de cambios

Muestra el desglose de puntos de lealtad por pedido en `/cuenta/pedidos`, tanto en la lista como en el detalle.

### Campos utilizados

Los campos se guardan en `orders.metadata` cuando la orden está en estado `paid`:

- `metadata.loyalty_points_earned` → Puntos ganados en ese pedido (número entero)
- `metadata.loyalty_points_spent` → Puntos gastados en el descuento (número entero, 0 si no aplica)

Estos campos son guardados por el helper centralizado `processLoyaltyForOrder` que ya está integrado en:
- `src/app/api/checkout/save-order/route.ts`
- `src/app/api/checkout/update-order-status/route.ts`
- `src/app/api/stripe/webhook/route.ts`

### Cambios realizados

#### 1. Tipos actualizados

**Archivo:** `src/lib/supabase/orders.server.ts`

- Añadidos `loyalty_points_earned`, `loyalty_points_spent`, y `loyalty_points_balance_after` al tipo `OrderSummary.metadata`
- Estos campos se leen correctamente del JSONB de Supabase

#### 2. Panel de detalle de pedido

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- Nueva sección "Puntos de lealtad" en el panel de detalle
- Muestra:
  - **Puntos ganados:** +XX (en verde)
  - **Puntos usados:** -YY (en naranja, solo si se usó descuento)
  - **Puntos netos:** ZZ (ganados - gastados)
- Solo se muestra si:
  - La orden está en estado `paid`
  - Hay datos válidos de puntos (no null/undefined)

#### 3. Resumen en lista de pedidos

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- Línea pequeña debajo del método de envío mostrando:
  - `Puntos: +90` (si solo ganó puntos)
  - `Puntos: +90 / -50` (si ganó y gastó puntos)
- Solo se muestra si:
  - La orden está en estado `paid`
  - Hay datos válidos de puntos

### Reglas de visualización

- Solo mostrar puntos si la orden está `paid`
- Si `loyalty_points_earned` y `loyalty_points_spent` vienen `null` o `undefined`, ocultar el bloque
- Si viene `0`, no mostrar esa línea (solo mostrar si > 0)
- Los puntos netos siempre se calculan y muestran si hay al menos un valor válido

### Verificación técnica

- ✅ `pnpm lint` - Sin errores (solo warnings preexistentes)
- ✅ `pnpm typecheck` - Sin errores
- ✅ `pnpm build` - Exitoso

### Cómo probar

1. **Hacer compras de prueba:**
   - Compra sin usar puntos: verificar que se muestre "Puntos ganados: +XX"
   - Compra usando puntos: verificar que se muestre "Puntos ganados: +XX", "Puntos usados: -1000", "Puntos netos: YY"

2. **Verificar en `/cuenta/pedidos`:**
   - En la lista: verificar que aparezca el resumen de puntos (ej: "Puntos: +90")
   - En el detalle: verificar que aparezca la sección completa de puntos con desglose

3. **Verificar casos edge:**
   - Pedidos pendientes: no deben mostrar puntos
   - Pedidos sin datos de puntos: no deben mostrar la sección

### Notas técnicas

- Los campos se guardan automáticamente por `processLoyaltyForOrder` cuando la orden pasa a `paid`
- La idempotencia está garantizada por el helper (no duplica puntos si se reintenta)
- El diseño mantiene consistencia con el resto de la UI (Tailwind, tipografía, espaciados)

