### PR TITLE
feat(account): improve loyalty bar animation and orders list

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -88,12 +88,15 @@ export default function PedidosPage() {
       const loyaltyData = await loyaltyResponse.json();
 
       if (ordersResponse.ok) {
-        if (ordersData.orders) {
+        if (ordersData.orders && Array.isArray(ordersData.orders)) {
           setOrders(ordersData.orders);
         } else {
           // Si no hay órdenes, establecer array vacío para mostrar empty state
           setOrders([]);
         }
+      } else {
+        // Si la respuesta no es ok, establecer array vacío para evitar mostrar datos incorrectos
+        setOrders([]);
       }
 
       if (loyaltyResponse.ok && loyaltyData) {

--- a/src/components/ui/LoyaltyPointsBar.tsx
+++ b/src/components/ui/LoyaltyPointsBar.tsx
@@ -16,21 +16,26 @@ export function LoyaltyPointsBar({
   max = 5000,
   className,
 }: LoyaltyPointsBarProps) {
-  const [displayPercent, setDisplayPercent] = useState(0);
+  const [progress, setProgress] = useState(0);
 
   useEffect(() => {
     // Si value <= 0, no animar
-    if (value <= 0) {
-      setDisplayPercent(0);
+    if (!value || value <= 0) {
+      setProgress(0);
       return;
     }
 
     // Calcular porcentaje
     const safeMax = Math.max(max, value || 0, 1);
-    const percentage = Math.min(100, (value / safeMax) * 100);
+    const percentage = Math.min(100, Math.max(0, (value / safeMax) * 100));
 
-    // Animar desde 0 hasta el porcentaje final
-    setDisplayPercent(percentage);
+    // Truco para que la transición se vea: resetear a 0 y luego animar al porcentaje final
+    setProgress(0);
+    const id = requestAnimationFrame(() => {
+      setProgress(percentage);
+    });
+
+    return () => cancelAnimationFrame(id);
   }, [value, max]);
 
   // Si value <= 0, no renderizar
@@ -46,7 +51,7 @@ export function LoyaltyPointsBar({
     >
       <div
         className="h-full bg-emerald-500 rounded-full transition-all duration-500 ease-out"
-        style={{ width: `${displayPercent}%` }}
+        style={{ width: `${progress}%` }}
       />
     </div>
   );


### PR DESCRIPTION
## Resumen
- Mejora la animación de LoyaltyPointsBar para que se vea claramente desde 0%
- Corrige el manejo de la respuesta de la API en /cuenta/pedidos para asegurar que los pedidos se muestren correctamente

## Cambios

### LoyaltyPointsBar
- src/components/ui/LoyaltyPointsBar.tsx:
  - Cambia el estado de displayPercent a progress para mayor claridad
  - Implementa el truco de equestAnimationFrame para resetear a 0% y luego animar al porcentaje final
  - Esto asegura que la animación se vea claramente cada vez que cambia el valor
  - La barra ahora siempre empieza en 0% y se anima hasta el porcentaje final

### /cuenta/pedidos
- src/app/cuenta/pedidos/page.tsx:
  - En handleAutoLoad: verifica que ordersData.orders sea un array antes de establecerlo
  - Si la respuesta es exitosa pero no tiene orders, establece orders = [] para mostrar el empty state
  - Si la respuesta no es ok, también establece orders = [] para evitar mostrar datos incorrectos
  - Esto asegura que la lista de pedidos se muestre correctamente cuando el usuario autenticado tiene pedidos

## QA
- pnpm lint (solo warnings preexistentes)
- pnpm typecheck
- pnpm build

## Confirmación
- No se modificó lógica de checkout, Stripe, Supabase ni SQL.
- Solo mejoras de frontend/TS.
