### PR TITLE
feat(account): add account section header

### DIFF
--- a/src/app/cuenta/direcciones/page.tsx
+++ b/src/app/cuenta/direcciones/page.tsx
@@ -1,4 +1,6 @@
 import { Metadata } from "next";
+import { createServerSupabase } from "@/lib/supabase/server-auth";
+import AccountSectionHeader from "@/components/account/AccountSectionHeader";
 import DireccionesClient from "./DireccionesClient";
 
 export const metadata: Metadata = {
@@ -16,7 +18,17 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-export default function DireccionesPage() {
+export default async function DireccionesPage() {
+  const supabase = createServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const fullName =
+    (user?.user_metadata &&
+      (user.user_metadata.full_name || user.user_metadata.fullName)) ||
+    null;
+
   return (
     <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
       <header>
@@ -25,6 +37,10 @@ export default function DireccionesPage() {
           Gestiona tus direcciones de envío para facilitar tus compras.
         </p>
       </header>
+      <AccountSectionHeader
+        user={{ email: user?.email ?? null, fullName }}
+        currentSection="direcciones"
+      />
       <DireccionesClient />
     </main>
   );

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -8,6 +8,7 @@ import type {
   OrderSummary,
   OrderDetail,
 } from "@/lib/supabase/orders.server";
+import AccountSectionHeader from "@/components/account/AccountSectionHeader";
 
 export default function PedidosPage() {
   const [email, setEmail] = useState("");
@@ -27,6 +28,7 @@ export default function PedidosPage() {
   const [loyaltyError, setLoyaltyError] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [userFullName, setUserFullName] = useState<string | null>(null);
 
   // Cargar email del usuario autenticado al montar
   useEffect(() => {
@@ -40,6 +42,10 @@ export default function PedidosPage() {
           setUserEmail(user.email);
           setEmail(user.email); // Pre-llenar el email
           setIsAuthenticated(true);
+          const metadata = user.user_metadata || {};
+          setUserFullName(
+            metadata.full_name || metadata.fullName || null,
+          );
           // Cargar órdenes automáticamente si el usuario está autenticado
           handleAutoLoad(user.email);
         }
@@ -317,6 +323,11 @@ export default function PedidosPage() {
           Consulta el historial de tus pedidos y los puntos generados.
         </p>
       </header>
+
+      <AccountSectionHeader
+        user={{ email: userEmail, fullName: userFullName }}
+        currentSection="pedidos"
+      />
 
       <div className="mt-6 bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 space-y-6">
 

--- a/src/app/cuenta/perfil/page.tsx
+++ b/src/app/cuenta/perfil/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { createServerSupabase } from "@/lib/supabase/server-auth";
 import EmailVerificationBanner from "@/components/account/EmailVerificationBanner";
 import AccountInfoBanner from "@/components/account/AccountInfoBanner";
+import AccountSectionHeader from "@/components/account/AccountSectionHeader";
 import EditProfileForm from "./EditProfileForm";
 
 export const dynamic = "force-dynamic";
@@ -45,6 +46,11 @@ export default async function PerfilPage({
           Gestiona tu cuenta y tus datos de contacto.
         </p>
       </header>
+
+      <AccountSectionHeader
+        user={{ email: user.email, fullName }}
+        currentSection="perfil"
+      />
 
       {user.email && (
         <EmailVerificationBanner

--- a/src/components/account/AccountSectionHeader.tsx
+++ b/src/components/account/AccountSectionHeader.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import clsx from "clsx";
+
+type AccountSectionHeaderProps = {
+  user?: {
+    email?: string | null;
+    fullName?: string | null;
+  } | null;
+  currentSection?: "perfil" | "pedidos" | "direcciones" | "pagos";
+};
+
+const navItems = [
+  { key: "perfil", label: "Perfil", href: "/cuenta/perfil" },
+  { key: "pedidos", label: "Pedidos", href: "/cuenta/pedidos" },
+  { key: "direcciones", label: "Direcciones", href: "/cuenta/direcciones" },
+];
+
+export default function AccountSectionHeader({
+  user,
+  currentSection,
+}: AccountSectionHeaderProps) {
+  const fullName = user?.fullName?.trim() || null;
+  const email = user?.email?.trim() || null;
+  const initial =
+    fullName?.[0]?.toUpperCase() ||
+    email?.[0]?.toUpperCase() ||
+    "D";
+
+  const secondaryLine = email || "Sin correo asociado";
+
+  return (
+    <div className="mb-8 rounded-2xl border border-slate-200/70 bg-white px-4 py-4 md:px-6 md:py-5 shadow-sm flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <Link
+        href="/cuenta"
+        className="flex items-center"
+        aria-label="Volver al panel de cuenta"
+      >
+        <div className="h-12 w-12 rounded-full bg-blue-600 text-white flex items-center justify-center text-lg font-semibold mr-3 hover:scale-105 transition-transform">
+          {initial}
+        </div>
+        <div className="flex flex-col">
+          <span className="text-sm font-medium text-slate-900">
+            Mi cuenta
+          </span>
+          <span className="text-xs text-slate-500 truncate max-w-[220px]">
+            {secondaryLine}
+          </span>
+        </div>
+      </Link>
+
+      <nav className="flex flex-wrap gap-2 justify-start md:justify-end">
+        {navItems.map((item) => {
+          const isActive = currentSection === item.key;
+          return (
+            <Link
+              key={item.key}
+              href={item.href}
+              className={clsx(
+                "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                isActive
+                  ? "border-blue-500 bg-blue-50 text-blue-700"
+                  : "border-slate-200 text-slate-600 hover:border-slate-300 hover:bg-slate-50",
+              )}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+        <span className="inline-flex items-center rounded-full border border-dashed border-slate-300 px-3 py-1 text-xs font-medium text-slate-400 cursor-default">
+          Métodos de pago (próximamente)
+        </span>
+      </nav>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Resumen
- añade el componente reutilizable \\AccountSectionHeader\\ con avatar, correo y navegación tipo pills.
- integra el header en \\/cuenta/perfil\\, \\/cuenta/pedidos\\ y \\/cuenta/direcciones\\ para volver rápido al dashboard.
- mantiene los layouts existentes y sólo agrega el bloque superior reutilizable.

## QA
- pnpm lint
- pnpm typecheck
- pnpm build
