### PR TITLE
feat(ux): improve PDP trust block with icons

### DIFF
--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -6,6 +6,7 @@ import QuantityInput from "@/components/cart/QuantityInput";
 import { useCartStore } from "@/lib/store/cartStore";
 import { useCheckoutStore, selectIsCheckoutDataComplete } from "@/lib/store/checkoutStore";
 import { mxnFromCents, formatMXNFromCents } from "@/lib/utils/currency";
+import { Truck, MessageCircle, ShieldCheck } from "lucide-react";
 
 type Product = {
   id: string;
@@ -190,16 +191,33 @@ export default function ProductActions({ product }: Props) {
           </a>
         </div>
 
-        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 space-y-2">
-          <p className="text-sm text-gray-700 text-center">
-            Envíos a todo México. En pedidos desde $2,000 MXN en productos, el envío es gratis.
-          </p>
-          <p className="text-sm text-gray-700 text-center">
-            Tienda familiar con atención por WhatsApp antes y después de tu compra.
-          </p>
-          <p className="text-sm text-gray-700 text-center">
-            Pagos seguros con tarjeta en modo prueba para tus pruebas de compra.
-          </p>
+        <div className="mt-4 rounded-xl border border-gray-200 bg-white/60 p-4 sm:p-5">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex-shrink-0 rounded-full bg-blue-50 p-2 text-blue-600" aria-hidden="true">
+                <Truck className="h-4 w-4" />
+              </div>
+              <p className="text-xs sm:text-sm text-gray-700">
+                Envíos a todo México. En pedidos desde $2,000 MXN en productos, el envío es gratis.
+              </p>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex-shrink-0 rounded-full bg-green-50 p-2 text-green-600" aria-hidden="true">
+                <MessageCircle className="h-4 w-4" />
+              </div>
+              <p className="text-xs sm:text-sm text-gray-700">
+                Tienda familiar con atención por WhatsApp antes y después de tu compra.
+              </p>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex-shrink-0 rounded-full bg-emerald-50 p-2 text-emerald-600" aria-hidden="true">
+                <ShieldCheck className="h-4 w-4" />
+              </div>
+              <p className="text-xs sm:text-sm text-gray-700">
+                Pagos seguros con tarjeta en modo prueba para tus pruebas de compra.
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Mejora de UI del bloque de confianza en PDP

### Objetivo

Mejorar la presentación visual del bloque de confianza en el PDP (`ProductActions.client.tsx`), convirtiéndolo de un bloque de texto simple a una franja de beneficios con iconos, similar al estilo del home pero más compacta.

### Cambios

**Archivo:** `src/components/product/ProductActions.client.tsx`

#### Antes:
- Bloque de texto simple con 3 párrafos centrados
- Fondo gris claro (`bg-gray-50`)
- Texto centrado sin iconos

#### Después:
- Grid responsive con iconos:
  - `grid-cols-1` en mobile
  - `sm:grid-cols-3` en pantallas medianas/desktop
- Cada ítem tiene:
  - Icono dentro de un círculo con color suave
  - Texto a la derecha del icono
- Iconos de `lucide-react`:
  - **Truck** (azul) - Envíos
  - **MessageCircle** (verde) - WhatsApp
  - **ShieldCheck** (esmeralda) - Pagos
- Estilo minimalista con `bg-white/60` y bordes suaves

### Texto mantenido

- "Envíos a todo México. En pedidos desde $2,000 MXN en productos, el envío es gratis."
- "Tienda familiar con atención por WhatsApp antes y después de tu compra."
- "Pagos seguros con tarjeta en modo prueba para tus pruebas de compra."

### QA técnico

✅ **`pnpm lint`**: Solo warnings preexistentes (0 errores nuevos)
✅ **`pnpm typecheck`**: Sin errores
✅ **`pnpm build`**: Exitoso

### No se tocó

✅ Lógica de carrito, checkout, puntos, órdenes
✅ Tipos de TypeScript ni esquemas Zod
✅ Configuración de Supabase, Stripe o env variables
✅ Solo markup y estilos Tailwind

### Verificación visual

✅ Bloque no se monta con los botones (tiene `mt-4`)
✅ Mantiene buen espaciado arriba/abajo
✅ Se ve bien en desktop y móvil
✅ Grid responsive funciona correctamente

