### PR TITLE
feat(ux): polish PDP and related products

### DIFF
--- a/src/app/catalogo/[section]/[slug]/PdpRelatedSection.tsx
+++ b/src/app/catalogo/[section]/[slug]/PdpRelatedSection.tsx
@@ -45,16 +45,20 @@ export default async function PdpRelatedSection({
   }));
 
   return (
-    <section className="mt-12 pt-8 border-t border-gray-200">
-      <h2 className="text-xl font-semibold mb-4">También te puede interesar</h2>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <section className="mt-12 pt-10 border-t border-gray-200 space-y-5">
+      <div>
+        <h2 className="text-2xl font-semibold text-gray-900">
+          También te puede interesar
+        </h2>
+        <p className="text-sm text-gray-600 mt-1">
+          Productos similares que suelen comprar otros clientes.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
         {productCards.map((product) => (
           <ProductCard key={product.id} {...product} />
         ))}
       </div>
-      <p className="text-sm text-gray-600 mt-4 text-center">
-        Si tienes dudas sobre cualquier producto, escríbenos por WhatsApp desde la burbuja en la esquina.
-      </p>
     </section>
   );
 }

--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -7,7 +7,6 @@ import ProductActions from "@/components/product/ProductActions.client";
 import ProductViewTracker from "@/components/ProductViewTracker.client";
 import { ROUTES } from "@/lib/routes";
 import Link from "next/link";
-import { Package, Truck, Shield } from "lucide-react";
 import PdpRelatedSection from "./PdpRelatedSection";
 
 export const dynamic = "force-dynamic";
@@ -191,7 +190,7 @@ export default async function ProductDetailPage({ params }: Props) {
                 </p>
               </div>
 
-              {/* Precio */}
+              {/* Precio y disponibilidad */}
               <div className="space-y-2">
                 <div className="text-4xl font-bold text-primary-600">
                   {price}
@@ -206,6 +205,11 @@ export default async function ProductDetailPage({ params }: Props) {
                   >
                     {!soldOut ? "En stock" : "Agotado"}
                   </span>
+                  {product.in_stock && (
+                    <span className="text-sm text-gray-600">
+                      Lista para envío inmediato
+                    </span>
+                  )}
                 </div>
               </div>
 
@@ -222,37 +226,24 @@ export default async function ProductDetailPage({ params }: Props) {
                   is_active: product.is_active,
                 }}
               />
-
-              {/* Características */}
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 pt-6 border-t">
-                <div className="flex items-center space-x-3">
-                  <Package className="h-5 w-5 text-primary-600" />
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">Envío</p>
-                    <p className="text-xs text-gray-600">
-                      Gratis en pedidos +$500
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-3">
-                  <Truck className="h-5 w-5 text-primary-600" />
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">Entrega</p>
-                    <p className="text-xs text-gray-600">1-3 días hábiles</p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-3">
-                  <Shield className="h-5 w-5 text-primary-600" />
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">
-                      Garantía
-                    </p>
-                    <p className="text-xs text-gray-600">30 días</p>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
+
+          {/* Descripción del producto */}
+          {product.description && (
+            <section className="mt-12 bg-white border border-gray-200 rounded-2xl shadow-sm p-6">
+              <h2 className="text-xl font-semibold text-gray-900 mb-3">
+                Descripción del producto
+              </h2>
+              <div className="prose prose-sm max-w-none text-gray-700">
+                {product.description.split("\n").map((paragraph, idx) => (
+                  <p key={idx} className="mb-3 last:mb-0">
+                    {paragraph.trim()}
+                  </p>
+                ))}
+              </div>
+            </section>
+          )}
 
           {/* Productos relacionados */}
           <PdpRelatedSection

--- a/src/app/checkout/gracias/Recommended.client.tsx
+++ b/src/app/checkout/gracias/Recommended.client.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import Link from "next/link";
 import { getWithTTL, KEYS } from "@/lib/utils/persist";
 import FeaturedGrid from "@/components/FeaturedGrid";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
@@ -143,56 +142,45 @@ export default function RecommendedClient() {
 
   if (loading) {
     return (
-      <section className="mt-12">
-        <h2 className="text-xl font-semibold mb-4">
-          También te puede interesar
-        </h2>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <section className="mt-12 space-y-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-gray-900">
+            También te puede interesar
+          </h2>
+          <p className="text-sm text-gray-600 mt-1">
+            Te dejamos algunos productos que combinan bien con tu compra.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
-              className="rounded-2xl border p-3 animate-pulse bg-gray-100 h-64"
+              className="rounded-2xl border border-gray-200 p-4 animate-pulse bg-gray-100 h-52"
             />
           ))}
         </div>
-        <p className="text-sm text-gray-600 mt-4 text-center">
-          Si tienes dudas sobre cualquier producto, escríbenos por WhatsApp desde la burbuja en la esquina.
+        <p className="text-sm text-gray-500 text-center">
+          Cargando recomendaciones…
         </p>
       </section>
     );
   }
 
   if (error || products.length === 0) {
-    return (
-      <section className="mt-12">
-        <h2 className="text-xl font-semibold mb-4">
-          También te puede interesar
-        </h2>
-        <div className="text-center py-8 text-gray-500">
-          <p className="mb-4">{error || "Sin recomendados disponibles"}</p>
-          <div className="flex gap-3 justify-center">
-            <Link href="/destacados" className="btn btn-primary">
-              Ver destacados
-            </Link>
-            <Link href="/buscar" className="btn">
-              Buscar productos
-            </Link>
-          </div>
-        </div>
-        <p className="text-sm text-gray-600 mt-4 text-center">
-          Si tienes dudas sobre cualquier producto, escríbenos por WhatsApp desde la burbuja en la esquina.
-        </p>
-      </section>
-    );
+    return null;
   }
 
   return (
-    <section className="mt-12">
-      <h2 className="text-xl font-semibold mb-4">También te puede interesar</h2>
+    <section className="mt-12 space-y-4">
+      <div>
+        <h2 className="text-2xl font-semibold text-gray-900">
+          También te puede interesar
+        </h2>
+        <p className="text-sm text-gray-600 mt-1">
+          Te dejamos algunos productos que combinan bien con tu compra.
+        </p>
+      </div>
       <FeaturedGrid items={products} hideSoldOutLabel={true} />
-      <p className="text-sm text-gray-600 mt-4 text-center">
-        Si tienes dudas sobre cualquier producto, escríbenos por WhatsApp desde la burbuja en la esquina.
-      </p>
     </section>
   );
 }

