### PR TITLE
feat(shipping): apply free shipping threshold from 2000 MXN

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -416,11 +416,16 @@ export default function PedidosPage() {
                               });
                             }
                             
-                            if (shippingCostCents !== undefined && shippingCostCents !== null && shippingCostCents > 0) {
-                              return `${method} · ${formatMXNFromCents(shippingCostCents)}`;
+                            if (shippingCostCents !== undefined && shippingCostCents !== null) {
+                              if (shippingCostCents > 0) {
+                                return `${method} · ${formatMXNFromCents(shippingCostCents)}`;
+                              } else {
+                                // Envío gratis (subtotal >= $2,000 MXN)
+                                return `${method} · $0.00 (envío gratis)`;
+                              }
                             }
                             
-                            // Para "Recoger en tienda" con costo 0, solo mostrar el método
+                            // Si no hay información de costo, solo mostrar el método
                             return method;
                           })()}
                         </p>

--- a/src/lib/shipping/freeShipping.ts
+++ b/src/lib/shipping/freeShipping.ts
@@ -1,0 +1,29 @@
+/**
+ * Configuración de envío gratis
+ * Envío gratis cuando el subtotal de productos es >= 2,000 MXN
+ */
+
+export const FREE_SHIPPING_THRESHOLD_MXN = 2000; // Umbral para envío gratis en MXN
+
+/**
+ * Aplica la regla de envío gratis si el subtotal es >= umbral
+ * @param productsSubtotalCents Subtotal de productos en centavos
+ * @param shippingCostCents Costo de envío calculado en centavos
+ * @returns Costo de envío final (0 si aplica envío gratis, sino el costo original)
+ */
+export function applyFreeShippingIfEligible({
+  productsSubtotalCents,
+  shippingCostCents,
+}: {
+  productsSubtotalCents: number;
+  shippingCostCents: number;
+}): number {
+  const thresholdCents = FREE_SHIPPING_THRESHOLD_MXN * 100;
+  
+  if (productsSubtotalCents >= thresholdCents) {
+    return 0;
+  }
+  
+  return shippingCostCents;
+}
+


### PR DESCRIPTION
## Implementación de envío gratis desde $2,000 MXN

### Objetivo

Implementar una regla global de envío gratis cuando el subtotal de productos es >= $2,000 MXN, sin romper el flujo actual de checkout.

### Cambios

#### 1. Nuevo helper de envío gratis

**Archivo:** `src/lib/shipping/freeShipping.ts`

- Constante `FREE_SHIPPING_THRESHOLD_MXN = 2000`
- Función `applyFreeShippingIfEligible()` que aplica la regla:
  - Si `productsSubtotalCents >= 2000 * 100` → retorna `0`
  - Si no → retorna `shippingCostCents` original

#### 2. Aplicación en frontend (checkout/pago)

**Archivo:** `src/app/checkout/pago/PagoClient.tsx`

- Importado `applyFreeShippingIfEligible`
- Calculado `productsSubtotalCents` usando `getSelectedSubtotalCents(checkoutItems)`
- Aplicada regla en `useMemo` para `shippingCost`:
  - Calcula `rawShippingCents` desde `rawShippingCost`
  - Aplica `applyFreeShippingIfEligible()` para obtener `finalShippingCents`
  - Convierte de vuelta a MXN para cálculos
- Actualizada visualización en resumen de precios:
  - Si `shippingCost > 0`: muestra precio normal
  - Si `shippingCost === 0`: muestra "$0.00 (envío gratis)"
- El valor `shippingCostCents` enviado al backend ya incluye la regla aplicada

#### 3. Visualización en /cuenta/pedidos

**Archivo:** `src/app/cuenta/pedidos/page.tsx`

- Actualizada lógica de visualización de envío:
  - Si `shippingCostCents > 0`: muestra `${method} · ${precio}`
  - Si `shippingCostCents === 0`: muestra `${method} · $0.00 (envío gratis)`
  - Si no hay información: solo muestra el método

#### 4. Backend (sin cambios)

**Archivos:** `src/app/api/checkout/create-order/route.ts`, `src/app/api/checkout/save-order/route.ts`

- No se modificaron estos archivos
- El backend recibe `shippingCostCents` del frontend (ya con regla aplicada)
- Se guarda en `metadata.shipping_cost_cents` como antes
- `save-order` preserva el valor existente si no viene en el payload

### Regla implementada

```
Si subtotal de productos >= $2,000 MXN
  → shipping_cost_cents = 0 (envío gratis)
Si subtotal < $2,000 MXN
  → shipping_cost_cents = costo normal calculado
```

### QA técnico

✅ **`pnpm lint`**: Solo warnings preexistentes (0 errores nuevos)
✅ **`pnpm typecheck`**: Sin errores
✅ **`pnpm build`**: Exitoso

### Pruebas manuales sugeridas

1. **Pedido < $2,000 MXN:**
   - Verificar que se muestra costo de envío normal
   - Confirmar que `shipping_cost_cents > 0` en la orden

2. **Pedido >= $2,000 MXN:**
   - Verificar que se muestra "$0.00 (envío gratis)" en checkout
   - Confirmar que `shipping_cost_cents === 0` en la orden
   - Verificar visualización correcta en `/cuenta/pedidos`

### No se tocó

✅ Lógica de puntos de lealtad
✅ Lógica de stock
✅ Flujos de Stripe (solo se usa el costo para mostrar info y guardar en metadata)
✅ Firmas de funciones públicas

