### PR TITLE
feat(catalog): add stock, shipping and points hints to product cards and PDP

### DIFF
--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -8,6 +8,8 @@ import ProductViewTracker from "@/components/ProductViewTracker.client";
 import { ROUTES } from "@/lib/routes";
 import Link from "next/link";
 import PdpRelatedSection from "./PdpRelatedSection";
+import { FREE_SHIPPING_THRESHOLD_MXN } from "@/lib/shipping/freeShipping";
+import { LOYALTY_POINTS_PER_MXN } from "@/lib/loyalty/config";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -201,20 +203,38 @@ export default async function ProductDetailPage({ params }: Props) {
                 <div className="text-4xl font-bold text-primary-600">
                   {price}
                 </div>
-                <div className="flex items-center space-x-2">
-                  <span
-                    className={`px-2 py-1 rounded-full text-xs font-medium ${
-                      !soldOut
-                        ? "bg-green-100 text-green-800"
-                        : "bg-red-100 text-red-800"
-                    }`}
-                  >
-                    {!soldOut ? "En stock" : "Agotado"}
-                  </span>
+                <div className="flex items-center space-x-2 flex-wrap gap-2">
+                  {/* Badge de stock mejorado */}
+                  {product.in_stock !== null &&
+                    product.in_stock !== undefined && (
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                          product.in_stock
+                            ? "bg-emerald-50 text-emerald-700"
+                            : "bg-red-50 text-red-700"
+                        }`}
+                      >
+                        {product.in_stock ? "En stock" : "Agotado"}
+                      </span>
+                    )}
                   {product.in_stock && (
                     <span className="text-sm text-gray-600">
                       Lista para envío inmediato
                     </span>
+                  )}
+                </div>
+
+                {/* Información de envío gratis y puntos */}
+                <div className="space-y-1 pt-2">
+                  <p className="text-sm text-gray-500">
+                    Envío gratis desde ${FREE_SHIPPING_THRESHOLD_MXN.toLocaleString("es-MX")} MXN en productos.
+                  </p>
+                  {product.price > 0 && (
+                    <p className="text-sm text-amber-700">
+                      Acumulas aprox.{" "}
+                      {Math.floor(product.price * LOYALTY_POINTS_PER_MXN).toLocaleString("es-MX")}{" "}
+                      puntos con este producto.
+                    </p>
                   )}
                 </div>
               </div>

--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -9,6 +9,8 @@ import { useCartStore } from "@/lib/store/cartStore";
 import { formatMXN, mxnFromCents } from "@/lib/utils/currency";
 import { normalizePrice, hasPurchasablePrice } from "@/lib/catalog/model";
 import { getWhatsAppHref } from "@/lib/whatsapp";
+import { FREE_SHIPPING_THRESHOLD_MXN } from "@/lib/shipping/freeShipping";
+import { LOYALTY_POINTS_PER_MXN } from "@/lib/loyalty/config";
 
 /**
  * Props unificadas para ProductCard
@@ -188,11 +190,33 @@ export default function ProductCard({
         {price !== null ? formatMXN(price) : "Consultar precio"}
       </div>
 
-      {/* Estado de stock */}
-      {soldOut && (
-        <span className="mt-1 inline-block rounded bg-red-100 px-2 py-0.5 text-[11px] text-red-700">
-          Agotado
+      {/* Estado de stock - Badge mejorado */}
+      {in_stock !== null && in_stock !== undefined && (
+        <span
+          className={`mt-1 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            in_stock
+              ? "bg-emerald-50 text-emerald-700"
+              : "bg-red-50 text-red-700"
+          }`}
+        >
+          {in_stock ? "En stock" : "Agotado"}
         </span>
+      )}
+
+      {/* Texto de envío gratis */}
+      {price !== null && (
+        <p className="mt-1 text-[11px] text-gray-500">
+          Envío gratis desde ${FREE_SHIPPING_THRESHOLD_MXN.toLocaleString("es-MX")} MXN en productos.
+        </p>
+      )}
+
+      {/* Puntos estimados */}
+      {price !== null && (
+        <p className="mt-0.5 text-[11px] text-amber-700">
+          Acumulas aprox.{" "}
+          {Math.floor(price * LOYALTY_POINTS_PER_MXN).toLocaleString("es-MX")}{" "}
+          puntos con este producto.
+        </p>
       )}
 
       {/* Controles: cantidad y agregar al carrito */}


### PR DESCRIPTION
Este PR mejora la UX de las tarjetas de producto y del PDP agregando badges de stock, información de envío gratis y puntos estimados de lealtad.

### Cambios principales

1. **Badge de stock mejorado:**
   - Si `in_stock === true` → badge verde "En stock" (`bg-emerald-50 text-emerald-700`)
   - Si `in_stock === false` → badge rojo "Agotado" (`bg-red-50 text-red-700`)
   - Si `in_stock` es `null` o `undefined` → no se muestra badge
   - Aplicado en `ProductCard` y PDP

2. **Texto de envío gratis:**
   - Muestra: "Envío gratis desde $2,000 MXN en productos."
   - Solo se muestra si el producto tiene precio definido
   - Ubicación: debajo del precio en ProductCard y PDP

3. **Puntos estimados de lealtad:**
   - Cálculo: `Math.floor(price * LOYALTY_POINTS_PER_MXN)`
   - Muestra: "Acumulas aprox. {puntos} puntos con este producto."
   - Solo se muestra si el producto tiene precio definido
   - Ubicación: debajo del texto de envío gratis

### Archivos modificados

- `src/components/catalog/ProductCard.tsx`:
  - Agregado badge de stock mejorado
  - Agregado texto de envío gratis
  - Agregado cálculo y display de puntos estimados
  - Imports de constantes necesarias

- `src/app/catalogo/[section]/[slug]/page.tsx`:
  - Mejorado badge de stock existente
  - Agregado texto de envío gratis en bloque de precio/disponibilidad
  - Agregado cálculo y display de puntos estimados
  - Imports de constantes necesarias

### Constantes utilizadas

- `FREE_SHIPPING_THRESHOLD_MXN` desde `src/lib/shipping/freeShipping.ts` (valor: 2000)
- `LOYALTY_POINTS_PER_MXN` desde `src/lib/loyalty/config.ts` (valor: 1)

### No se tocó

- Lógica backend de stock, envío o puntos
- Supabase o Stripe
- Lógica de checkout (solo UX informativa)
- Tests existentes

### QA técnico

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅

### Ejemplos visuales

**ProductCard:**
```
[Imagen del producto]
Título del producto
$1,500 MXN
[En stock] ← Badge verde
Envío gratis desde $2,000 MXN en productos. ← Texto gris pequeño
Acumulas aprox. 1,500 puntos con este producto. ← Texto ámbar pequeño
[Cantidad] [Agregar al carrito]
```

**PDP:**
```
[Imagen del producto] | Título del producto
                      | $1,500 MXN
                      | [En stock] Lista para envío inmediato
                      | Envío gratis desde $2,000 MXN en productos.
                      | Acumulas aprox. 1,500 puntos con este producto.
                      | [Controles de compra]
```

### Comportamiento esperado

- Badge de stock solo aparece cuando `in_stock` está explícitamente definido (true/false)
- Texto de envío gratis y puntos solo aparecen cuando el producto tiene precio
- Los textos usan estilos consistentes con la paleta actual
- No se calcula si el producto por sí solo llega a los $2,000 (solo informativo)

