### PR TITLE
feat(ui): improve account scroll and points display

### DIFF
--- a/src/app/checkout/gracias/GraciasContent.tsx
+++ b/src/app/checkout/gracias/GraciasContent.tsx
@@ -897,6 +897,25 @@ export default function GraciasContent() {
                   </>
                 )}
               </>
+            ) : loyaltyInfo.pointsBalance !== null && loyaltyInfo.pointsBalance > 0 ? (
+              <>
+                <p className="text-blue-900 font-medium mb-1">
+                  Tu nuevo balance de puntos es{" "}
+                  <AnimatedPoints
+                    value={loyaltyInfo.pointsBalance}
+                    className="font-semibold"
+                  />{" "}
+                  puntos.
+                </p>
+                <LoyaltyPointsBar
+                  value={loyaltyInfo.pointsBalance}
+                  max={Math.max(loyaltyInfo.pointsBalance, 2000)}
+                  className="mt-1"
+                />
+                <p className="text-blue-700 text-sm mt-2">
+                  Tus puntos de esta compra se verán reflejados en unos minutos.
+                </p>
+              </>
             ) : (
               <p className="text-blue-700 text-sm">
                 Tus puntos se actualizarán en unos minutos.

--- a/src/app/cuenta/direcciones/DireccionesClient.tsx
+++ b/src/app/cuenta/direcciones/DireccionesClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useEffect, useTransition, useRef } from "react";
 import type { AccountAddress } from "@/lib/supabase/addresses.server";
 import { isValidEmail } from "@/lib/validation/email";
 import { getBrowserSupabase } from "@/lib/supabase/client";
@@ -36,6 +36,7 @@ export default function DireccionesClient() {
     country: "México",
     is_default: false,
   });
+  const addressesRef = useRef<HTMLDivElement | null>(null);
 
   // Cargar email del usuario autenticado al montar
   useEffect(() => {
@@ -86,6 +87,16 @@ export default function DireccionesClient() {
 
       const data = await response.json();
       setAddresses(data.addresses || []);
+      
+      // Scroll suave hacia el listado si hay direcciones
+      if (data.addresses && data.addresses.length > 0) {
+        setTimeout(() => {
+          addressesRef.current?.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }, 100);
+      }
       
       // Si no hay direcciones, mostrar mensaje amigable
       if (!data.addresses || data.addresses.length === 0) {
@@ -150,6 +161,14 @@ export default function DireccionesClient() {
         });
         setEditingId(null);
         await loadAddresses();
+        
+        // Scroll suave hacia el listado después de guardar
+        setTimeout(() => {
+          addressesRef.current?.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }, 200);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Error al guardar dirección");
         console.error("[handleSubmit] Error:", err);
@@ -523,7 +542,7 @@ export default function DireccionesClient() {
 
       {/* Lista de direcciones */}
       {email.trim() && addresses.length > 0 && (
-        <div className="space-y-4">
+        <div ref={addressesRef} className="space-y-4">
           <h2 className="text-lg font-semibold">Direcciones guardadas</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {addresses.map((address) => (

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -29,6 +29,7 @@ export default function PedidosPage() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [userFullName, setUserFullName] = useState<string | null>(null);
+  const ordersRef = useRef<HTMLDivElement | null>(null);
 
   // Cargar email del usuario autenticado al montar
   useEffect(() => {
@@ -151,6 +152,16 @@ export default function PedidosPage() {
         // Lista de órdenes
         setOrders(ordersData.orders);
         setOrderDetail(null);
+        
+        // Scroll suave hacia los resultados si hay pedidos
+        if (ordersData.orders.length > 0) {
+          setTimeout(() => {
+            ordersRef.current?.scrollIntoView({
+              behavior: "smooth",
+              block: "start",
+            });
+          }, 100);
+        }
       }
 
       // Actualizar puntos de lealtad si la respuesta fue exitosa
@@ -454,7 +465,7 @@ export default function PedidosPage() {
 
         {/* Lista de órdenes */}
         {orders && orders.length > 0 && (
-          <div className="overflow-hidden">
+          <div ref={ordersRef} className="overflow-hidden">
             <div className="px-4 sm:px-6 py-4 border-b border-gray-200">
               <h2 className="text-lg sm:text-xl font-semibold tracking-tight text-gray-900">
                 {orders.length} pedido{orders.length !== 1 ? "s" : ""} encontrado
@@ -572,7 +583,17 @@ export default function PedidosPage() {
           </div>
         )}
 
-        {orders && orders.length === 0 && (
+        {/* Empty state: no hay pedidos */}
+        {email.trim() && isValidEmail(email) && !loading && orders && orders.length === 0 && !orderDetail && !error && (
+          <div ref={ordersRef} className="bg-gray-50 rounded-lg border border-gray-200 p-8 text-center">
+            <p className="text-gray-700 font-medium mb-2">Todavía no tienes pedidos con este correo</p>
+            <p className="text-sm text-gray-600">
+              Cuando realices tu primera compra, aparecerá aquí.
+            </p>
+          </div>
+        )}
+
+        {orders && orders.length === 0 && orderDetail && (
           <div className="text-center py-12">
             <h3 className="text-lg font-semibold text-gray-900 mb-2">
               Aún no tienes pedidos


### PR DESCRIPTION
## Resumen
- Mejora visualización de puntos en /checkout/gracias cuando hay balance pero no puntos de esta compra.
- Añade scroll suave en /cuenta/pedidos y /cuenta/direcciones.
- Añade empty state claro en /cuenta/pedidos.

## Cambios

### /checkout/gracias
- src/app/checkout/gracias/GraciasContent.tsx: muestra balance de puntos con AnimatedPoints y LoyaltyPointsBar cuando hay pointsBalance pero no pointsEarned.

### /cuenta/pedidos
- src/app/cuenta/pedidos/page.tsx: añade scroll suave hacia resultados cuando búsqueda es exitosa. Añade empty state claro cuando no hay pedidos.

### /cuenta/direcciones
- src/app/cuenta/direcciones/DireccionesClient.tsx: añade scroll suave hacia listado cuando se cargan direcciones o se guarda una nueva.

## QA
- pnpm lint (solo warnings preexistentes)
- pnpm typecheck
- pnpm build

## Confirmación
- No se modificó lógica de checkout, Stripe, Supabase ni SQL.
- Solo mejoras de UX/visual.
