### PR TITLE
feat(catalog): show active filters and clear button

### DIFF
--- a/src/components/catalog/FiltersSelect.client.tsx
+++ b/src/components/catalog/FiltersSelect.client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { type PriceRangeKey } from "@/lib/catalog/config";
+import { useRouter, useSearchParams } from "next/navigation";
+import { type PriceRangeKey, getPriceRangeLabel } from "@/lib/catalog/config";
 
 type FiltersSelectProps = {
   inStockOnly: boolean;
@@ -13,6 +13,7 @@ type FiltersSelectProps = {
 /**
  * Componente client para filtros de catálogo
  * Maneja checkbox "solo en stock" y select de rango de precio
+ * Muestra chips de filtros activos y botón para limpiarlos
  * Navega a la URL con los filtros seleccionados, reseteando page a 1
  */
 export default function FiltersSelect({
@@ -22,6 +23,9 @@ export default function FiltersSelect({
   preserveParams = {},
 }: FiltersSelectProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const hasActiveFilters = inStockOnly || priceRange !== "all";
 
   const buildUrl = (newInStock: boolean, newPriceRange: PriceRangeKey) => {
     const params = new URLSearchParams();
@@ -58,38 +62,92 @@ export default function FiltersSelect({
     router.push(buildUrl(inStockOnly, newPriceRange));
   };
 
-  return (
-    <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
-      {/* Checkbox "Solo productos en stock" */}
-      <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
-        <input
-          type="checkbox"
-          checked={inStockOnly}
-          onChange={handleInStockChange}
-          className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500 focus:ring-2"
-          aria-label="Solo productos en stock"
-        />
-        <span>Solo productos en stock</span>
-      </label>
+  const handleClearFilters = () => {
+    const params = new URLSearchParams();
 
-      {/* Select de rango de precio */}
-      <div className="flex items-center gap-2">
-        <label htmlFor="price-range-select" className="text-sm text-gray-700">
-          Rango de precio:
+    // Preservar parámetros que NO son filtros (ej: q, sort)
+    Object.entries(preserveParams).forEach(([key, value]) => {
+      if (value && key !== "inStock" && key !== "priceRange") {
+        params.set(key, value);
+      }
+    });
+
+    // Preservar sort desde searchParams si existe y no está en preserveParams
+    if (searchParams) {
+      const sort = searchParams.get("sort");
+      if (sort && sort !== "relevance" && !preserveParams.sort) {
+        params.set("sort", sort);
+      }
+    }
+
+    // Forzar page a 1
+    params.set("page", "1");
+
+    // No agregar inStock ni priceRange (filtros eliminados)
+
+    router.push(`${basePath}?${params.toString()}`);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Controles de filtros */}
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+        {/* Checkbox "Solo productos en stock" */}
+        <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={inStockOnly}
+            onChange={handleInStockChange}
+            className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500 focus:ring-2"
+            aria-label="Solo productos en stock"
+          />
+          <span>Solo productos en stock</span>
         </label>
-        <select
-          id="price-range-select"
-          value={priceRange}
-          onChange={handlePriceRangeChange}
-          className="text-sm border border-gray-300 rounded-md px-3 py-2 bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          aria-label="Seleccionar rango de precio"
-        >
-          <option value="all">Todos los precios</option>
-          <option value="lt_500">Menos de $500</option>
-          <option value="500_1000">$500 a $1,000</option>
-          <option value="gt_1000">Más de $1,000</option>
-        </select>
+
+        {/* Select de rango de precio */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="price-range-select" className="text-sm text-gray-700">
+            Rango de precio:
+          </label>
+          <select
+            id="price-range-select"
+            value={priceRange}
+            onChange={handlePriceRangeChange}
+            className="text-sm border border-gray-300 rounded-md px-3 py-2 bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            aria-label="Seleccionar rango de precio"
+          >
+            <option value="all">Todos los precios</option>
+            <option value="lt_500">Menos de $500</option>
+            <option value="500_1000">$500 a $1,000</option>
+            <option value="gt_1000">Más de $1,000</option>
+          </select>
+        </div>
       </div>
+
+      {/* Chips de filtros activos y botón limpiar */}
+      {hasActiveFilters && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs text-gray-500">Filtros activos:</span>
+          {inStockOnly && (
+            <span className="inline-flex items-center rounded-full border border-gray-300 px-2 py-0.5 text-xs text-gray-700 bg-gray-50">
+              En stock
+            </span>
+          )}
+          {priceRange !== "all" && (
+            <span className="inline-flex items-center rounded-full border border-gray-300 px-2 py-0.5 text-xs text-gray-700 bg-gray-50">
+              {getPriceRangeLabel(priceRange)}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleClearFilters}
+            className="ml-2 text-xs text-blue-600 hover:text-blue-700 underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded"
+            aria-label="Limpiar todos los filtros"
+          >
+            Limpiar filtros
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/catalog/config.ts
+++ b/src/lib/catalog/config.ts
@@ -112,3 +112,22 @@ export function getPriceRangeBounds(priceRange: PriceRangeKey): {
   }
 }
 
+/**
+ * Obtiene el label de texto para un rango de precio
+ * @param key Clave del rango de precio
+ * @returns Label legible para mostrar en UI
+ */
+export function getPriceRangeLabel(key: PriceRangeKey): string {
+  switch (key) {
+    case "lt_500":
+      return "Menos de $500";
+    case "500_1000":
+      return "$500 a $1,000";
+    case "gt_1000":
+      return "Más de $1,000";
+    case "all":
+    default:
+      return "Todos los precios";
+  }
+}
+


### PR DESCRIPTION
Este PR mejora la UX de los filtros en catálogo y búsqueda, agregando chips visuales para filtros activos y un botón para limpiarlos.

### Mejoras implementadas

1. **Chips de filtros activos:**
   - Muestra chips visuales debajo de los controles cuando hay filtros aplicados
   - Chip "En stock" cuando `inStock=true`
   - Chip con el rango de precio cuando `priceRange !== "all"`

2. **Botón "Limpiar filtros":**
   - Resetea todos los filtros (`inStock`, `priceRange`)
   - Preserva parámetros importantes (`q`, `sort`)
   - Resetea `page` a `1`
   - Solo se muestra cuando hay filtros activos

### Rutas afectadas

- `/catalogo/[section]`: Chips y botón limpiar arriba del grid
- `/buscar`: Chips y botón limpiar junto a los resultados

### Comportamiento

- Los chips muestran el estado actual de los filtros
- Al hacer clic en "Limpiar filtros":
  - Se eliminan `inStock` y `priceRange` de la URL
  - Se preserva `sort` (si existe)
  - En `/buscar`, se preserva `q`
  - `page` se resetea a `1`

### Archivos modificados

- `src/lib/catalog/config.ts`: Agregado helper `getPriceRangeLabel()` para labels de rangos
- `src/components/catalog/FiltersSelect.client.tsx`: 
  - Agregado display de chips de filtros activos
  - Agregado botón "Limpiar filtros"
  - Agregado lógica para preservar `sort` al limpiar filtros

### No se tocó

- Lógica de filtros en backend (solo UI)
- Paginación y ordenamiento (siguen funcionando igual)
- Lógica de negocio

### QA técnico

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅

### Ejemplos de URLs para QA

- `/catalogo/instrumental-ortodoncia?inStock=true&priceRange=500_1000&sort=price_asc&page=2`
  - Debe mostrar 2 chips (En stock, $500 a $1,000) y botón limpiar
  - Al limpiar: `/catalogo/instrumental-ortodoncia?sort=price_asc&page=1`

- `/buscar?q=arcos&inStock=true&priceRange=lt_500&page=1`
  - Debe mostrar 2 chips y botón limpiar
  - Al limpiar: `/buscar?q=arcos&page=1`

