### PR TITLE
feat(ux): add custom 404 and better empty states

### DIFF
--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import Link from "next/link";
 import type { Metadata } from "next";
 import dynamicImport from "next/dynamic";
+import { Search } from "lucide-react";
 import SearchResultCard from "@/components/SearchResultCard";
 import { ROUTES } from "@/lib/routes";
+import { getWhatsAppUrl } from "@/lib/whatsapp/config";
 import SearchTracker from "@/components/SearchTracker.client";
 import Pagination from "@/components/catalog/Pagination";
 import {
@@ -182,26 +184,33 @@ export default async function BuscarPage({ searchParams }: Props) {
       )}
 
       {items.length === 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 p-8 text-center">
-          <p className="text-gray-700 mb-2 font-medium">
-            No encontramos productos para "{q}"
-          </p>
+        <div className="bg-white rounded-lg border border-gray-200 p-8 text-center max-w-2xl mx-auto">
+          <div className="w-16 h-16 mx-auto rounded-full bg-gray-100 flex items-center justify-center mb-4">
+            <Search className="w-8 h-8 text-gray-400" aria-hidden="true" />
+          </div>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            No encontramos resultados para "{q}"
+          </h2>
           <p className="text-sm text-gray-600 mb-6">
-            Intenta con otros términos, revisa la ortografía o prueba con menos palabras
+            Prueba con otro término (por ejemplo, "brackets", "guantes", "resortes") o escríbenos por WhatsApp y te ayudamos a encontrar el producto.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <Link
-              href={ROUTES.destacados()}
-              className="px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium"
+              href={ROUTES.catalogIndex()}
+              className="px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
             >
-              Ver productos destacados
+              Ver todo el catálogo
             </Link>
-            <Link
-              href="/tienda"
-              className="px-6 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium"
-            >
-              Ver todos los productos
-            </Link>
+            {getWhatsAppUrl(`Hola, busco productos relacionados con "${q}" en Depósito Dental Noriega.`) && (
+              <Link
+                href={getWhatsAppUrl(`Hola, busco productos relacionados con "${q}" en Depósito Dental Noriega.`)!}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-6 py-3 border border-green-500 text-green-700 rounded-lg hover:bg-green-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+              >
+                Hablar por WhatsApp
+              </Link>
+            )}
           </div>
         </div>
       )}

--- a/src/app/catalogo/[section]/page.tsx
+++ b/src/app/catalogo/[section]/page.tsx
@@ -12,6 +12,8 @@ import {
   normalizePriceRangeParam,
 } from "@/lib/catalog/config";
 import dynamicImport from "next/dynamic";
