### PR TITLE
feat(ux): add global WhatsApp floating button

### DIFF
--- a/src/components/WhatsappBubble.tsx
+++ b/src/components/WhatsappBubble.tsx
@@ -1,33 +1,50 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { SITE, waLink } from "@/lib/site";
+import { getWhatsAppUrl } from "@/lib/whatsapp/config";
 import FAB from "@/components/FAB";
+import { MessageCircle } from "lucide-react";
 
 export default function WhatsappBubble() {
   const pathname = usePathname();
-  const msg = `Hola, vengo desde ${SITE.name}. Página: ${pathname}. ¿Me ayudas?`;
-  const href = waLink(msg);
-
+  
+  // Ocultar en checkout y cuenta
+  if (pathname?.startsWith("/checkout") || pathname?.startsWith("/cuenta")) {
+    return null;
+  }
+  
+  const whatsappUrl = getWhatsAppUrl();
+  
+  // No renderizar si no hay teléfono configurado
+  if (!whatsappUrl) {
+    return null;
+  }
+  
+  // Offset para no encimarse con el carrito
+  // CartBubble usa offset={88} cuando está vacío (carrito vacío)
+  // CartSticky está en bottom-6 right-6 (24px desde abajo) cuando hay items
+  // En mobile: el carrito sticky está en bottom-0 (barra inferior), así que WhatsApp puede estar arriba
+  // En desktop: CartSticky está en bottom-6 (24px), así que WhatsApp debe estar más arriba
+  // Usamos offset={88} para estar al mismo nivel que CartBubble cuando está vacío
+  // Si hay items, CartSticky está en bottom-6, así que WhatsApp (offset 88 = 88px) queda más arriba
   return (
-    <FAB offset={16}>
+    <FAB offset={88}>
       <a
-        href={href}
+        href={whatsappUrl}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="Chatear por WhatsApp"
-        className="h-14 w-14 rounded-full bg-green-500 hover:bg-green-600 text-white shadow-xl flex items-center justify-center transition-all hover:scale-110"
+        aria-label="Abrir chat de WhatsApp de Depósito Dental Noriega"
+        title="Abrir WhatsApp"
+        className="h-14 w-14 rounded-full bg-emerald-500 hover:bg-emerald-600 text-white shadow-lg flex items-center justify-center transition-all hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            window.open(whatsappUrl, "_blank", "noopener,noreferrer");
+          }
+        }}
       >
-        <svg
-          viewBox="0 0 32 32"
-          width="26"
-          height="26"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path d="M19.1 17.6c-.3-.2-1.8-.9-2.1-1-.3-.1-.5-.2-.7.2s-.8 1-1 1.2c-.2.2-.4.3-.7.1s-1.4-.5-2.6-1.6c-1-.9-1.6-1.9-1.8-2.2-.2-.3 0-.5.1-.6.1-.1.3-.3.4-.5.1-.2.2-.3.2-.5.1-.2 0-.4 0-.5s-.7-1.7-1-2.3c-.3-.6-.5-.5-.7-.5h-.6c-.2 0-.5.1-.8.4s-1 1-1 2.4 1 2.8 1.2 3c.2.2 2 3.1 4.9 4.3.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.7-.7 1.9-1.3.2-.7.2-1.2.2-1.3 0-.2-.2-.3-.4-.4z" />
-          <path d="M26.7 5.3C23.9 2.4 20.1.9 16.1.9 8.4.9 2.1 7.2 2.1 14.9c0 2.3.6 4.6 1.8 6.6L2 31l9.6-2.5c1.9 1 4 1.5 6.2 1.5h.1c7.7 0 14-6.3 14-14 0-3.8-1.5-7.3-4.2-10.7zm-10.6 21.5c-2 0-4-.5-5.7-1.5l-.4-.3-4.2 1.1 1.1-4.1-.3-.4c-1.2-1.9-1.8-4.1-1.8-6.4 0-6.6 5.4-12 12-12 3.2 0 6.2 1.2 8.5 3.5s3.5 5.3 3.5 8.5c0 6.6-5.4 12-12 12z" />
-        </svg>
+        <MessageCircle className="h-6 w-6" aria-hidden="true" />
       </a>
     </FAB>
   );

--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import QuantityInput from "@/components/cart/QuantityInput";
 import { useCartStore } from "@/lib/store/cartStore";
 import { useCheckoutStore, selectIsCheckoutDataComplete } from "@/lib/store/checkoutStore";
 import { mxnFromCents, formatMXNFromCents } from "@/lib/utils/currency";
 import { Truck, MessageCircle, ShieldCheck } from "lucide-react";