--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -6,6 +6,7 @@ import QuantityInput from "@/components/cart/QuantityInput";
 import { useCartStore } from "@/lib/store/cartStore";
 import { useCheckoutStore, selectIsCheckoutDataComplete } from "@/lib/store/checkoutStore";
 import { mxnFromCents, formatMXNFromCents } from "@/lib/utils/currency";
+import { MessageCircle, ShieldCheck, Truck } from "lucide-react";
 
 type Product = {
   id: string;
@@ -130,6 +131,8 @@ export default function ProductActions({ product }: Props) {
 
   const whatsappMessage = `Hola, me interesa: ${product.title} (${product.section}). Cantidad: ${qty}. Precio: ${formattedPrice}`;
   const whatsappUrl = `https://wa.me/${process.env.NEXT_PUBLIC_WHATSAPP_PHONE}?text=${encodeURIComponent(whatsappMessage)}`;
+  const isStripeTestEnv =
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY?.includes("test") ?? false;
 
   return (
     <div className="space-y-4">
@@ -188,6 +191,36 @@ export default function ProductActions({ product }: Props) {
             </svg>
             Consultar por WhatsApp
           </a>
+        </div>
+
+        <div className="rounded-lg border border-gray-200 bg-white/80 p-4 space-y-3 text-sm text-gray-700">
+          <div className="flex items-start gap-3">
+            <Truck className="w-5 h-5 text-primary-600 mt-0.5" />
+            <div>
+              <p className="font-medium text-gray-900">Envíos a todo México</p>
+              <p className="text-xs text-gray-600">
+                Calculamos la paquetería ideal según tu dirección o puedes recoger en tienda.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <MessageCircle className="w-5 h-5 text-primary-600 mt-0.5" />
+            <div>
+              <p className="font-medium text-gray-900">Atención personal</p>
+              <p className="text-xs text-gray-600">
+                Escríbenos por WhatsApp si necesitas asesoría antes de comprar.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="w-5 h-5 text-primary-600 mt-0.5" />
+            <div>
+              <p className="font-medium text-gray-900">Pagos seguros con Stripe</p>
+              <p className="text-xs text-gray-600">
+                Tarjeta, SPEI y OXXO{isStripeTestEnv ? " (modo prueba activo)" : ""}.
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## UX polish for PDP and related products

### Cambios principales

- **PDP (/catalogo/[section]/[slug])**
  - Reordenada la jerarquía visual: título → precio → estado → controles de compra → descripción.
  - Nuevo bloque de confianza bajo los botones (envíos a todo México, soporte por WhatsApp, pagos seguros con Stripe indicando modo prueba si aplica).
  - Sección de descripción con estilo consistente antes de los recomendados.
- **Sección "También te puede interesar" (PDP y checkout/gracias)**
  - Título/subtítulo unificados y explicación breve.
  - Layout responsivo limpio, máximo 4 productos y sin secciones vacías.
- **/checkout/gracias**
  - Recomendados con el mismo encabezado/subtítulo y skeleton ligero.
  - Estados vacíos ocultos para evitar bloques sin contenido.

### QA
- pnpm lint
- pnpm typecheck
- pnpm build

_No se tocaron configuraciones ni credenciales de Supabase/Stripe, ni la lógica del carrito, checkout o puntos._
