### PR TITLE
feat(ui): add add-to-cart confetti and animated points

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@stripe/stripe-js": "^4.8.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.75.0",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "csv-parse": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.75.0
         version: 2.75.0
+      canvas-confetti:
+        specifier: ^1.9.4
+        version: 1.9.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2227,6 +2230,9 @@ packages:
 
   caniuse-lite@1.0.30001750:
     resolution: {integrity: sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==}
+
+  canvas-confetti@1.9.4:
+    resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -7453,6 +7459,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001750: {}
+
+  canvas-confetti@1.9.4: {}
 
   chai@5.3.3:
     dependencies:

--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { SITE } from "@/lib/site";
 import PdpRelatedSection from "./PdpRelatedSection";
 import { FREE_SHIPPING_THRESHOLD_MXN } from "@/lib/shipping/freeShipping";
 import { LOYALTY_POINTS_PER_MXN } from "@/lib/loyalty/config";
+import { AnimatedPoints } from "@/components/ui/AnimatedPoints";
 import Breadcrumbs from "@/components/navigation/Breadcrumbs";
 import {
   getBreadcrumbsJsonLd,
@@ -252,7 +253,10 @@ export default async function ProductDetailPage({ params }: Props) {
                   {product.price > 0 && (
                     <p className="text-sm text-amber-700">
                       Acumulas aprox.{" "}
-                      {Math.floor(product.price * LOYALTY_POINTS_PER_MXN).toLocaleString("es-MX")}{" "}
+                      <AnimatedPoints
+                        value={Math.floor(product.price * LOYALTY_POINTS_PER_MXN)}
+                        className="font-semibold"
+                      />{" "}
                       puntos con este producto.
                     </p>
                   )}

--- a/src/app/checkout/gracias/GraciasContent.tsx
+++ b/src/app/checkout/gracias/GraciasContent.tsx
@@ -13,6 +13,7 @@ import { useCartStore } from "@/lib/store/cartStore";
 import { useCheckoutStore } from "@/lib/store/checkoutStore";
 import { loadStripe } from "@stripe/stripe-js";
 import { trackPurchase } from "@/lib/analytics/events";
+import { AnimatedPoints } from "@/components/ui/AnimatedPoints";
 
 type LastOrder = {
   orderRef: string;
@@ -855,11 +856,21 @@ export default function GraciasContent() {
             {loyaltyInfo.pointsEarned !== null && loyaltyInfo.pointsEarned > 0 ? (
               <>
                 <p className="text-blue-900 font-medium mb-1">
-                  Por este pedido ganaste {loyaltyInfo.pointsEarned.toLocaleString()} puntos.
+                  Por este pedido ganaste{" "}
+                  <AnimatedPoints
+                    value={loyaltyInfo.pointsEarned}
+                    className="font-semibold"
+                  />{" "}
+                  puntos.
                 </p>
                 {loyaltyInfo.pointsBalance !== null && (
                   <p className="text-blue-700 text-sm">
-                    Ahora tienes {loyaltyInfo.pointsBalance.toLocaleString()} puntos acumulados en tu cuenta.
+                    Ahora tienes{" "}
+                    <AnimatedPoints
+                      value={loyaltyInfo.pointsBalance}
+                      className="font-semibold"
+                    />{" "}
+                    puntos acumulados en tu cuenta.
                   </p>
                 )}
               </>

--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -12,6 +12,7 @@ import { getWhatsAppHref } from "@/lib/whatsapp";
 import { FREE_SHIPPING_THRESHOLD_MXN } from "@/lib/shipping/freeShipping";
 import { LOYALTY_POINTS_PER_MXN } from "@/lib/loyalty/config";
 import { trackAddToCart, trackWhatsappClick } from "@/lib/analytics/events";
+import { launchCartConfetti } from "@/lib/ui/confetti";
 
 /**
  * Props unificadas para ProductCard
@@ -116,6 +117,9 @@ export default function ProductCard({
       quantity: qty,
       source: "card",
     });
+
+    // Confeti al agregar al carrito
+    void launchCartConfetti();
 
     setTimeout(() => {
       busyRef.current = false;

--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -9,6 +9,7 @@ import { mxnFromCents, formatMXNFromCents } from "@/lib/utils/currency";
 import { Truck, MessageCircle, ShieldCheck } from "lucide-react";
 import { getWhatsAppProductUrl } from "@/lib/whatsapp/config";
 import { trackAddToCart, trackWhatsappClick } from "@/lib/analytics/events";
+import { launchCartConfetti } from "@/lib/ui/confetti";
 
 type Product = {
   id: string;
@@ -66,6 +67,9 @@ export default function ProductActions({ product }: Props) {
       quantity: qty,
       source: "pdp",
     });
+
+    // Confeti al agregar al carrito
+    void launchCartConfetti();
   }
 
   function handleBuyNow() {

--- a/src/components/ui/AnimatedPoints.tsx
+++ b/src/components/ui/AnimatedPoints.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+type AnimatedPointsProps = {
+  value: number;
+  durationMs?: number; // default ~600
+  className?: string;
+};
+
+/**
+ * Componente que anima un contador de puntos desde 0 hasta el valor final
+ */
+export function AnimatedPoints({
+  value,
+  durationMs = 600,
+  className,
+}: AnimatedPointsProps) {
+  const [displayValue, setDisplayValue] = useState(0);
+
+  useEffect(() => {
+    if (value <= 0) {
+      setDisplayValue(0);
+      return;
+    }
+
+    let start: number | null = null;
+    const startValue = 0;
+    const diff = value - startValue;
+
+    const step = (timestamp: number) => {
+      if (start === null) start = timestamp;
+      const progress = Math.min((timestamp - start) / durationMs, 1);
+      const current = Math.round(startValue + diff * progress);
+      setDisplayValue(current);
+      if (progress < 1) {
+        requestAnimationFrame(step);
+      }
+    };
+
+    const frame = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frame);
+  }, [value, durationMs]);
+
+  return (
+    <span className={className}>
+      {displayValue.toLocaleString("es-MX")}
+    </span>
+  );
+}
+

--- a/src/lib/ui/canvas-confetti.d.ts
+++ b/src/lib/ui/canvas-confetti.d.ts
@@ -1,0 +1,25 @@
+declare module "canvas-confetti" {
+  interface Options {
+    particleCount?: number;
+    angle?: number;
+    spread?: number;
+    startVelocity?: number;
+    decay?: number;
+    gravity?: number;
+    drift?: number;
+    ticks?: number;
+    origin?: {
+      x?: number;
+      y?: number;
+    };
+    colors?: string[];
+    shapes?: ("square" | "circle")[];
+    scalar?: number;
+    zIndex?: number;
+    disableForReducedMotion?: boolean;
+  }
+
+  function confetti(options?: Options): Promise<null> | null;
+  export = confetti;
+}
+

--- a/src/lib/ui/confetti.ts
+++ b/src/lib/ui/confetti.ts
@@ -1,0 +1,76 @@
+/**
+ * Helper SSR-safe para lanzar confeti al agregar productos al carrito
+ */
+
+export type CartConfettiOptions = {
+  particleCount?: number;
+  spread?: number;
+  origin?: { x?: number; y?: number };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let confettiInstance: any = null;
+
+async function loadConfetti() {
+  if (typeof window === "undefined") return null;
+  
+  if (confettiInstance) return confettiInstance;
+  
+  try {
+    confettiInstance = await import("canvas-confetti");
+    return confettiInstance;
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.debug("[confetti] Error loading canvas-confetti:", err);
+    }
+    return null;
+  }
+}
+
+/**
+ * Lanza confeti al agregar un producto al carrito
+ * Solo se muestra una vez por sesión del navegador
+ */
+export async function launchCartConfetti(
+  opts?: CartConfettiOptions,
+): Promise<void> {
+  // SSR-safe: no hacer nada en servidor
+  if (typeof window === "undefined") return;
+
+  // Verificar si ya se mostró confeti en esta sesión
+  const shownKey = "ddn_cart_confetti_shown";
+  if (sessionStorage.getItem(shownKey) === "1") {
+    return;
+  }
+
+  try {
+    const confetti = await loadConfetti();
+    if (!confetti) return;
+
+    const defaultOptions = {
+      particleCount: 80,
+      spread: 70,
+      origin: { y: 0.8 },
+    };
+
+    const finalOptions = {
+      ...defaultOptions,
+      ...opts,
+      origin: {
+        ...defaultOptions.origin,
+        ...opts?.origin,
+      },
+    };
+
+    confetti.default(finalOptions);
+
+    // Marcar como mostrado en esta sesión
+    sessionStorage.setItem(shownKey, "1");
+  } catch (err) {
+    // Fallar en silencio
+    if (process.env.NODE_ENV === "development") {
+      console.debug("[confetti] Error launching confetti:", err);
+    }
+  }
+}
+


### PR DESCRIPTION
## Resumen
- Añade confeti al agregar productos al carrito (ProductCard + PDP).
- Añade contador animado para puntos de lealtad (PDP + /checkout/gracias).
- Mantiene todas las animaciones existentes sin modificarlas.

## Cambios

### Confeti
- src/lib/ui/confetti.ts: helper SSR-safe para lanzar confeti.
- src/lib/ui/canvas-confetti.d.ts: declaración de tipos para canvas-confetti.
- src/components/catalog/ProductCard.tsx: confeti al agregar desde card.
- src/components/product/ProductActions.client.tsx: confeti al agregar desde PDP.
- Confeti se muestra solo una vez por sesión del navegador.

### Contador animado de puntos
- src/components/ui/AnimatedPoints.tsx: componente que anima contador desde 0 hasta valor final.
- src/app/catalogo/[section]/[slug]/page.tsx: usa AnimatedPoints para puntos estimados.
- src/app/checkout/gracias/GraciasContent.tsx: usa AnimatedPoints para puntos ganados y balance.

## Dependencias
- canvas-confetti@1.9.4 (añadida)

## QA
- pnpm lint (solo warnings preexistentes)
- pnpm typecheck
- pnpm build

## Confirmación
- No se modificó lógica de negocio (solo UI/UX).
- No se cambiaron textos ni copy.
- Animaciones existentes se mantienen intactas.