+import { getWhatsAppProductUrl } from "@/lib/whatsapp/config";
 
 type Product = {
   id: string;
@@ -129,8 +130,18 @@ export default function ProductActions({ product }: Props) {
     }
   }
 
-  const whatsappMessage = `Hola, me interesa: ${product.title} (${product.section}). Cantidad: ${qty}. Precio: ${formattedPrice}`;
-  const whatsappUrl = `https://wa.me/${process.env.NEXT_PUBLIC_WHATSAPP_PHONE}?text=${encodeURIComponent(whatsappMessage)}`;
+  // Usar helper centralizado de WhatsApp
+  const [whatsappUrl, setWhatsappUrl] = useState<string | null>(null);
+  
+  useEffect(() => {
+    const url = getWhatsAppProductUrl(
+      product.title,
+      product.section,
+      qty,
+      formattedPrice,
+    );
+    setWhatsappUrl(url);
+  }, [product.title, product.section, qty, formattedPrice]);
 
   return (
     <div className="space-y-4">
@@ -178,17 +189,26 @@ export default function ProductActions({ product }: Props) {
             Comprar ahora
           </button>
 
-          <a
-            href={whatsappUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="w-full bg-green-500 text-white px-6 py-3 rounded-md hover:bg-green-600 transition-colors font-semibold flex items-center justify-center gap-2"
-          >
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893A11.821 11.821 0 0020.885 3.488" />
-            </svg>
-            Consultar por WhatsApp
-          </a>
+          {whatsappUrl ? (
+            <a
+              href={whatsappUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full bg-green-500 text-white px-6 py-3 rounded-md hover:bg-green-600 transition-colors font-semibold flex items-center justify-center gap-2"
+            >
+              <MessageCircle className="w-5 h-5" />
+              Consultar por WhatsApp
+            </a>
+          ) : (
+            <button
+              disabled
+              className="w-full bg-gray-400 text-white px-6 py-3 rounded-md cursor-not-allowed font-semibold flex items-center justify-center gap-2"
+              title="WhatsApp no configurado"
+            >
+              <MessageCircle className="w-5 h-5" />
+              Consultar por WhatsApp
+            </button>
+          )}
         </div>
 
         <div className="mt-4 rounded-xl border border-gray-200 bg-white/60 p-4 sm:p-5">

--- a/src/lib/whatsapp/config.ts
+++ b/src/lib/whatsapp/config.ts
@@ -1,0 +1,80 @@
+/**
+ * Configuración centralizada de WhatsApp
+ * Reutiliza helpers existentes de src/lib/site.ts
+ */
+
+import { SITE, waLink } from "@/lib/site";
+
+/**
+ * Obtiene el número de WhatsApp desde la configuración
+ * @returns Número de WhatsApp o null si no está configurado
+ */
+export function getWhatsAppPhone(): string | null {
+  // Reutilizar SITE.waPhone que ya lee NEXT_PUBLIC_WA_PHONE
+  // Si no está definido, retornar null
+  const phone = SITE.waPhone;
+  if (!phone || phone.trim() === "") {
+    return null;
+  }
+  return phone;
+}
+
+/**
+ * Mensaje por defecto para WhatsApp
+ * @returns Mensaje base para iniciar conversación
+ */
+export function getWhatsAppDefaultMessage(): string {
+  return "Hola, me interesa hacer un pedido en Depósito Dental Noriega.";
+}
+
+/**
+ * Genera URL de WhatsApp con mensaje personalizado
+ * @param message Mensaje personalizado (opcional, usa mensaje por defecto si no se proporciona)
+ * @returns URL de WhatsApp o null si el teléfono no está configurado
+ */
+export function getWhatsAppUrl(message?: string): string | null {
+  const phone = getWhatsAppPhone();
+  if (!phone) {
+    return null;
+  }
+  
+  const finalMessage = message || getWhatsAppDefaultMessage();
+  return waLink(finalMessage);
+}
+
+/**
+ * Genera URL de WhatsApp para consulta de producto específico
+ * @param productTitle Título del producto
+ * @param section Sección del producto
+ * @param quantity Cantidad (opcional)
+ * @param price Precio formateado (opcional)
+ * @returns URL de WhatsApp o null si el teléfono no está configurado
+ */
+export function getWhatsAppProductUrl(
+  productTitle: string,
+  section: string,
+  quantity?: number,
+  price?: string,
+): string | null {
+  const phone = getWhatsAppPhone();
+  if (!phone) {
+    return null;
+  }
+  
+  const parts = [
+    `Hola, me interesa: ${productTitle}`,
+    `(${section})`,
+  ];
+  
+  if (quantity) {
+    parts.push(`Cantidad: ${quantity}`);
+  }
+  
+  if (price) {
+    parts.push(`Precio: ${price}`);
+  }
+  
+  const message = parts.join(". ");
+  return waLink(message);
+}
+


### PR DESCRIPTION
## Botón flotante global de WhatsApp

### Objetivo

Implementar un botón flotante de WhatsApp global en todo el sitio, reutilizando configuración centralizada y manteniendo el diseño limpio sin competir con el carrito flotante.

### Cambios

#### 1. Helper centralizado de WhatsApp

**Archivo:** `src/lib/whatsapp/config.ts` (nuevo)

- **`getWhatsAppPhone()`**: Obtiene el número desde `NEXT_PUBLIC_WHATSAPP_PHONE` (reutiliza `SITE.waPhone` de `src/lib/site.ts`)
- **`getWhatsAppDefaultMessage()`**: Mensaje base: "Hola, me interesa hacer un pedido en Depósito Dental Noriega."
- **`getWhatsAppUrl(message?)`**: Genera URL de WhatsApp con mensaje personalizado o por defecto
- **`getWhatsAppProductUrl(productTitle, section, quantity?, price?)`**: Genera URL para consulta de producto específico

#### 2. Actualización de WhatsappBubble

**Archivo:** `src/components/WhatsappBubble.tsx`

**Cambios:**
- **Ocultación condicional**: Se oculta en `/checkout/*` y `/cuenta/*` usando `usePathname()`
- **Helper centralizado**: Usa `getWhatsAppUrl()` del helper
- **No renderiza si no hay teléfono**: Retorna `null` si `getWhatsAppPhone()` es `null`
- **Icono actualizado**: Usa `MessageCircle` de `lucide-react` en lugar de SVG inline
- **Accesibilidad mejorada**:
  - `aria-label="Abrir chat de WhatsApp de Depósito Dental Noriega"`
  - `title="Abrir WhatsApp"`
  - `tabIndex={0}` y `onKeyDown` para soporte de teclado (Enter/Space)
- **Posicionamiento**: `offset={88}` para no encimarse con el carrito
  - `CartBubble` (carrito vacío) usa `offset={88}`
  - `CartSticky` (con items) está en `bottom-6 right-6` (24px desde abajo)
  - WhatsApp queda al mismo nivel que `CartBubble` cuando está vacío, y más arriba cuando hay items

#### 3. Actualización de ProductActions (PDP)

**Archivo:** `src/components/product/ProductActions.client.tsx`

**Cambios:**
- **Helper centralizado**: Usa `getWhatsAppProductUrl()` en lugar de construir URL manualmente
- **Manejo de estado**: Usa `useState` y `useEffect` para calcular URL cuando cambian `qty` o `formattedPrice`
- **Fallback**: Si WhatsApp no está configurado, muestra botón deshabilitado con mensaje amigable
- **Icono consistente**: Usa `MessageCircle` de `lucide-react` en lugar de SVG inline

### Comportamiento final

#### Si `NEXT_PUBLIC_WHATSAPP_PHONE` está definido:
- ✅ Botón flotante visible en: home, tienda, destacados, catálogo, PDP, buscar
- ✅ Botón flotante **oculto** en: `/checkout/*`, `/cuenta/*`
- ✅ Botón "Consultar por WhatsApp" en PDP funciona correctamente
- ✅ Ambos usan el mismo número y helper centralizado

#### Si `NEXT_PUBLIC_WHATSAPP_PHONE` NO está definido:
- ✅ Botón flotante no se renderiza (retorna `null`)
- ✅ Botón en PDP se muestra deshabilitado con mensaje "WhatsApp no configurado"
- ✅ No hay errores en consola

### Posicionamiento

- **Mobile**: 
  - `CartSticky` está en `bottom-0` (barra inferior completa)
  - `WhatsappBubble` está en `offset={88}` (88px desde abajo), no se encima
- **Desktop**:
  - `CartSticky` está en `bottom-6 right-6` (24px desde abajo, 24px desde derecha)
  - `WhatsappBubble` está en `offset={88}` (88px desde abajo), queda más arriba que el carrito
  - `CartBubble` (carrito vacío) también usa `offset={88}`, WhatsApp queda al mismo nivel

### QA técnico

✅ **`pnpm lint`**: Solo warnings preexistentes (0 errores nuevos)
✅ **`pnpm typecheck`**: Sin errores
✅ **`pnpm build`**: Exitoso

### Archivos modificados

- `src/lib/whatsapp/config.ts` (nuevo)
- `src/components/WhatsappBubble.tsx`
- `src/components/product/ProductActions.client.tsx`

### No se tocó

✅ Lógica de carrito, checkout, puntos, órdenes
✅ Configuración de Supabase, Stripe
✅ Otros componentes de WhatsApp existentes

