### PR TITLE
fix(account): show orders list correctly on account page

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -95,8 +95,12 @@ export default function PedidosPage() {
           setOrders([]);
         }
       } else {
-        // Si la respuesta no es ok, establecer array vacío para evitar mostrar datos incorrectos
+        // Si la respuesta no es ok, establecer array vacío y mostrar mensaje para evitar confusiones
         setOrders([]);
+        setError(
+          ordersData.error ||
+            "Hubo un problema al cargar tus pedidos automáticamente. Intenta de nuevo.",
+        );
       }
 
       if (loyaltyResponse.ok && loyaltyData) {


### PR DESCRIPTION
## Resumen\n- corrige /api/account/orders para que use solo orders/order_items y maneje errores de tablas faltantes\n- maneja errores controlados al migrar carritos when la tabla carts no existe\n- mejora el autoload de /cuenta/pedidos para que muestre mensaje si la API responde con error\n\n## QA\n- pnpm lint\n- pnpm typecheck\n- pnpm build