### PR TITLE
feat(account): fix orders list and loyalty bar

### DIFF
--- a/src/app/checkout/gracias/GraciasContent.tsx
+++ b/src/app/checkout/gracias/GraciasContent.tsx
@@ -863,66 +863,72 @@ export default function GraciasContent() {
         </h1>
 
         {/* Mensaje de puntos de lealtad */}
-        {displayStatus === "paid" && loyaltyInfo && (
-          <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            {loyaltyInfo.pointsEarned !== null && loyaltyInfo.pointsEarned > 0 ? (
-              <>
+        {displayStatus === "paid" && loyaltyInfo && (() => {
+          const previousBalance = loyaltyInfo.pointsBalance ?? 0;
+          const earned = loyaltyInfo.pointsEarned ?? 0;
+          const newBalance = previousBalance + earned;
+
+          if (earned > 0) {
+            // Caso A: usuario ganó puntos en esta compra
+            return (
+              <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
                 <p className="text-blue-900 font-medium mb-1">
-                  Por este pedido ganaste{" "}
+                  Ganaste{" "}
                   <AnimatedPoints
-                    value={loyaltyInfo.pointsEarned}
+                    value={earned}
                     className="font-semibold"
                   />{" "}
-                  puntos.
+                  puntos con esta compra.
                 </p>
                 <LoyaltyPointsBar
-                  value={loyaltyInfo.pointsEarned}
+                  value={newBalance}
+                  max={Math.max(newBalance, 2000)}
                   className="mt-1"
                 />
-                {loyaltyInfo.pointsBalance !== null && (
-                  <>
-                    <p className="text-blue-700 text-sm mt-2">
-                      Ahora tienes{" "}
-                      <AnimatedPoints
-                        value={loyaltyInfo.pointsBalance}
-                        className="font-semibold"
-                      />{" "}
-                      puntos acumulados en tu cuenta.
-                    </p>
-                    <LoyaltyPointsBar
-                      value={loyaltyInfo.pointsBalance}
-                      max={Math.max(loyaltyInfo.pointsBalance, 2000)}
-                      className="mt-1"
-                    />
-                  </>
-                )}
-              </>
-            ) : loyaltyInfo.pointsBalance !== null && loyaltyInfo.pointsBalance > 0 ? (
-              <>
-                <p className="text-blue-900 font-medium mb-1">
-                  Tu nuevo balance de puntos es{" "}
+                <p className="text-blue-700 text-sm mt-2">
+                  Tu nuevo balance es{" "}
                   <AnimatedPoints
-                    value={loyaltyInfo.pointsBalance}
+                    value={newBalance}
+                    from={previousBalance}
+                    className="font-semibold"
+                  />{" "}
+                  puntos.
+                </p>
+              </div>
+            );
+          } else if (newBalance > 0) {
+            // Caso B: usuario tiene puntos pero no hay pointsEarned aún (delay del backend)
+            return (
+              <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                <p className="text-blue-900 font-medium mb-1">
+                  Tu balance actual de puntos es{" "}
+                  <AnimatedPoints
+                    value={newBalance}
                     className="font-semibold"
                   />{" "}
                   puntos.
                 </p>
                 <LoyaltyPointsBar
-                  value={loyaltyInfo.pointsBalance}
-                  max={Math.max(loyaltyInfo.pointsBalance, 2000)}
+                  value={newBalance}
+                  max={Math.max(newBalance, 2000)}
                   className="mt-1"
                 />
                 <p className="text-blue-700 text-sm mt-2">
                   Tus puntos de esta compra se verán reflejados en unos minutos.
                 </p>
-              </>
-            ) : (
-              <p className="text-blue-700 text-sm">
-                Tus puntos se actualizarán en unos minutos.
-              </p>
-            )}
-          </div>
-        )}
+              </div>
+            );
+          } else {
+            // Caso C: no hay puntos (fallback)
+            return (
+              <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                <p className="text-blue-700 text-sm">
+                  Tus puntos se actualizarán en unos minutos.
+                </p>
+              </div>
+            );
+          }
+        })()}
 
         {/* Número de orden y estado */}
         {orderRef && (

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -87,8 +87,13 @@ export default function PedidosPage() {
       const ordersData = await ordersResponse.json();
       const loyaltyData = await loyaltyResponse.json();
 
-      if (ordersResponse.ok && ordersData.orders) {
-        setOrders(ordersData.orders);
+      if (ordersResponse.ok) {
+        if (ordersData.orders) {
+          setOrders(ordersData.orders);
+        } else {
+          // Si no hay órdenes, establecer array vacío para mostrar empty state
+          setOrders([]);
+        }
       }
 
       if (loyaltyResponse.ok && loyaltyData) {
@@ -162,6 +167,10 @@ export default function PedidosPage() {
             });
           }, 100);
         }
+      } else {
+        // Si no hay órdenes ni detalle, establecer array vacío para mostrar empty state
+        setOrders([]);
+        setOrderDetail(null);
       }
 
       // Actualizar puntos de lealtad si la respuesta fue exitosa
@@ -584,7 +593,7 @@ export default function PedidosPage() {
         )}
 
         {/* Empty state: no hay pedidos */}
