### PR TITLE
feat(seo): improve open graph metadata for catalog and PDP

### DIFF
--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -27,10 +27,6 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const siteName =
-    process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega";
-  const base =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app";
   const section = decodeURIComponent(params.section ?? "");
   const slug = decodeURIComponent(params.slug ?? "");
 
@@ -43,7 +39,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   if (!product) {
-    const title = `Producto no disponible | ${siteName}`;
+    const title = `Producto no disponible | ${SITE.name}`;
     return {
       title,
       description: "Producto no disponible.",
@@ -56,39 +52,49 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     .replace(/-/g, " ")
     .replace(/\b\w/g, (l: string) => l.toUpperCase());
 
-  const title = `${product.title} | ${sectionFormatted} | ${siteName}`;
+  const title = `${product.title} | ${sectionFormatted} | ${SITE.name}`;
   const description =
-    product.description?.slice(0, 150) ??
-    `${product.title} - ${sectionFormatted}. Disponible en ${siteName}.`;
-  const image = product.image_url ?? "/og-default.jpg";
-  const url = `${base}/catalogo/${product.section}/${product.slug}`;
+    product.description?.trim()?.slice(0, 160) ??
+    `Compra ${product.title} en ${SITE.name}. Productos para odontólogos y clínicas en México.`;
+
+  // URL absoluta de la imagen del producto o fallback a OG por defecto
+  const og_image_url = product.image_url
+    ? new URL(product.image_url, SITE.url).toString()
+    : `${SITE.url}${SITE.socialImage}`;
+
+  // URL absoluta de la página del producto
+  const productUrl = new URL(
+    ROUTES.product(product.section, product.slug),
+    SITE.url,
+  ).toString();
 
   return {
     title,
     description,
     openGraph: {
       type: "website",
-      url,
-      siteName,
+      url: productUrl,
+      siteName: SITE.name,
       title,
       description,
       images: [
         {
-          url: image,
+          url: og_image_url,
           width: 1200,
           height: 630,
           alt: product.title,
         },
       ],
+      locale: "es_MX",
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [image],
+      images: [og_image_url],
     },
     alternates: {
-      canonical: url,
+      canonical: productUrl,
     },
   };
 }

--- a/src/app/catalogo/[section]/page.tsx
+++ b/src/app/catalogo/[section]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { getBySection } from "@/lib/catalog/getBySection.server";
 import { ROUTES } from "@/lib/routes";
+import { SITE } from "@/lib/site";
 import ProductCard from "@/components/catalog/ProductCard";
 import Pagination from "@/components/catalog/Pagination";
 import {
@@ -38,10 +39,6 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const siteName =
-    process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega";
-  const base =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app";
   const section = decodeURIComponent(params.section ?? "").trim();
 
   // Intentar obtener productos de la sección (solo primera página para metadata)
@@ -58,37 +55,44 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     .replace(/-/g, " ")
     .replace(/\b\w/g, (l) => l.toUpperCase());
 
-  const title = `${sectionName} | ${siteName}`;
-  const description = `Explora ${sectionName} en ${siteName}.`;
-  const image = items?.[0]?.image_url ?? "/og/cover.jpg";
-  const url = `${base}/catalogo/${section}`;
+  const title = `${sectionName} | ${SITE.name}`;
+  const description = `Explora ${sectionName} en ${SITE.name}. Productos dentales de calidad para consultorios y clínicas.`;
+
+  // Usar imagen del primer producto si existe, sino OG por defecto
+  const og_image_url = items?.[0]?.image_url
+    ? new URL(items[0].image_url, SITE.url).toString()
+    : `${SITE.url}${SITE.socialImage}`;
+
+  // URL absoluta de la sección
+  const sectionUrl = new URL(ROUTES.section(section), SITE.url).toString();
 
   return {
     title,
     description,
     openGraph: {
       type: "website",
-      url,
-      siteName,
+      url: sectionUrl,
+      siteName: SITE.name,
       title,
       description,
       images: [
         {
-          url: image,
+          url: og_image_url,
           width: 1200,
           height: 630,
           alt: sectionName,
         },
       ],
+      locale: "es_MX",
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [image],
+      images: [og_image_url],
     },
     alternates: {
-      canonical: url,
+      canonical: sectionUrl,
     },
   };
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ const ToothAccountMenu = dynamic(
   },
 );
 import { ROUTES } from "@/lib/routes";
+import { SITE } from "@/lib/site";
 import BrandMark from "@/components/BrandMark";
 import {
   getOrganizationJsonLd,
@@ -63,15 +64,12 @@ const AnalyticsGa4Bridge = dynamic(
 const inter = Inter({ subsets: ["latin"], display: "swap" });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://dental-noriega.vercel.app",
-  ),
+  metadataBase: new URL(SITE.url),
   title: {
-    default: "Depósito Dental Noriega | Insumos dentales en México",
-    template: "%s | Depósito Dental Noriega",
+    default: `${SITE.name} | Insumos dentales en México`,
+    template: `%s | ${SITE.name}`,
   },
-  description:
-    "Insumos y equipos dentales de calidad. Servicio a clínicas, consultorios y mayoristas. Envío a todo México.",
+  description: SITE.description,
   keywords: [
     "insumos dentales",
     "equipos dentales",
@@ -82,17 +80,16 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     type: "website",
-    url: "/",
-    siteName: process.env.NEXT_PUBLIC_SITE_NAME ?? "Depósito Dental Noriega",
-    title: "Depósito Dental Noriega | Insumos dentales en México",
-    description:
-      "Insumos y equipos dentales de calidad. Servicio a clínicas, consultorios y mayoristas. Envío a todo México.",
+    url: SITE.url,
+    siteName: SITE.name,
+    title: `${SITE.name} | Insumos dentales en México`,
+    description: SITE.description,
     images: [
       {
-        url: "/og-default.jpg",
+        url: `${SITE.url}${SITE.socialImage}`,
         width: 1200,
         height: 630,
-        alt: "Depósito Dental Noriega",
+        alt: SITE.name,
       },
     ],
     locale: "es_MX",
@@ -100,10 +97,9 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     creator: "@dentalnoriega",
-    title: "Depósito Dental Noriega | Insumos dentales en México",
-    description:
-      "Insumos y equipos dentales de calidad. Servicio a clínicas, consultorios y mayoristas.",
-    images: ["/og-default.jpg"],
+    title: `${SITE.name} | Insumos dentales en México`,
+    description: SITE.description,
+    images: [`${SITE.url}${SITE.socialImage}`],
   },
   robots: {
     index: true,

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -3,6 +3,8 @@
 
 export const SITE = {
   name: process.env.NEXT_PUBLIC_SITE_NAME || "DENTAL NORIEGA",
+  description:
+    "Insumos y equipos dentales de calidad. Servicio a clínicas, consultorios y mayoristas. Envío a todo México.",
   waPhone: process.env.NEXT_PUBLIC_WA_PHONE || "525531033715",
   email: process.env.NEXT_PUBLIC_CONTACT_EMAIL || "dental.noriega721@gmail.com",
   address:
@@ -18,6 +20,7 @@ export const SITE = {
     process.env.NEXT_PUBLIC_INSTAGRAM_URL ||
     "https://www.instagram.com/deposito.dental.noriega",
   url: process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+  socialImage: "/og-default.jpg",
 };
 
 export function waLink(prefill: string) {


### PR DESCRIPTION
Este PR mejora las meta tags de Open Graph y Twitter Cards para mejorar las previsualizaciones cuando se comparte la web o un producto. Cambios: SITE extendido con description y socialImage, metadata global mejorada usando SITE, Open Graph para PDP con URLs absolutas, Open Graph para secciones mejorado. Verificacion: lint, typecheck y build pasan. No se modifico logica de checkout, Stripe ni Supabase.