### PR TITLE
feat(catalog): add pagination to catalog and search

### DIFF
--- a/src/components/catalog/Pagination.tsx
+++ b/src/components/catalog/Pagination.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import React from "react";
+
+type PaginationProps = {
+  page: number;
+  hasNextPage: boolean;
+  basePath: string;
+  extraQuery?: Record<string, string>;
+};
+
+/**
+ * Componente reutilizable de paginación
+ * Muestra botones "Anterior" y "Siguiente" con navegación basada en URL
+ */
+export default function Pagination({
+  page,
+  hasNextPage,
+  basePath,
+  extraQuery = {},
+}: PaginationProps) {
+  // Construir query string con parámetros adicionales (ej: q para búsqueda)
+  const buildQueryString = (targetPage: number): string => {
+    const params = new URLSearchParams();
+    params.set("page", targetPage.toString());
+    
+    // Agregar parámetros adicionales (ej: q para búsqueda)
+    Object.entries(extraQuery).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+      }
+    });
+    
+    return params.toString();
+  };
+
+  const prevPage = page > 1 ? page - 1 : null;
+  const nextPage = hasNextPage ? page + 1 : null;
+
+  // No mostrar paginación si solo hay una página
+  if (page === 1 && !hasNextPage) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Paginación de productos"
+      className="flex flex-wrap justify-center items-center gap-3 pt-6 border-t border-gray-200 mt-8"
+    >
+      {prevPage ? (
+        <Link
+          href={`${basePath}?${buildQueryString(prevPage)}`}
+          className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+          aria-label="Ir a la página anterior"
+        >
+          ← Anterior
+        </Link>
+      ) : (
+        <span
+          className="px-4 py-2 border border-gray-200 text-gray-400 rounded-lg cursor-not-allowed bg-gray-50"
+          aria-disabled="true"
+        >
+          ← Anterior
+        </span>
+      )}
+
+      <span className="px-4 py-2 text-gray-600 text-sm">Página {page}</span>
+
+      {nextPage ? (
+        <Link
+          href={`${basePath}?${buildQueryString(nextPage)}`}
+          className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+          aria-label="Ir a la página siguiente"
+        >
+          Siguiente →
+        </Link>
+      ) : (
+        <span
+          className="px-4 py-2 border border-gray-200 text-gray-400 rounded-lg cursor-not-allowed bg-gray-50"
+          aria-disabled="true"
+        >
+          Siguiente →
+        </span>
+      )}
+    </nav>
+  );
+}
+

--- a/src/lib/catalog/config.ts
+++ b/src/lib/catalog/config.ts
@@ -1,0 +1,39 @@
+/**
+ * Configuración del catálogo
+ * Constantes compartidas para paginación y límites
+ */
+
+export const CATALOG_PAGE_SIZE = 24; // Productos por página
+
+/**
+ * Calcula el offset para paginación basado en el número de página (1-based)
+ * @param page Número de página (1-based)
+ * @param pageSize Tamaño de página
+ * @returns Offset para usar en .range() de Supabase
+ */
+export function calculateOffset(page: number, pageSize: number = CATALOG_PAGE_SIZE): number {
+  return (page - 1) * pageSize;
+}
+
+/**
+ * Parsea y valida el número de página desde searchParams
+ * @param pageParam Valor del query param 'page' (string o undefined)
+ * @returns Número de página válido (mínimo 1)
+ */
+export function parsePage(pageParam: string | undefined): number {
+  if (!pageParam) return 1;
+  const parsed = parseInt(pageParam, 10);
+  if (isNaN(parsed) || parsed < 1) return 1;
+  return parsed;
+}
+
+/**
+ * Determina si hay una página siguiente basado en la cantidad de items retornados
+ * @param itemsCount Cantidad de items en la página actual
+ * @param pageSize Tamaño de página
+ * @returns true si hay más páginas disponibles
+ */
+export function hasNextPage(itemsCount: number, pageSize: number = CATALOG_PAGE_SIZE): boolean {
+  return itemsCount === pageSize;
+}
+

--- a/src/lib/catalog/getBySection.server.ts
+++ b/src/lib/catalog/getBySection.server.ts
@@ -2,18 +2,41 @@ import "server-only";
 import { unstable_noStore as noStore } from "next/cache";
 import { createClient } from "@/lib/supabase/public";
 import { mapDbToCatalogItem } from "./mapDbToProduct";
+import { CATALOG_PAGE_SIZE, calculateOffset } from "./config";
 
-export async function getBySection(section: string) {
+export type GetBySectionResult = {
+  items: ReturnType<typeof mapDbToCatalogItem>[];
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+};
+
+export async function getBySection(
+  section: string,
+  page: number = 1,
+): Promise<GetBySectionResult> {
   noStore();
   const sb = createClient();
+
+  const pageSize = CATALOG_PAGE_SIZE;
+  const offset = calculateOffset(page, pageSize);
 
   const { data, error } = await sb
     .from("api_catalog_with_images")
     .select("*")
     .eq("section", section)
     .order("created_at", { ascending: false })
-    .limit(200);
+    .range(offset, offset + pageSize - 1);
 
   if (error) throw error;
-  return (data ?? []).map(mapDbToCatalogItem);
+  
+  const items = (data ?? []).map(mapDbToCatalogItem);
+  const hasNextPage = items.length === pageSize;
+
+  return {
+    items,
+    page,
+    pageSize,
+    hasNextPage,
+  };
 }

--- a/src/test/section.empty.test.tsx
+++ b/src/test/section.empty.test.tsx
@@ -25,6 +25,7 @@ describe("CatalogoSectionPage empty state", () => {
 
     const Page = await CatalogoSectionPage({
       params: { section: "test-section" },
+      searchParams: {},
     });
 
     // Verificar que la función retorna un elemento React válido
@@ -39,6 +40,7 @@ describe("CatalogoSectionPage empty state", () => {
 
     const Page = await CatalogoSectionPage({
       params: { section: "" },
+      searchParams: {},
     });
 
     expect(Page).toBeTruthy();


### PR DESCRIPTION
Este PR implementa paginación real en el catálogo y en la búsqueda, usando Supabase con `.range` y un componente reutilizable de UI.

### Cambios principales

- Nueva constante compartida `CATALOG_PAGE_SIZE = 24` en `src/lib/catalog/config.ts`.
- Nueva utilidad de paginación: helpers para calcular `page`, `offset` y `hasNextPage`.
- Nuevo componente `src/components/catalog/Pagination.tsx`:
  - Botones Anterior / Siguiente
  - Estados deshabilitados cuando no hay más páginas
  - Accesible (`aria-label`, focus states)

### Integraciones

- `/catalogo/[section]`:
  - Lee `searchParams.page`
  - Pide productos paginados desde Supabase con `.range`
  - Renderiza `Pagination` al final del grid

- `/buscar`:
  - Usa `CATALOG_PAGE_SIZE` como tamaño de página
  - Mantiene el query param `q` al cambiar de página
  - Renderiza `Pagination` debajo de los resultados

- `/api/products/search`:
  - Implementada paginación server-side con `.range`
  - Devuelve `{ items, page, pageSize, hasNextPage }` para el frontend

### Tests

- Actualizados:
  - `section.no404.test.tsx`
  - `section.empty.test.tsx`
- Ajustados para pasar `searchParams` y contemplar la nueva paginación.

### No se tocó

- Lógica de carrito
- Checkout y Stripe
- Sistema de puntos de lealtad
- Configuración de Supabase o env vars

### QA técnico

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