-        {email.trim() && isValidEmail(email) && !loading && orders && orders.length === 0 && !orderDetail && !error && (
+        {email.trim() && isValidEmail(email) && !loading && orders !== null && orders.length === 0 && !orderDetail && !error && (
           <div ref={ordersRef} className="bg-gray-50 rounded-lg border border-gray-200 p-8 text-center">
             <p className="text-gray-700 font-medium mb-2">Todavía no tienes pedidos con este correo</p>
             <p className="text-sm text-gray-600">

--- a/src/components/ui/AnimatedPoints.tsx
+++ b/src/components/ui/AnimatedPoints.tsx
@@ -4,28 +4,30 @@ import { useState, useEffect } from "react";
 
 type AnimatedPointsProps = {
   value: number;
+  from?: number; // valor inicial para la animación (default: 0)
   durationMs?: number; // default ~600
   className?: string;
 };
 
 /**
- * Componente que anima un contador de puntos desde 0 hasta el valor final
+ * Componente que anima un contador de puntos desde un valor inicial hasta el valor final
  */
 export function AnimatedPoints({
   value,
+  from = 0,
   durationMs = 600,
   className,
 }: AnimatedPointsProps) {
-  const [displayValue, setDisplayValue] = useState(0);
+  const [displayValue, setDisplayValue] = useState(from);
 
   useEffect(() => {
-    if (value <= 0) {
+    if (value <= 0 && from <= 0) {
       setDisplayValue(0);
       return;
     }
 
     let start: number | null = null;
-    const startValue = 0;
+    const startValue = from;
     const diff = value - startValue;
 
     const step = (timestamp: number) => {
@@ -40,7 +42,7 @@ export function AnimatedPoints({
 
     const frame = requestAnimationFrame(step);
     return () => cancelAnimationFrame(frame);
-  }, [value, durationMs]);
+  }, [value, from, durationMs]);
 
   return (
     <span className={className}>


### PR DESCRIPTION
## Resumen
- Arregla la visualización de la lista de pedidos en /cuenta/pedidos
- Corrige el cálculo y visualización del nuevo balance de puntos en /checkout/gracias

## Cambios

### /cuenta/pedidos
- src/app/cuenta/pedidos/page.tsx:
  - Asegura que cuando se cargan órdenes automáticamente (usuario autenticado), se establezca orders como array vacío si no hay pedidos, para mostrar el empty state correctamente.
  - En handleSubmit, si no hay órdenes ni detalle, establece orders como array vacío.
  - Mejora la condición del empty state para verificar orders !== null en lugar de solo orders.

### /checkout/gracias
- src/app/checkout/gracias/GraciasContent.tsx:
  - Calcula correctamente el nuevo balance: 
ewBalance = previousBalance + earned
  - Si arned > 0: muestra \
Ganaste
X
puntos
con
esta
compra\ y \Tu
nuevo
balance
es
Y
puntos\ (animando de previousBalance a 
ewBalance)
  - La barra de puntos usa 
ewBalance como valor (no solo previousBalance)
  - Si arned === 0 y 
ewBalance > 0: muestra balance actual con mensaje de delay
  - Si 
ewBalance === 0: fallback al mensaje azul original

### AnimatedPoints
- src/components/ui/AnimatedPoints.tsx:
  - Añade prop opcional rom para animar desde un valor inicial diferente de 0
  - Permite animar desde el balance anterior hasta el nuevo balance

## QA
- pnpm lint (solo warnings preexistentes)
- pnpm typecheck
- pnpm build

## Confirmación
- No se modificó lógica de checkout, Stripe, Supabase ni SQL.
- Solo mejoras de frontend/TS.
