### PR TITLE
feat: refine Skydropx rates and improve admin shipping

### DIFF
--- a/src/app/admin/pedidos/AdminPedidosClient.tsx
+++ b/src/app/admin/pedidos/AdminPedidosClient.tsx
@@ -252,7 +252,24 @@ export default function AdminPedidosClient({
                       </span>
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
-                      {formatShippingMethod(order.metadata?.shipping_method)}
+                      {order.shipping_provider === "pickup" ? (
+                        <span className="text-gray-700">Recoger en tienda · $0</span>
+                      ) : order.shipping_provider === "skydropx" ? (
+                        <div>
+                          <div className="font-medium text-gray-900">
+                            {order.shipping_service_name || "Skydropx"}
+                          </div>
+                          {order.shipping_price_cents !== null && (
+                            <div className="text-xs text-gray-500">
+                              {formatMXNFromCents(order.shipping_price_cents)}
+                            </div>
+                          )}
+                        </div>
+                      ) : order.metadata?.shipping_method ? (
+                        formatShippingMethod(order.metadata.shipping_method)
+                      ) : (
+                        <span className="text-gray-400">N/A</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-right">
                       {order.total_cents !== null

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -261,133 +261,96 @@ export default async function AdminPedidoDetailPage({
           </div>
         )}
 
-        {/* Envío Skydropx */}
+        {/* Datos de envío */}
         <div className="px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold mb-3">Envío Skydropx</h2>
-          {(() => {
-            const metadata = (order.metadata || {}) as Record<string, unknown>;
-            const shipping = metadata.shipping as
-              | {
-                  provider?: string;
-                  option_code?: string;
-                  price_cents?: number;
-                  rate?: {
-                    external_id?: string;
-                    provider?: string;
-                    service?: string;
-                    eta_min_days?: number | null;
-                    eta_max_days?: number | null;
-                  };
-                  shipment?: {
-                    id?: string;
-                    tracking_number?: string;
-                    label_url?: string;
-                  };
-                }
-              | undefined;
-
-            // Si existe shipment, mostrar información de guía creada
-            if (shipping?.shipment) {
-              return (
-                <div className="space-y-3">
-                  <div className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-sm font-medium text-green-800">
-                    Guía creada
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <p className="text-gray-600">Proveedor</p>
-                      <p className="font-medium">Skydropx</p>
-                    </div>
-                    {shipping.rate?.provider && (
-                      <div>
-                        <p className="text-gray-600">Carrier/Servicio</p>
-                        <p className="font-medium">{shipping.rate.provider}</p>
-                      </div>
-                    )}
-                    {shipping.shipment.tracking_number && (
-                      <div>
-                        <p className="text-gray-600">Tracking Number</p>
-                        <p className="font-medium font-mono">
-                          {shipping.shipment.tracking_number}
-                        </p>
-                      </div>
-                    )}
-                    {shipping.shipment.label_url && (
-                      <div>
-                        <p className="text-gray-600">Guía PDF</p>
-                        <Link
-                          href={shipping.shipment.label_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-primary-600 hover:text-primary-700 underline"
-                        >
-                          Ver guía PDF
-                        </Link>
-                      </div>
-                    )}
-                  </div>
+          <h2 className="text-lg font-semibold mb-3">Datos de envío</h2>
+          {order.shipping_provider ? (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <p className="text-gray-600">Proveedor</p>
+                  <p className="font-medium">
+                    {order.shipping_provider === "pickup"
+                      ? "Recoger en tienda"
+                      : order.shipping_provider === "skydropx"
+                        ? "Skydropx"
+                        : order.shipping_provider}
+                  </p>
                 </div>
-              );
-            }
-
-            // Si hay información de tarifa pero no shipment, mostrar resumen y botón
-            if (shipping?.rate) {
-              return (
-                <div className="space-y-3">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <p className="text-gray-600">Proveedor</p>
-                      <p className="font-medium">Skydropx</p>
-                    </div>
-                    {shipping.rate.service && (
-                      <div>
-                        <p className="text-gray-600">Servicio</p>
-                        <p className="font-medium">{shipping.rate.service}</p>
-                      </div>
-                    )}
-                    {typeof shipping.price_cents === "number" && (
-                      <div>
-                        <p className="text-gray-600">Precio</p>
-                        <p className="font-medium">
-                          {formatMXNFromCents(shipping.price_cents)}
-                        </p>
-                      </div>
-                    )}
-                    {(shipping.rate.eta_min_days ||
-                      shipping.rate.eta_max_days) && (
-                      <div>
-                        <p className="text-gray-600">Tiempo estimado</p>
-                        <p className="font-medium">
-                          {shipping.rate.eta_min_days &&
-                          shipping.rate.eta_max_days
-                            ? `${shipping.rate.eta_min_days}-${shipping.rate.eta_max_days} días`
-                            : shipping.rate.eta_min_days
-                              ? `${shipping.rate.eta_min_days}+ días`
-                              : ""}
-                        </p>
-                      </div>
-                    )}
+                {order.shipping_service_name && (
+                  <div>
+                    <p className="text-gray-600">Servicio</p>
+                    <p className="font-medium">{order.shipping_service_name}</p>
                   </div>
+                )}
+                {order.shipping_price_cents !== null && (
+                  <div>
+                    <p className="text-gray-600">Precio</p>
+                    <p className="font-medium">
+                      {formatMXNFromCents(order.shipping_price_cents)}
+                    </p>
+                  </div>
+                )}
+                {(order.shipping_eta_min_days || order.shipping_eta_max_days) && (
+                  <div>
+                    <p className="text-gray-600">Tiempo estimado</p>
+                    <p className="font-medium">
+                      {order.shipping_eta_min_days && order.shipping_eta_max_days
+                        ? `${order.shipping_eta_min_days}-${order.shipping_eta_max_days} días`
+                        : order.shipping_eta_min_days
+                          ? `${order.shipping_eta_min_days}+ días`
+                          : ""}
+                    </p>
+                  </div>
+                )}
+                {order.shipping_status && (
+                  <div>
+                    <p className="text-gray-600">Estado</p>
+                    <p className="font-medium">{order.shipping_status}</p>
+                  </div>
+                )}
+                {order.shipping_tracking_number && (
+                  <div>
+                    <p className="text-gray-600">Número de guía</p>
+                    <p className="font-medium font-mono">
+                      {order.shipping_tracking_number}
+                    </p>
+                  </div>
+                )}
+                {order.shipping_label_url && (
+                  <div>
+                    <p className="text-gray-600">Etiqueta PDF</p>
+                    <Link
+                      href={order.shipping_label_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary-600 hover:text-primary-700 underline"
+                    >
+                      Ver etiqueta PDF
+                    </Link>
+                  </div>
+                )}
+              </div>
+
+              {/* Botón para crear guía si es Skydropx y no tiene tracking */}
+              {order.shipping_provider === "skydropx" &&
+                order.shipping_rate_ext_id &&
+                !order.shipping_tracking_number && (
                   <form action={createSkydropxLabelAction.bind(null, order.id)}>
                     <button
                       type="submit"
                       className="mt-4 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors font-medium"
                     >
-                      Crear guía Skydropx
+                      Crear guía en Skydropx
                     </button>
                   </form>
-                </div>
-              );
-            }
-
-            // Si no hay información de shipping
-            return (
-              <p className="text-sm text-gray-500">
-                Esta orden no tiene información de envío calculada. Revisa el
-                checkout.
-              </p>
-            );
-          })()}
+                )}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">
+              Esta orden no tiene información de envío. Revisa el checkout.
+            </p>
+          )}
         </div>
 
         {/* Productos */}

--- a/src/app/checkout/datos/ClientPage.tsx
+++ b/src/app/checkout/datos/ClientPage.tsx
@@ -946,46 +946,100 @@ function DatosPageContent() {
                 </p>
               )}
               {!loadingRates && shippingOptions && shippingOptions.length > 0 && (
-                <div className="space-y-2">
-                  {shippingOptions.map((option) => (
-                    <label
-                      key={option.code}
-                      className={`flex items-center p-3 border rounded-lg cursor-pointer transition-colors ${
-                        selectedShippingOption?.code === option.code
-                          ? "border-primary-500 bg-primary-50"
-                          : "border-gray-200 hover:border-gray-300"
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="shippingOption"
-                        value={option.code}
-                        checked={selectedShippingOption?.code === option.code}
-                        onChange={() => {
-                          setSelectedShippingOption(option);
-                          // Establecer método de envío basado en el label (standard o express)
-                          const method = option.label.toLowerCase().includes("express") ? "express" : "standard";
-                          setShipping(method, option.priceCents / 100);
-                        }}
-                        className="mr-3 h-4 w-4 text-primary-600 focus:ring-primary-500"
-                      />
-                      <div className="flex-1">
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium text-gray-900">
-                            {option.label}
-                          </span>
-                          <span className="text-sm font-semibold text-gray-900">
-                            {formatMXNMoney(option.priceCents / 100)}
-                          </span>
+                <div className="space-y-4">
+                  {/* Opción recomendada (primera) */}
+                  {shippingOptions.length > 0 && (
+                    <div>
+                      <h4 className="text-xs font-semibold text-primary-600 mb-2 uppercase tracking-wide">
+                        Recomendado
+                      </h4>
+                      <label
+                        key={shippingOptions[0].code}
+                        className={`flex items-center p-3 border-2 rounded-lg cursor-pointer transition-colors ${
+                          selectedShippingOption?.code === shippingOptions[0].code
+                            ? "border-primary-500 bg-primary-50"
+                            : "border-primary-200 hover:border-primary-300"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="shippingOption"
+                          value={shippingOptions[0].code}
+                          checked={selectedShippingOption?.code === shippingOptions[0].code}
+                          onChange={() => {
+                            setSelectedShippingOption(shippingOptions[0]);
+                            // Usar "standard" como método cuando es Skydropx
+                            setShipping("standard", shippingOptions[0].priceCents / 100);
+                          }}
+                          className="mr-3 h-4 w-4 text-primary-600 focus:ring-primary-500"
+                        />
+                        <div className="flex-1">
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm font-medium text-gray-900">
+                              {shippingOptions[0].label}
+                            </span>
+                            <span className="text-sm font-semibold text-gray-900">
+                              {formatMXNMoney(shippingOptions[0].priceCents / 100)}
+                            </span>
+                          </div>
+                          {shippingOptions[0].etaMinDays && shippingOptions[0].etaMaxDays && (
+                            <p className="text-xs text-gray-500 mt-1">
+                              Tiempo estimado: {shippingOptions[0].etaMinDays}-{shippingOptions[0].etaMaxDays} días
+                            </p>
+                          )}
                         </div>
-                        {option.etaMinDays && option.etaMaxDays && (
-                          <p className="text-xs text-gray-500 mt-1">
-                            Tiempo estimado: {option.etaMinDays}-{option.etaMaxDays} días
-                          </p>
-                        )}
+                      </label>
+                    </div>
+                  )}
+
+                  {/* Otras opciones (resto) */}
+                  {shippingOptions.length > 1 && (
+                    <div>
+                      <h4 className="text-xs font-semibold text-gray-600 mb-2 uppercase tracking-wide">
+                        Otras opciones de paquetería
+                      </h4>
+                      <div className="space-y-2">
+                        {shippingOptions.slice(1).map((option) => (
+                          <label
+                            key={option.code}
+                            className={`flex items-center p-3 border rounded-lg cursor-pointer transition-colors ${
+                              selectedShippingOption?.code === option.code
+                                ? "border-primary-500 bg-primary-50"
+                                : "border-gray-200 hover:border-gray-300"
+                            }`}
+                          >
+                            <input
+                              type="radio"
+                              name="shippingOption"
+                              value={option.code}
+                              checked={selectedShippingOption?.code === option.code}
+                              onChange={() => {
+                                setSelectedShippingOption(option);
+                                // Usar "standard" como método cuando es Skydropx
+                                setShipping("standard", option.priceCents / 100);
+                              }}
+                              className="mr-3 h-4 w-4 text-primary-600 focus:ring-primary-500"
+                            />
+                            <div className="flex-1">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-gray-900">
+                                  {option.label}
+                                </span>
+                                <span className="text-sm font-semibold text-gray-900">
+                                  {formatMXNMoney(option.priceCents / 100)}
+                                </span>
+                              </div>
+                              {option.etaMinDays && option.etaMaxDays && (
+                                <p className="text-xs text-gray-500 mt-1">
+                                  Tiempo estimado: {option.etaMinDays}-{option.etaMaxDays} días
+                                </p>
+                              )}
+                            </div>
+                          </label>
+                        ))}
                       </div>
-                    </label>
-                  ))}
+                    </div>
+                  )}
                 </div>
               )}
               {!loadingRates && (!shippingOptions || shippingOptions.length === 0) && !ratesError && (

--- a/src/lib/actions/shipping.admin.ts
+++ b/src/lib/actions/shipping.admin.ts
@@ -2,170 +2,56 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { getOrderWithItemsAdmin } from "@/lib/supabase/orders.server";
-import { createSkydropxShipment } from "@/lib/shipping/skydropx.server";
-import { createClient } from "@supabase/supabase-js";
 
 /**
  * Crea una guía de envío en Skydropx para una orden
+ * Usa el endpoint interno /api/shipping/create-shipment
  */
 export async function createSkydropxLabelAction(
   orderId: string,
   _formData: FormData,
 ): Promise<void> {
-  // Obtener orden
-  const order = await getOrderWithItemsAdmin(orderId);
+  try {
+    // Llamar al endpoint interno
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.VERCEL_URL 
+      ? `https://${process.env.VERCEL_URL}` 
+      : "http://localhost:3000";
+    
+    const response = await fetch(`${baseUrl}/api/shipping/create-shipment`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ orderId }),
+    });
 
-  if (!order) {
-    redirect(`/admin/pedidos/${orderId}?error=orden_no_encontrada`);
-    return;
+    const data = await response.json().catch(() => ({ ok: false, reason: "unknown_error" }));
+
+    if (!data.ok) {
+      // Mapear razones de error a mensajes de query string
+      const errorMap: Record<string, string> = {
+        invalid_order_id: "orden_no_encontrada",
+        order_not_found: "orden_no_encontrada",
+        unsupported_provider: "proveedor_no_soportado",
+        missing_shipping_rate: "rate_id_no_encontrado",
+        missing_address_data: "direccion_incompleta",
+        skydropx_error: "skydropx_label_failed",
+        unknown_error: "error_desconocido",
+      };
+      
+      const errorKey = errorMap[data.reason || "unknown_error"] || "error_desconocido";
+      redirect(`/admin/pedidos/${orderId}?error=${errorKey}`);
+      return;
+    }
+
+    // Revalidar rutas
+    revalidatePath("/admin/pedidos");
+    revalidatePath(`/admin/pedidos/${orderId}`);
+
+    redirect(`/admin/pedidos/${orderId}?success=skydropx_label_created`);
+  } catch (error) {
+    console.error("[createSkydropxLabelAction] Error inesperado:", error);
+    redirect(`/admin/pedidos/${orderId}?error=error_desconocido`);
   }
-
-  // Extraer datos de dirección desde metadata
-  const metadata = (order.metadata || {}) as Record<string, unknown>;
-  const shipping = metadata.shipping as
-    | {
-        provider?: string;
-        option_code?: string;
-        price_cents?: number;
-        rate?: {
-          external_id?: string;
-          provider?: string;
-          service?: string;
-          eta_min_days?: number | null;
-          eta_max_days?: number | null;
-        };
-      }
-    | undefined;
-
-  const contactName =
-    (metadata.contact_name as string) ||
-    order.shipping?.contact_name ||
-    "";
-  const contactPhone =
-    (metadata.contact_phone as string) ||
-    order.shipping?.contact_phone ||
-    "";
-  const contactAddress =
-    (metadata.contact_address as string) ||
-    order.shipping?.contact_address ||
-    "";
-  const contactCity =
-    (metadata.contact_city as string) || order.shipping?.contact_city || "";
-  const contactState =
-    (metadata.contact_state as string) || order.shipping?.contact_state || "";
-  const contactCp =
-    (metadata.contact_cp as string) || "";
-
-  // Validar que tengamos datos mínimos
-  if (!contactCp || !contactState || !contactCity) {
-    redirect(
-      `/admin/pedidos/${orderId}?error=direccion_incompleta`,
-    );
-    return;
-  }
-
-  // Obtener rate_id desde shipping.rate o recalcular
-  const rateId: string | undefined = shipping?.rate?.external_id;
-
-  // Si no hay rate_id guardado, intentar recalcular (fallback documentado)
-  if (!rateId) {
-    // Por ahora, requerir que exista rate_id en metadata
-    // En el futuro se podría recalcular llamando a getSkydropxRates
-    redirect(
-      `/admin/pedidos/${orderId}?error=rate_id_no_encontrado`,
-    );
-    return;
-  }
-
-  // Calcular peso aproximado del carrito (1kg por producto como default)
-  const totalWeightGrams = order.items.reduce((sum, item) => {
-    return sum + (item.qty || 1) * 1000;
-  }, 0);
-
-  // Crear envío en Skydropx
-  const result = await createSkydropxShipment({
-    rateId,
-    destination: {
-      postalCode: contactCp,
-      state: contactState,
-      city: contactCity,
-      country: "MX",
-      name: contactName,
-      phone: contactPhone || undefined,
-      email: order.email || undefined,
-      addressLine1: contactAddress || undefined,
-    },
-    pkg: {
-      weightGrams: totalWeightGrams || 1000,
-      // Dimensiones por defecto: 20x20x10 cm
-      lengthCm: 20,
-      widthCm: 20,
-      heightCm: 10,
-    },
-  });
-
-  if (!result.success) {
-    redirect(
-      `/admin/pedidos/${orderId}?error=skydropx_label_failed`,
-    );
-    return;
-  }
-
-  // Actualizar orden en Supabase con información del envío
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!supabaseUrl || !serviceRoleKey) {
-    redirect(
-      `/admin/pedidos/${orderId}?error=configuracion_supabase`,
-    );
-    return;
-  }
-
-  const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  });
-
-  // Actualizar metadata.shipping con información del shipment
-  const updatedShipping = {
-    ...shipping,
-    provider: "skydropx",
-    shipment: {
-      id: result.shipmentId,
-      tracking_number: result.trackingNumber || "",
-      label_url: result.labelUrl || "",
-    },
-  };
-
-  const updatedMetadata = {
-    ...metadata,
-    shipping: updatedShipping,
-  };
-
-  const { error: updateError } = await supabase
-    .from("orders")
-    .update({
-      metadata: updatedMetadata,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", orderId);
-
-  if (updateError) {
-    console.error("[createSkydropxLabelAction] Error al actualizar orden:", updateError);
-    redirect(
-      `/admin/pedidos/${orderId}?error=error_actualizar_orden`,
-    );
-    return;
-  }
-
-  // Revalidar rutas
-  revalidatePath("/admin/pedidos");
-  revalidatePath(`/admin/pedidos/${orderId}`);
-
-  redirect(`/admin/pedidos/${orderId}?success=skydropx_label_created`);
 }
 

--- a/src/lib/supabase/orders.server.ts
+++ b/src/lib/supabase/orders.server.ts
@@ -29,6 +29,15 @@ export type OrderSummary = {
     loyalty_points_spent?: number | null;
     loyalty_points_balance_after?: number | null;
   } | null;
+  shipping_provider: string | null;
+  shipping_service_name: string | null;
+  shipping_price_cents: number | null;
+  shipping_rate_ext_id: string | null;
+  shipping_eta_min_days: number | null;
+  shipping_eta_max_days: number | null;
+  shipping_tracking_number: string | null;
+  shipping_label_url: string | null;
+  shipping_status: string | null;
 };
 
 export type ShippingInfo = {
@@ -119,7 +128,7 @@ export async function getOrdersByEmail(
 
   const { data, error } = await supabase
     .from("orders")
-    .select("id, created_at, status, email, total_cents, metadata")
+    .select("id, created_at, status, email, total_cents, metadata, shipping_provider, shipping_service_name, shipping_price_cents, shipping_rate_ext_id, shipping_eta_min_days, shipping_eta_max_days, shipping_tracking_number, shipping_label_url, shipping_status")
     .eq("email", normalizedEmail)
     .order("created_at", { ascending: false })
     .limit(limit);
@@ -167,6 +176,15 @@ export async function getOrdersByEmail(
     email: order.email || normalizedEmail || "",
     total_cents: order.total_cents,
     metadata: (order.metadata as OrderSummary["metadata"]) || null,
+    shipping_provider: order.shipping_provider || null,
+    shipping_service_name: order.shipping_service_name || null,
+    shipping_price_cents: order.shipping_price_cents || null,
+    shipping_rate_ext_id: order.shipping_rate_ext_id || null,
+    shipping_eta_min_days: order.shipping_eta_min_days || null,
+    shipping_eta_max_days: order.shipping_eta_max_days || null,
+    shipping_tracking_number: order.shipping_tracking_number || null,
+    shipping_label_url: order.shipping_label_url || null,
+    shipping_status: order.shipping_status || null,
   }));
 }
 
@@ -205,7 +223,7 @@ export async function getOrderWithItems(
     // Buscar orden por id (UNA sola búsqueda)
     const { data: orderData, error } = await supabase
       .from("orders")
-      .select("id, created_at, status, email, total_cents, metadata")
+      .select("id, created_at, status, email, total_cents, metadata, shipping_provider, shipping_service_name, shipping_price_cents, shipping_rate_ext_id, shipping_eta_min_days, shipping_eta_max_days, shipping_tracking_number, shipping_label_url, shipping_status")
       .eq("id", normalizedOrderId)
       .maybeSingle();
 
@@ -278,6 +296,15 @@ export async function getOrderWithItems(
       metadata: (orderData.metadata as OrderSummary["metadata"]) || null,
       items,
       ownedByEmail, // Flag que indica si el email coincide (true/false/null)
+      shipping_provider: orderData.shipping_provider || null,
+      shipping_service_name: orderData.shipping_service_name || null,
+      shipping_price_cents: orderData.shipping_price_cents || null,
+      shipping_rate_ext_id: orderData.shipping_rate_ext_id || null,
+      shipping_eta_min_days: orderData.shipping_eta_min_days || null,
+      shipping_eta_max_days: orderData.shipping_eta_max_days || null,
+      shipping_tracking_number: orderData.shipping_tracking_number || null,
+      shipping_label_url: orderData.shipping_label_url || null,
+      shipping_status: orderData.shipping_status || null,
     };
   } catch (err) {
     console.error("[getOrderWithItems] Error inesperado:", err);
@@ -312,7 +339,7 @@ export async function getAllOrdersAdmin(
   try {
     let query = supabase
       .from("orders")
-      .select("id, created_at, status, email, total_cents, metadata", {
+      .select("id, created_at, status, email, total_cents, metadata, shipping_provider, shipping_service_name, shipping_price_cents, shipping_rate_ext_id, shipping_eta_min_days, shipping_eta_max_days, shipping_tracking_number, shipping_label_url, shipping_status", {
         count: "exact",
       });
 
@@ -369,6 +396,15 @@ export async function getAllOrdersAdmin(
       email: order.email || "",
       total_cents: order.total_cents,
       metadata: (order.metadata as OrderSummary["metadata"]) || null,
+      shipping_provider: order.shipping_provider || null,
+      shipping_service_name: order.shipping_service_name || null,
+      shipping_price_cents: order.shipping_price_cents || null,
+      shipping_rate_ext_id: order.shipping_rate_ext_id || null,
+      shipping_eta_min_days: order.shipping_eta_min_days || null,
+      shipping_eta_max_days: order.shipping_eta_max_days || null,
+      shipping_tracking_number: order.shipping_tracking_number || null,
+      shipping_label_url: order.shipping_label_url || null,
+      shipping_status: order.shipping_status || null,
     }));
 
     return {
@@ -411,7 +447,7 @@ export async function getOrderWithItemsAdmin(
     // Buscar orden por id
     const { data: orderData, error } = await supabase
       .from("orders")
-      .select("id, created_at, status, email, total_cents, metadata")
+      .select("id, created_at, status, email, total_cents, metadata, shipping_provider, shipping_service_name, shipping_price_cents, shipping_rate_ext_id, shipping_eta_min_days, shipping_eta_max_days, shipping_tracking_number, shipping_label_url, shipping_status")
       .eq("id", normalizedOrderId)
       .maybeSingle();
 
@@ -524,6 +560,15 @@ export async function getOrderWithItemsAdmin(
       items,
       ownedByEmail: null, // No aplica en admin
       shipping,
+      shipping_provider: orderData.shipping_provider || null,
+      shipping_service_name: orderData.shipping_service_name || null,
+      shipping_price_cents: orderData.shipping_price_cents || null,
+      shipping_rate_ext_id: orderData.shipping_rate_ext_id || null,
+      shipping_eta_min_days: orderData.shipping_eta_min_days || null,
+      shipping_eta_max_days: orderData.shipping_eta_max_days || null,
+      shipping_tracking_number: orderData.shipping_tracking_number || null,
+      shipping_label_url: orderData.shipping_label_url || null,
+      shipping_status: orderData.shipping_status || null,
     };
   } catch (err) {
     console.error("[getOrderWithItemsAdmin] Error inesperado:", err);


### PR DESCRIPTION
Este PR refina la integración de Skydropx y mejora el panel de pedidos admin.

### Cambios principales

1) Filtrado y selección curada de tarifas Skydropx
- Filtra tarifas no válidas (not_applicable, no_coverage, pallet, total = 0).
- Usa lista blanca de proveedores: fedex, dhl, estafeta, paquetexpress, coordinadora.
- Prefiere servicios con pickup disponible.
- Ordena por días (ETA) y precio, y expone:
  - Opción recomendada
  - Opción más rápida
  - Opción más barata

2) Mejora de UI en /checkout/datos
- Sección \"Recomendado\" para la mejor opción.
- Sección \"Otras opciones de paquetería\" para el resto.
- \"Recoger en tienda\" se mantiene siempre disponible como opción aparte.

3) Panel admin de pedidos mejorado
- Tabla de pedidos muestra columna \"Envío\" con proveedor, servicio y precio.
- Detalle de pedido muestra bloque \"Datos de envío\" con:
  - provider, servicio, precio, ETA, estado, tracking y link a label.
- Botón \"Crear guía en Skydropx\" cuando:
  - shipping_provider = 'skydropx'
  - shipping_rate_ext_id no es null
  - shipping_tracking_number es null

### Verificaciones

- ✅ pnpm lint (solo warnings preexistentes)
- ✅ pnpm typecheck
- ✅ pnpm build

### Checklist de pruebas manuales

- [ ] Probar checkout completo con dirección válida y verificar que aparezcan opciones de Skydropx
- [ ] Verificar que la opción \"Recomendado\" se muestre destacada
- [ ] Verificar que \"Recoger en tienda\" esté siempre disponible
- [ ] Probar crear una orden con Skydropx y verificar que se guarden los campos de shipping
- [ ] En panel admin, verificar que la columna \"Envío\" muestre información correcta
- [ ] En detalle de pedido, verificar que el bloque \"Datos de envío\" muestre toda la información
- [ ] Probar el botón \"Crear guía en Skydropx\" y verificar que se cree la guía y se actualice la orden