### PR TITLE
feat(account): refine account nav and avatar

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -40,7 +40,8 @@ export default function PedidosPage() {
         const { data: { user } } = await s.auth.getUser();
         if (user?.email && isValidEmail(user.email)) {
           setUserEmail(user.email);
-          setEmail(user.email); // Pre-llenar el email
+          // Pre-llenar el email solo si el campo está vacío
+          setEmail((prev) => prev || user.email || "");
           setIsAuthenticated(true);
           const metadata = user.user_metadata || {};
           setUserFullName(
@@ -58,6 +59,7 @@ export default function PedidosPage() {
     };
 
     loadUserEmail();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Función para cargar órdenes automáticamente cuando el usuario está autenticado
@@ -355,7 +357,6 @@ export default function PedidosPage() {
                 placeholder="tu@email.com"
                 autoComplete="email"
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-                disabled={isAuthenticated && !!userEmail}
               />
               {isAuthenticated && userEmail && (
                 <p className="mt-1 text-sm text-gray-500">

--- a/src/components/ToothAccountMenu.tsx
+++ b/src/components/ToothAccountMenu.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCartStore, selectCartCount } from "@/lib/store/cartStore";
 import { getBrowserSupabase } from "@/lib/supabase/client";
+import { getUserInitial } from "@/lib/account/avatar";
 import type { User } from "@supabase/supabase-js";
 
 export function ToothAccountMenu() {
@@ -75,7 +76,10 @@ export function ToothAccountMenu() {
           className="flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-lg px-2 py-1 hover:bg-gray-50 transition"
         >
           <div className="h-9 w-9 rounded-full bg-blue-600 text-white flex items-center justify-center text-sm font-semibold shadow-sm">
-            {user.email?.[0]?.toUpperCase() || user.user_metadata?.full_name?.[0]?.toUpperCase() || "U"}
+            {getUserInitial({
+              fullName: user.user_metadata?.full_name || user.user_metadata?.fullName || null,
+              email: user.email || null,
+            })}
           </div>
           <span className="hidden sm:inline-block ml-2 text-sm font-medium text-gray-700">
             Cuenta
@@ -100,6 +104,14 @@ export function ToothAccountMenu() {
         >
           {user ? (
             <>
+              <Link
+                href="/cuenta"
+                className="block rounded-xl px-3 py-2 hover:bg-neutral-50 transition-colors"
+                onClick={() => setOpen(false)}
+                role="menuitem"
+              >
+                Mi cuenta
+              </Link>
               <Link
                 href="/cuenta/perfil"
                 className="block rounded-xl px-3 py-2 hover:bg-neutral-50 transition-colors"

--- a/src/components/account/AccountSectionHeader.tsx
+++ b/src/components/account/AccountSectionHeader.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import clsx from "clsx";
+import { getUserInitial } from "@/lib/account/avatar";
 
 type AccountSectionHeaderProps = {
   user?: {
@@ -21,20 +23,18 @@ export default function AccountSectionHeader({
   user,
   currentSection,
 }: AccountSectionHeaderProps) {
+  const router = useRouter();
   const fullName = user?.fullName?.trim() || null;
   const email = user?.email?.trim() || null;
-  const initial =
-    fullName?.[0]?.toUpperCase() ||
-    email?.[0]?.toUpperCase() ||
-    "D";
-
+  const initial = getUserInitial({ fullName, email });
   const secondaryLine = email || "Sin correo asociado";
 
   return (
     <div className="mb-8 rounded-2xl border border-slate-200/70 bg-white px-4 py-4 md:px-6 md:py-5 shadow-sm flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-      <Link
-        href="/cuenta"
-        className="flex items-center"
+      <button
+        type="button"
+        onClick={() => router.push("/cuenta")}
+        className="flex items-center gap-3 text-left hover:bg-slate-50 rounded-xl px-3 py-2 -mx-3 -my-2 transition"
         aria-label="Volver al panel de cuenta"
       >
         <div className="h-12 w-12 rounded-full bg-blue-600 text-white flex items-center justify-center text-lg font-semibold mr-3 hover:scale-105 transition-transform">
@@ -48,7 +48,7 @@ export default function AccountSectionHeader({
             {secondaryLine}
           </span>
         </div>
-      </Link>
+      </button>
 
       <nav className="flex flex-wrap gap-2 justify-start md:justify-end">
         {navItems.map((item) => {

--- a/src/lib/account/avatar.ts
+++ b/src/lib/account/avatar.ts
@@ -1,0 +1,14 @@
+export type MinimalUser = {
+  fullName?: string | null;
+  email?: string | null;
+};
+
+export function getUserInitial(user: MinimalUser | null | undefined): string {
+  const nameSource = (user?.fullName ?? user?.email ?? "").trim();
+
+  if (!nameSource) return "?";
+
+  const firstChar = nameSource[0] ?? "?";
+  return firstChar.toUpperCase();
+}
+


### PR DESCRIPTION
## Resumen
- Crea helper reutilizable getUserInitial para unificar la inicial del avatar en toda la app.
- Añade opción Mi cuenta al menú desplegable del header.
- Mejora el prefill del correo en Mis pedidos (campo editable).
- Hace más obvio volver al dashboard desde el header de cuenta (botón clickeable).

## Cambios
- src/lib/account/avatar.ts: nuevo helper para calcular inicial del usuario.
- src/components/ToothAccountMenu.tsx: usa el helper y añade Mi cuenta al menú.
- src/components/account/AccountSectionHeader.tsx: usa el helper y convierte el bloque izquierdo en botón clickeable.
- src/app/cuenta/pedidos/page.tsx: mejora prefill del correo y quita disabled del input.

## QA
- pnpm lint
- pnpm typecheck
- pnpm build
