### PR TITLE
fix(ux): fix shop category links to catalog sections

### DIFF
--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import FeaturedGrid from "@/components/FeaturedGrid";
 import { getFeaturedItems } from "@/lib/catalog/getFeatured.server";
+import { ROUTES } from "@/lib/routes";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -20,18 +21,18 @@ export const metadata: Metadata = {
 };
 
 const categories = [
-  { title: "Consumibles y Profilaxis", href: "/tienda/consumibles" },
-  { title: "Equipos", href: "/tienda/equipos" },
-  { title: "Instrumental Clínico", href: "/tienda/instrumental-clinico" },
-  { title: "Instrumental Ortodoncia", href: "/tienda/instrumental-ortodoncia" },
+  { title: "Consumibles y Profilaxis", sectionSlug: "consumibles-y-profilaxis" },
+  { title: "Equipos", sectionSlug: "equipos" },
+  { title: "Instrumental Clínico", sectionSlug: "instrumental-clinico" },
+  { title: "Instrumental Ortodoncia", sectionSlug: "instrumental-ortodoncia" },
   {
     title: "Ortodoncia: Brackets y Tubos",
-    href: "/tienda/ortodoncia-brackets",
+    sectionSlug: "ortodoncia-brackets-y-tubos",
   },
-  { title: "Ortodoncia: Arcos y Resortes", href: "/tienda/ortodoncia-arcos" },
+  { title: "Ortodoncia: Arcos y Resortes", sectionSlug: "ortodoncia-arcos-y-resortes" },
   {
     title: "Ortodoncia: Accesorios y Retenedores",
-    href: "/tienda/ortodoncia-accesorios",
+    sectionSlug: "ortodoncia-accesorios-y-retenedores",
   },
 ];
 
@@ -82,8 +83,8 @@ export default async function TiendaPage() {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {categories.map((category) => (
               <Link
-                key={category.href}
-                href={category.href}
+                key={category.sectionSlug}
+                href={ROUTES.section(category.sectionSlug)}
                 className="bg-white rounded-lg shadow hover:shadow-lg transition-shadow p-8 text-center"
                 aria-label={`Ver productos de ${category.title}`}
               >


### PR DESCRIPTION
## Corrección de enlaces de categorías en /tienda

### Problema

Las categorías en `/tienda` estaban enlazando a rutas incorrectas (`/tienda/[section]`) que devolvían 404, cuando deberían enlazar a las rutas correctas del catálogo (`/catalogo/[section]`).

### Solución

**Cambios en `src/app/tienda/page.tsx`:**

1. **Importado `ROUTES` helper:**
   - Añadido `import { ROUTES } from "@/lib/routes"` para usar la función `ROUTES.section()`

2. **Actualizada estructura de categorías:**
   - Cambiado de `href: "/tienda/[section]"` a `sectionSlug: "[section-slug]"`
   - Mapeados los slugs de categorías a los slugs correctos que usa el catálogo:
     - `consumibles-y-profilaxis`
     - `equipos`
     - `instrumental-clinico`
     - `instrumental-ortodoncia`
     - `ortodoncia-brackets-y-tubos`
     - `ortodoncia-arcos-y-resortes`
     - `ortodoncia-accesorios-y-retenedores`

3. **Actualizados los enlaces:**
   - Cambiado `href={category.href}` a `href={ROUTES.section(category.sectionSlug)}`
   - Esto genera URLs como `/catalogo/[section-slug]` que son las rutas correctas del catálogo

### Archivo modificado

- `src/app/tienda/page.tsx` - Solo cambios en navegación de categorías

### QA técnico

✅ **`pnpm lint`**: Solo warnings preexistentes (0 errores nuevos)
✅ **`pnpm typecheck`**: Sin errores
✅ **`pnpm build`**: Exitoso

### Verificación

✅ Los enlaces ahora apuntan a `/catalogo/[section]` que es la ruta correcta
✅ Se usa `ROUTES.section()` para mantener consistencia con el resto del código
✅ No se tocó lógica de carrito, checkout, puntos ni configuración
✅ No se cambiaron textos de copy, solo navegación