+import { Package } from "lucide-react";
+import { getWhatsAppUrl } from "@/lib/whatsapp/config";
 import Breadcrumbs from "@/components/navigation/Breadcrumbs";
 
 const SortSelect = dynamicImport(
@@ -137,22 +139,72 @@ export default async function CatalogoSectionPage({ params, searchParams }: Prop
   
   const products = result?.items ?? [];
 
-  // Si no hay productos, mostrar mensaje
+  // Si no hay productos, mostrar mensaje mejorado
   if (products.length === 0 && !errorOccurred) {
+    const sectionName = params.section
+      .replace(/-/g, " ")
+      .replace(/\b\w/g, (l) => l.toUpperCase());
+    
+    const whatsappUrl = getWhatsAppUrl(`Hola, busco productos en la sección "${sectionName}" en Depósito Dental Noriega.`);
+
     return (
-      <div className="p-6">
-        <h1 className="text-xl font-semibold">Sin productos en esta sección</h1>
-        <p className="text-sm opacity-70 mt-1">
-          Prueba en{" "}
-          <Link href="/destacados" className="underline">
-            Destacados
-          </Link>{" "}
-          o{" "}
-          <Link href="/buscar" className="underline">
-            buscar
-          </Link>
-          .
-        </p>
+      <div className="min-h-screen bg-gray-50">
+        <div className="bg-gradient-to-r from-primary-600 to-primary-800 text-white py-12">
+          <div className="max-w-7xl mx-auto px-4">
+            <Breadcrumbs
+              items={[
+                { href: ROUTES.home(), label: "Inicio" },
+                { href: ROUTES.catalogIndex(), label: "Catálogo" },
+                { label: sectionName },
+              ]}
+              className="mb-4"
+            />
+            <h1 className="text-4xl font-bold mb-2">{sectionName}</h1>
+            <p className="text-primary-100">
+              Por ahora no hay productos en esta sección
+            </p>
+          </div>
+        </div>
+
+        <div className="max-w-3xl mx-auto px-4 py-12">
+          <div className="bg-white rounded-lg border border-gray-200 p-8 text-center">
+            <div className="w-16 h-16 mx-auto rounded-full bg-gray-100 flex items-center justify-center mb-4">
+              <Package className="w-8 h-8 text-gray-400" aria-hidden="true" />
+            </div>
+            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+              Por ahora no hay productos en esta sección
+            </h2>
+            <p className="text-sm text-gray-600 mb-6">
+              Puedes revisar otras categorías o escribirnos por WhatsApp para conseguirte el producto.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href={ROUTES.catalogIndex()}
+                className="px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              >
+                Ver todas las secciones del catálogo
+              </Link>
+              <Link
+                href={ROUTES.destacados()}
+                className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              >
+                Ir a destacados
+              </Link>
+            </div>
+            {whatsappUrl && (
+              <div className="mt-4">
+                <Link
+                  href={whatsappUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-6 py-3 border border-green-500 text-green-700 rounded-lg hover:bg-green-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+                >
+                  Hablar por WhatsApp
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -69,17 +69,22 @@ export default function ErrorPage({
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
             Ocurrió un error inesperado
           </h1>
-          <p className="text-gray-600 mb-8">
-            Hubo un problema al cargar esta página. Por favor, intenta de nuevo.
+          <p className="text-gray-600 mb-4">
+            Algo salió mal al cargar esta página.
           </p>
+          {pathname?.includes("/checkout/gracias") && (
+            <p className="text-sm text-gray-500 mb-4">
+              Tu pedido y los pagos no se ven afectados. Si ya completaste tu compra, revisa tu correo o contacta por WhatsApp.
+            </p>
+          )}
         </div>
         <div className="flex flex-col sm:flex-row gap-3 justify-center mb-4">
           <button
             onClick={handleRetry}
             className="px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-            aria-label="Intentar de nuevo"
+            aria-label="Reintentar"
           >
-            Intentar de nuevo
+            Reintentar
           </button>
           <Link
             href="/"
@@ -87,15 +92,6 @@ export default function ErrorPage({
             aria-label="Volver al inicio"
           >
             Volver al inicio
-          </Link>
-        </div>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Link
-            href="/tienda"
-            className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-            aria-label="Ir a la tienda"
-          >
-            Ir a la tienda
           </Link>
         </div>
         {/* Error digest para debugging - solo mostrar si existe */}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,51 +1,55 @@
 // src/app/not-found.tsx
 import React from "react";
 import Link from "next/link";
+import { Search } from "lucide-react";
 import { ROUTES } from "@/lib/routes";
+import { getWhatsAppUrl } from "@/lib/whatsapp/config";
 
 export default function NotFound() {
+  const whatsappUrl = getWhatsAppUrl("Hola, necesito ayuda para encontrar un producto en el sitio.");
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-12">
       <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8 text-center">
         <div className="mb-6">
           <div className="w-20 h-20 mx-auto rounded-full bg-gray-100 flex items-center justify-center mb-4">
-            <svg
-              className="w-12 h-12 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
+            <Search className="w-12 h-12 text-gray-400" aria-hidden="true" />
           </div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
             Página no encontrada
           </h1>
           <p className="text-gray-600 mb-8">
-            La página que buscas no existe o fue movida.
+            No encontramos esta página. Puede que el enlace esté roto o el producto ya no exista.
           </p>
         </div>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Link
-            href={ROUTES.home()}
-            className="px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-            aria-label="Volver al inicio"
-          >
-            Volver al inicio
-          </Link>
-          <Link
-            href={ROUTES.tienda()}
-            className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-            aria-label="Ir a la tienda"
-          >
-            Ir a la tienda
-          </Link>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              href={ROUTES.catalogIndex()}
+              className="px-6 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              aria-label="Ir al catálogo"
+            >
+              Ir al catálogo
+            </Link>
+            <Link
+              href={ROUTES.home()}
+              className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              aria-label="Ir al inicio"
+            >
+              Ir al inicio
+            </Link>
+          </div>
+          {whatsappUrl && (
+            <Link
+              href={whatsappUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-6 py-3 border border-green-500 text-green-700 rounded-lg hover:bg-green-50 transition-colors font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+              aria-label="Hablar por WhatsApp"
+            >
+              Hablar por WhatsApp
+            </Link>
+          )}
         </div>
       </div>
     </main>


### PR DESCRIPTION
Este PR mejora las paginas de error y los estados vacios para una mejor experiencia de usuario. Cambios: Pagina 404 mejorada con iconos, botones y link a WhatsApp. Error boundary mejorado con mensaje mas claro y nota sobre pedidos. Empty state en /buscar mejorado con diseno de tarjeta y opciones claras. Empty state en /catalogo/[section] mejorado manteniendo breadcrumbs y hero. Verificacion: lint, typecheck y build pasan. No se modifico logica de checkout, Stripe ni Supabase.