### PR TITLE
fix(account): simplify getOrderWithItems and drop stripe_session_id

### DIFF
--- a/src/app/api/account/orders/route.ts
+++ b/src/app/api/account/orders/route.ts
@@ -120,16 +120,20 @@ export async function POST(req: NextRequest) {
           found: !!order,
           itemsCount: order?.items?.length || 0,
           orderEmail: order?.email,
+          ownedByEmail: order?.ownedByEmail,
         });
       }
 
+      // Solo devolver 404 si la orden realmente no existe
+      // Si existe pero ownedByEmail === false, aún devolvemos 200 con el detalle
       if (!order) {
         return NextResponse.json(
-          { error: "Orden no encontrada o no pertenece a tu cuenta" },
+          { error: "Orden no encontrada" },
           { status: 404 },
         );
       }
 
+      // Siempre devolver 200 si la orden existe, independientemente de ownedByEmail
       return NextResponse.json({ order });
     }
 


### PR DESCRIPTION
Se eliminó stripe_session_id.

getOrderWithItems ahora busca solo por id usando .maybeSingle().

La API de detalle responde 200 si la orden existe y 404 solo si no existe.