### PR TITLE
feat(catalog): add sort options to catalog and search

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,24 +1,38 @@
-Este PR agrega una página informativa "Cómo comprar" y enlaces de navegación en el header y footer.
+Este PR implementa ordenamiento en el catálogo y búsqueda, preservando la paginación existente.
 
-### Cambios principales
+### Opciones de ordenamiento
 
-- **Nueva página `/como-comprar`:**
-  - Guía completa sobre cómo comprar en Depósito Dental Noriega
-  - Secciones: Quiénes somos, Cómo comprar, Envíos y envío gratis, Atención por WhatsApp, Puntos de lealtad, Pagos, Contacto
-  - Usa constantes existentes (`FREE_SHIPPING_THRESHOLD_MXN`, `LOYALTY_*`) para información precisa
-  - Incluye botones de contacto por WhatsApp usando helpers existentes
-  - Metadata SEO optimizada
+- **`relevance`** (por defecto): Orden por fecha de creación (más recientes primero)
+- **`price_asc`**: Precio de menor a mayor (columna `price_cents`)
+- **`price_desc`**: Precio de mayor a menor (columna `price_cents`)
+- **`name_asc`**: Nombre alfabético A-Z (columna `title`)
 
-- **Enlaces de navegación:**
-  - Agregado "Cómo comprar" en el header principal (después de "Buscar")
-  - Agregado "Cómo comprar" en la sección "Información" del footer
+### Rutas afectadas
+
+- `/catalogo/[section]`: Agregado `<select>` de ordenamiento arriba del grid
+- `/buscar`: Agregado `<select>` de ordenamiento junto a los resultados
+
+### Preservación de parámetros
+
+- Al cambiar de página, se preserva `sort` en la URL
+- En `/buscar`, se preservan `q`, `page` y `sort` simultáneamente
+- Al cambiar el orden, `page` se resetea a `1` automáticamente
+
+### Archivos modificados
+
+- `src/lib/catalog/config.ts`: Agregado tipo `CatalogSortOption` y helper `normalizeSortParam`
+- `src/lib/catalog/getBySection.server.ts`: Acepta `sort` y aplica `.order()` según opción
+- `src/app/api/products/search/route.ts`: Lee `sort` de query params y aplica ordenamiento
+- `src/components/catalog/SortSelect.client.tsx`: Nuevo componente client para UI de ordenamiento
+- `src/app/catalogo/[section]/page.tsx`: Integra `SortSelect` y pasa `sort` a `getBySection`
+- `src/app/buscar/page.tsx`: Integra `SortSelect` y pasa `sort` a API
+- `src/components/catalog/Pagination.tsx`: Ya soportaba `extraQuery`, ahora recibe `sort`
 
 ### No se tocó
 
-- Supabase (ninguna tabla, query o configuración)
-- Stripe (ninguna configuración ni lógica de pagos)
-- Lógica de negocio (carrito, checkout, puntos, envíos)
-- Solo contenido estático y navegación
+- Supabase Dashboard (solo queries con `.order()` en código)
+- Lógica de puntos, checkout, Stripe
+- Paginación existente (solo se preserva `sort` en URLs)
 
 ### QA técnico
 

--- a/src/app/api/products/search/route.ts
+++ b/src/app/api/products/search/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { unstable_noStore as noStore } from "next/cache";
 import { createClient } from "@/lib/supabase/public";
 import { mapDbToCatalogItem } from "@/lib/catalog/mapDbToProduct";
