### PR TITLE
fix(pedidos): use full UUID for detail, shortId for display

### DIFF
--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -535,7 +535,7 @@ export default function PedidosPage() {
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
                         <span className="font-mono text-sm text-gray-500">
-                          {order.id.substring(0, 8)}...
+                          {order.shortId}
                         </span>
                         <span
                           className={`px-2 py-1 rounded text-xs font-medium ${
@@ -615,7 +615,7 @@ export default function PedidosPage() {
                         onClick={() => handleViewDetail(order.id)}
                         disabled={loadingDetail && selectedOrderId === order.id}
                         className="mt-2 text-sm text-primary-600 hover:text-primary-700 underline disabled:opacity-50 disabled:cursor-not-allowed"
-                        aria-label={`Ver detalle del pedido ${order.id.substring(0, 8)}`}
+                        aria-label={`Ver detalle del pedido ${order.shortId}`}
                       >
                         {loadingDetail && selectedOrderId === order.id
                           ? "Cargando detalle..."

--- a/src/lib/supabase/orders.server.ts
+++ b/src/lib/supabase/orders.server.ts
@@ -6,7 +6,8 @@ import type { PostgrestError } from "@supabase/supabase-js";
  * Tipos para órdenes y items
  */
 export type OrderSummary = {
-  id: string;
+  id: string; // UUID completo de Supabase
+  shortId: string; // Versión truncada para mostrar en UI (ej: "702693b3…")
   created_at: string;
   status: string;
   email: string;
@@ -134,7 +135,8 @@ export async function getOrdersByEmail(
   }
 
   return (data || []).map((order) => ({
-    id: order.id,
+    id: order.id, // UUID completo - NUNCA truncar
+    shortId: `${order.id.slice(0, 8)}…`, // Versión truncada solo para UI
     created_at: order.created_at,
     status: order.status,
     email: order.email || normalizedEmail || "",
@@ -282,7 +284,8 @@ export async function getOrderWithItems(
     }
 
     return {
-      id: orderData.id,
+      id: orderData.id, // UUID completo - NUNCA truncar
+      shortId: `${orderData.id.slice(0, 8)}…`, // Versión truncada solo para UI
       created_at: orderData.created_at,
       status: orderData.status,
       email: orderData.email || normalizedEmail || "",


### PR DESCRIPTION
Fix: detalle de pedido usando el UUID completo de la orden y no un ID truncado. La lista de pedidos muestra shortId en la UI, pero el botón 'Ver detalle' siempre envía el UUID completo. QA: lint/typecheck/build pasan.