-import { CATALOG_PAGE_SIZE, calculateOffset, hasNextPage as calculateHasNextPage } from "@/lib/catalog/config";
+import { CATALOG_PAGE_SIZE, calculateOffset, hasNextPage as calculateHasNextPage, normalizeSortParam } from "@/lib/catalog/config";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -29,6 +29,7 @@ export async function GET(req: Request) {
   const qRaw = url.searchParams.get("q") || "";
   const q = qRaw.trim().toLowerCase();
   const page = Math.max(1, parseInt(url.searchParams.get("page") || "1", 10));
+  const sort = normalizeSortParam(url.searchParams.get("sort"));
   const perPage = CATALOG_PAGE_SIZE;
 
   if (!q) {
@@ -43,14 +44,32 @@ export async function GET(req: Request) {
     // Buscar en api_catalog_with_images con ilike sobre title, product_slug y section
     // Usar un OR en una sola cadena .or() para Supabase
     // Aplicar paginación directamente en Supabase con .range()
-    const { data, error, count } = await sb
+    let query = sb
       .from("api_catalog_with_images")
       .select("*", { count: "exact" })
       .or(`title.ilike.%${q}%,product_slug.ilike.%${q}%,section.ilike.%${q}%`)
       .eq("is_active", true)
-      .eq("in_stock", true)
-      .order("created_at", { ascending: false })
-      .range(offset, offset + perPage - 1);
+      .eq("in_stock", true);
+
+    // Aplicar ordenamiento según la opción seleccionada
+    switch (sort) {
+      case "price_asc":
+        query = query.order("price_cents", { ascending: true });
+        break;
+      case "price_desc":
+        query = query.order("price_cents", { ascending: false });
+        break;
+      case "name_asc":
+        query = query.order("title", { ascending: true });
+        break;
+      case "relevance":
+      default:
+        // Orden por defecto (más recientes primero)
+        query = query.order("created_at", { ascending: false });
+        break;
+    }
+
+    const { data, error, count } = await query.range(offset, offset + perPage - 1);
 
     if (error) {
       console.error("[search] Supabase error:", error);

--- a/src/components/catalog/SortSelect.client.tsx
+++ b/src/components/catalog/SortSelect.client.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { type CatalogSortOption } from "@/lib/catalog/config";
+
+type SortSelectProps = {
+  currentSort: CatalogSortOption;
+  basePath: string;
+  preserveParams?: Record<string, string>;
+};
+
+/**
+ * Componente client para seleccionar ordenamiento
+ * Navega a la URL con el sort seleccionado, reseteando page a 1
+ */
+export default function SortSelect({
+  currentSort,
+  basePath,
+  preserveParams = {},
+}: SortSelectProps) {
+  const router = useRouter();
+
+  const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newSort = e.target.value as CatalogSortOption;
+    const params = new URLSearchParams();
+
+    // Preservar parámetros adicionales (ej: q para búsqueda)
+    Object.entries(preserveParams).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+      }
+    });
+
+    // Agregar sort
+    if (newSort !== "relevance") {
+      params.set("sort", newSort);
+    }
+
+    // Resetear page a 1 cuando cambia el orden
+    params.set("page", "1");
+
+    router.push(`${basePath}?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="sort-select" className="text-sm text-gray-700">
+        Ordenar por:
+      </label>
+      <select
+        id="sort-select"
+        value={currentSort}
+        onChange={handleSortChange}
+        className="text-sm border border-gray-300 rounded-md px-3 py-2 bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        aria-label="Seleccionar ordenamiento"
+      >
+        <option value="relevance">Relevancia</option>
+        <option value="price_asc">Precio: menor a mayor</option>
+        <option value="price_desc">Precio: mayor a menor</option>
+        <option value="name_asc">Nombre: A-Z</option>
+      </select>
+    </div>
+  );
+}
+

--- a/src/lib/catalog/config.ts
+++ b/src/lib/catalog/config.ts
@@ -37,3 +37,32 @@ export function hasNextPage(itemsCount: number, pageSize: number = CATALOG_PAGE_
   return itemsCount === pageSize;
 }
 
+/**
+ * Opciones de ordenamiento disponibles para el catálogo
+ */
+export type CatalogSortOption = "relevance" | "price_asc" | "price_desc" | "name_asc";
+
+/**
+ * Normaliza el parámetro de ordenamiento desde la URL
+ * @param sortParam Valor del query param 'sort' (string, null o undefined)
+ * @returns Opción de ordenamiento válida, usando 'relevance' como fallback
+ */
+export function normalizeSortParam(
+  sortParam: string | null | undefined,
+): CatalogSortOption {
+  if (!sortParam) return "relevance";
+  
+  const validOptions: CatalogSortOption[] = [
+    "relevance",
+    "price_asc",
+    "price_desc",
+    "name_asc",
+  ];
+  
+  if (validOptions.includes(sortParam as CatalogSortOption)) {
+    return sortParam as CatalogSortOption;
+  }
+  
+  return "relevance";
+}
+

--- a/src/lib/catalog/getBySection.server.ts
+++ b/src/lib/catalog/getBySection.server.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { unstable_noStore as noStore } from "next/cache";
 import { createClient } from "@/lib/supabase/public";
 import { mapDbToCatalogItem } from "./mapDbToProduct";
-import { CATALOG_PAGE_SIZE, calculateOffset } from "./config";
+import { CATALOG_PAGE_SIZE, calculateOffset, type CatalogSortOption } from "./config";
 
 export type GetBySectionResult = {
   items: ReturnType<typeof mapDbToCatalogItem>[];
@@ -14,6 +14,7 @@ export type GetBySectionResult = {
 export async function getBySection(
   section: string,
   page: number = 1,
+  sort: CatalogSortOption = "relevance",
 ): Promise<GetBySectionResult> {
   noStore();
   const sb = createClient();
@@ -21,12 +22,30 @@ export async function getBySection(
   const pageSize = CATALOG_PAGE_SIZE;
   const offset = calculateOffset(page, pageSize);
 
-  const { data, error } = await sb
+  let query = sb
     .from("api_catalog_with_images")
     .select("*")
-    .eq("section", section)
-    .order("created_at", { ascending: false })
-    .range(offset, offset + pageSize - 1);
+    .eq("section", section);
+
+  // Aplicar ordenamiento según la opción seleccionada
+  switch (sort) {
+    case "price_asc":
+      query = query.order("price_cents", { ascending: true });
+      break;
+    case "price_desc":
+      query = query.order("price_cents", { ascending: false });
+      break;
+    case "name_asc":
+      query = query.order("title", { ascending: true });
+      break;
+    case "relevance":
+    default:
+      // Orden por defecto (más recientes primero)
+      query = query.order("created_at", { ascending: false });
+      break;
+  }
+
+  const { data, error } = await query.range(offset, offset + pageSize - 1);
 
   if (error) throw error;
   


### PR DESCRIPTION
Este PR implementa ordenamiento en el catálogo y búsqueda, preservando la paginación existente.

### Opciones de ordenamiento

- **`relevance`** (por defecto): Orden por fecha de creación (más recientes primero)
- **`price_asc`**: Precio de menor a mayor (columna `price_cents`)
- **`price_desc`**: Precio de mayor a menor (columna `price_cents`)
- **`name_asc`**: Nombre alfabético A-Z (columna `title`)

### Rutas afectadas

- `/catalogo/[section]`: Agregado `<select>` de ordenamiento arriba del grid
- `/buscar`: Agregado `<select>` de ordenamiento junto a los resultados

### Preservación de parámetros

- Al cambiar de página, se preserva `sort` en la URL
- En `/buscar`, se preservan `q`, `page` y `sort` simultáneamente
- Al cambiar el orden, `page` se resetea a `1` automáticamente

### Archivos modificados

- `src/lib/catalog/config.ts`: Agregado tipo `CatalogSortOption` y helper `normalizeSortParam`
- `src/lib/catalog/getBySection.server.ts`: Acepta `sort` y aplica `.order()` según opción
- `src/app/api/products/search/route.ts`: Lee `sort` de query params y aplica ordenamiento
- `src/components/catalog/SortSelect.client.tsx`: Nuevo componente client para UI de ordenamiento
- `src/app/catalogo/[section]/page.tsx`: Integra `SortSelect` y pasa `sort` a `getBySection`
- `src/app/buscar/page.tsx`: Integra `SortSelect` y pasa `sort` a API
- `src/components/catalog/Pagination.tsx`: Ya soportaba `extraQuery`, ahora recibe `sort`

### No se tocó

- Supabase Dashboard (solo queries con `.order()` en código)
- Lógica de puntos, checkout, Stripe
- Paginación existente (solo se preserva `sort` en URLs)

### QA técnico

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅

