### PR TITLE
feat: refine manual payments and re-enable free shipping promo

### DIFF
--- a/ops/sql/2025-01-XX_add_payment_fields_to_orders.sql
+++ b/ops/sql/2025-01-XX_add_payment_fields_to_orders.sql
@@ -8,8 +8,11 @@ ALTER TABLE public.orders
   ADD COLUMN IF NOT EXISTS payment_status TEXT;
 
 -- Comentarios para documentación
-COMMENT ON COLUMN public.orders.payment_method IS 'Método de pago utilizado: "card" (Stripe), "bank_transfer" (transferencia), "cash" (efectivo)';
-COMMENT ON COLUMN public.orders.payment_status IS 'Estado del pago: "pending", "paid", "canceled"';
+COMMENT ON COLUMN public.orders.payment_method IS
+  'Método de pago utilizado: "card" (Stripe), "bank_transfer" (transferencia/depósito)';
+
+COMMENT ON COLUMN public.orders.payment_status IS
+  'Estado del pago: "pending", "paid", "canceled"';
 
 -- Actualizar pedidos existentes con Stripe para que tengan payment_method = "card" y payment_status = "paid"
 -- Solo si tienen stripe_session_id y status = "paid"

--- a/src/app/api/checkout/create-order/route.ts
+++ b/src/app/api/checkout/create-order/route.ts
@@ -27,7 +27,7 @@ const CreateOrderRequestSchema = z.object({
   shippingMethod: z.enum(["pickup", "standard", "express"]).optional(),
   shippingCostCents: z.number().int().nonnegative().optional(), // Costo de envío en centavos
   // Método y estado de pago
-  paymentMethod: z.enum(["card", "bank_transfer", "cash"]).optional(),
+  paymentMethod: z.enum(["card", "bank_transfer"]).optional(),
   paymentStatus: z.enum(["pending", "paid", "canceled"]).optional(),
   // Información de Skydropx opcional
   shipping: z.object({

--- a/src/app/checkout/datos/ClientPage.tsx
+++ b/src/app/checkout/datos/ClientPage.tsx
@@ -262,6 +262,12 @@ function DatosPageContent() {
           return sum + (item.qty || 1) * 1000; // 1kg por producto
         }, 0);
 
+        // Calcular subtotal en centavos para aplicar promo de envío gratis
+        const subtotalCents = selectedItems.reduce((sum, item) => {
+          const priceCents = typeof item.price_cents === "number" ? item.price_cents : typeof item.price === "number" ? Math.round(item.price * 100) : 0;
+          return sum + priceCents * (item.qty || 1);
+        }, 0);
+
         const response = await fetch("/api/shipping/rates", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -273,6 +279,7 @@ function DatosPageContent() {
               country: "MX",
             },
             totalWeightGrams: totalWeightGrams || 1000,
+            subtotalCents,
           }),
           signal: controller.signal,
         });
@@ -975,9 +982,21 @@ function DatosPageContent() {
                         />
                         <div className="flex-1">
                           <div className="flex items-center justify-between">
-                            <span className="text-sm font-medium text-gray-900">
-                              {shippingOptions[0].label}
-                            </span>
+                            <div>
+                              <span className="text-sm font-medium text-gray-900">
+                                Envío a domicilio (Skydropx)
+                              </span>
+                              {shippingOptions[0].priceCents === 0 && shippingOptions[0].originalPriceCents && (
+                                <p className="text-xs text-green-600 font-medium mt-0.5">
+                                  Envío GRATIS en pedidos desde $2,000 {shippingOptions[0].originalPriceCents > 0 && `(antes ${formatMXNMoney(shippingOptions[0].originalPriceCents / 100)})`}
+                                </p>
+                              )}
+                              {shippingOptions[0].priceCents === 0 && !shippingOptions[0].originalPriceCents && (
+                                <p className="text-xs text-green-600 font-medium mt-0.5">
+                                  Envío GRATIS en tu pedido
+                                </p>
+                              )}
+                            </div>
                             <span className="text-sm font-semibold text-gray-900">
                               {formatMXNMoney(shippingOptions[0].priceCents / 100)}
                             </span>

--- a/src/app/checkout/pago-pendiente/PagoPendienteClient.tsx
+++ b/src/app/checkout/pago-pendiente/PagoPendienteClient.tsx
@@ -97,7 +97,6 @@ export default function PagoPendienteClient() {
 
   const paymentMethod = order.payment_method;
   const isBankTransfer = paymentMethod === "bank_transfer";
-  const isCash = paymentMethod === "cash";
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
@@ -140,63 +139,70 @@ export default function PagoPendienteClient() {
           {/* Instrucciones según método */}
           {isBankTransfer && (
             <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-              <h2 className="font-semibold text-gray-900 mb-3">
-                Instrucciones para transferencia bancaria
+              <h2 className="text-xl font-semibold text-gray-900 mb-2">
+                Tu pedido fue registrado con pago pendiente
               </h2>
-              <div className="space-y-3 text-sm text-gray-700">
-                <p>
-                  <strong>1. Realiza la transferencia</strong>
-                </p>
-                <p>
-                  Transfiere el monto de <strong>{formatMXNFromCents(order.total_cents)}</strong> a la siguiente cuenta:
-                </p>
-                <div className="bg-white rounded-md p-4 border border-blue-300">
-                  <p className="font-medium mb-2">Datos bancarios:</p>
-                  <p>Banco: [Nombre del banco]</p>
-                  <p>CLABE: [CLABE]</p>
-                  <p>Cuenta: [Número de cuenta]</p>
-                  <p>Beneficiario: Depósito Dental Noriega</p>
+              <p className="text-sm text-gray-700 mb-4">
+                <strong>Método elegido:</strong> Transferencia / Depósito
+              </p>
+              <div className="space-y-4 text-sm text-gray-700">
+                <div>
+                  <p className="font-medium mb-2">
+                    <strong>1. Transfiere o deposita el total de tu pedido</strong>
+                  </p>
+                  <p className="mb-2">
+                    Monto a pagar: <strong>{formatMXNFromCents(order.total_cents)}</strong>
+                  </p>
+                  <div className="bg-white rounded-md p-4 border border-blue-300 mt-2">
+                    <p className="font-medium mb-2">Datos bancarios:</p>
+                    <ul className="list-disc list-inside space-y-1">
+                      <li>Banco: [TODO: completar en el futuro con datos reales]</li>
+                      <li>Cuenta/CLABE: [TODO]</li>
+                      <li>Beneficiario: Depósito Dental Noriega</li>
+                      <li>Referencia: Usa el ID de tu orden <span className="font-mono font-semibold">{order.id.slice(0, 8)}</span> o tu email <span className="font-semibold">{order.contact_email || "del pedido"}</span></li>
+                    </ul>
+                  </div>
                 </div>
-                <p>
-                  <strong>2. Envía el comprobante</strong>
-                </p>
-                <p>
-                  Una vez realizada la transferencia, envía el comprobante por WhatsApp o correo electrónico para que podamos confirmar tu pago y procesar tu pedido.
-                </p>
-                <p className="text-xs text-gray-600 mt-4">
-                  <strong>Nota:</strong> Tu pedido está reservado. En cuanto confirmemos tu pago, actualizaremos el estado a Pagado y procederemos con el envío.
+                <div>
+                  <p className="font-medium mb-2">
+                    <strong>2. Formas de realizar el depósito:</strong>
+                  </p>
+                  <ul className="list-disc list-inside space-y-1 ml-4">
+                    <li>Desde tu app bancaria (transferencia SPEI)</li>
+                    <li>En sucursal bancaria (ventanilla)</li>
+                    <li>En tiendas como Oxxo, 7-Eleven, etc., pidiendo depósito a cuenta/CLABE</li>
+                  </ul>
+                </div>
+                <div>
+                  <p className="font-medium mb-2">
+                    <strong>3. Envía el comprobante</strong>
+                  </p>
+                  <p>
+                    Una vez realizado el pago, envía tu comprobante por WhatsApp al{" "}
+                    <a href="https://wa.me/[NÚMERO WHATSAPP]" target="_blank" rel="noopener noreferrer" className="text-primary-600 underline">
+                      [NÚMERO WHATSAPP]
+                    </a>{" "}
+                    o a nuestro correo{" "}
+                    <a href="mailto:[CORREO]" className="text-primary-600 underline">
+                      [CORREO]
+                    </a>{" "}
+                    para que podamos confirmar tu pedido.
+                  </p>
+                </div>
+                <p className="text-xs text-gray-600 mt-4 bg-yellow-50 p-2 rounded border border-yellow-200">
+                  <strong>Nota importante:</strong> Tu pedido está reservado. En cuanto confirmemos tu pago, actualizaremos el estado a Pagado y procederemos con el envío.
                 </p>
               </div>
             </div>
           )}
 
-          {isCash && (
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-              <h2 className="font-semibold text-gray-900 mb-3">
-                Instrucciones para pago en efectivo
-              </h2>
-              <div className="space-y-3 text-sm text-gray-700">
-                <p>
-                  <strong>1. Realiza el pago</strong>
-                </p>
-                <p>
-                  Puedes pagar el monto de <strong>{formatMXNFromCents(order.total_cents)}</strong> en:
-                </p>
-                <ul className="list-disc list-inside space-y-1 ml-4">
-                  <li>Oxxo (código de barras o referencia)</li>
-                  <li>Ventanilla bancaria</li>
-                  <li>Tienda física</li>
-                </ul>
-                <p className="mt-4">
-                  <strong>2. Envía el comprobante</strong>
-                </p>
-                <p>
-                  Una vez realizado el pago, envía el comprobante por WhatsApp o correo electrónico para que podamos confirmar tu pago y procesar tu pedido.
-                </p>
-                <p className="text-xs text-gray-600 mt-4">
-                  <strong>Nota:</strong> Tu pedido está reservado. En cuanto confirmemos tu pago, actualizaremos el estado a Pagado y procederemos con el envío.
-                </p>
-              </div>
+          {paymentMethod === "card" && (
+            <div className="bg-green-50 border border-green-200 rounded-lg p-6">
+              <h2 className="font-semibold text-green-800 mb-2">Pago con Tarjeta</h2>
+              <p className="text-green-700">
+                Tu pago con tarjeta ha sido procesado. Si ves esta página, es posible que haya habido un error de redirección.
+                Por favor, revisa el estado de tu pedido en tu cuenta o contacta a soporte.
+              </p>
             </div>
           )}
 

--- a/src/app/checkout/pago/PagoClient.tsx
+++ b/src/app/checkout/pago/PagoClient.tsx
@@ -434,8 +434,8 @@ export default function PagoClient() {
         : Math.round(shippingCost * 100);
       
       // Determinar payment_method y payment_status según el método seleccionado
-      const selectedPaymentMethodValue = paymentMethod === "card" ? "card" : paymentMethod === "bank_transfer" ? "bank_transfer" : paymentMethod === "cash" ? "cash" : null;
-      const selectedPaymentStatusValue = selectedPaymentMethodValue === "card" ? "pending" : selectedPaymentMethodValue === "bank_transfer" || selectedPaymentMethodValue === "cash" ? "pending" : null;
+      const selectedPaymentMethodValue = paymentMethod === "card" ? "card" : paymentMethod === "bank_transfer" ? "bank_transfer" : null;
+      const selectedPaymentStatusValue = selectedPaymentMethodValue === "card" ? "pending" : selectedPaymentMethodValue === "bank_transfer" ? "pending" : null;
 
       const orderPayload = {
         email: datos.email, // Email del checkout para la orden y Stripe
@@ -583,7 +583,7 @@ export default function PagoClient() {
 
       // Si el método de pago es tarjeta, StripePaymentForm creará el PaymentIntent internamente
       if (paymentMethod !== "card") {
-        // Para métodos manuales (bank_transfer o cash), redirigir a página de instrucciones
+        // Para métodos manuales (bank_transfer), redirigir a página de instrucciones
         resetCheckout();
         router.push(`/checkout/pago-pendiente?order=${encodeURIComponent(newOrderId)}`);
       }
@@ -1175,9 +1175,13 @@ export default function PagoClient() {
           >
             <option value="">Selecciona...</option>
             <option value="card">Tarjeta de crédito/débito (Stripe)</option>
-            <option value="bank_transfer">Transferencia / depósito bancario (SPEI)</option>
-            <option value="cash">Pago en efectivo (Oxxo / ventanilla)</option>
+            <option value="bank_transfer">Transferencia o depósito en efectivo</option>
           </select>
+          {watch("paymentMethod") === "bank_transfer" && (
+            <p className="text-sm text-gray-600 mt-1">
+              Te daremos los datos bancarios para transferir o depositar en sucursal, Oxxo, 7-Eleven, etc. Tu pedido se confirma al registrar el pago.
+            </p>
+          )}
           {errors.paymentMethod && (
             <p className="text-red-500 text-sm mt-1">
               {errors.paymentMethod.message}

--- a/src/app/checkout/pago/page.tsx
+++ b/src/app/checkout/pago/page.tsx
@@ -9,12 +9,12 @@ export const revalidate = 0;
 export const metadata: Metadata = {
   title: "Pago",
   description:
-    "Completa el pago de tu pedido de forma segura. Aceptamos tarjetas, OXXO y más métodos de pago.",
+    "Completa el pago de tu pedido de forma segura. Aceptamos tarjetas y transferencias bancarias.",
   robots: { index: false, follow: true },
   openGraph: {
     title: "Pago | Depósito Dental Noriega",
     description:
-      "Completa el pago de tu pedido de forma segura. Aceptamos tarjetas, OXXO y más métodos de pago.",
+      "Completa el pago de tu pedido de forma segura. Aceptamos tarjetas y transferencias bancarias.",
     type: "website",
   },
 };

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -907,8 +907,7 @@ export default function PedidosPage() {
                     </span>
                     {/* Mensaje contextual para pedidos pendientes de métodos manuales */}
                     {orderDetail.payment_status === "pending" &&
-                      (orderDetail.payment_method === "bank_transfer" ||
-                        orderDetail.payment_method === "cash") && (
+                      orderDetail.payment_method === "bank_transfer" && (
                         <p className="text-sm text-gray-600 mt-2 italic">
                           Tu pedido está reservado. En cuanto confirmemos tu pago, actualizaremos el estado a Pagado.
                         </p>

--- a/src/lib/orders/paymentStatus.ts
+++ b/src/lib/orders/paymentStatus.ts
@@ -1,7 +1,7 @@
 /**
  * Métodos de pago disponibles para órdenes
  */
-export type PaymentMethod = "card" | "bank_transfer" | "cash";
+export type PaymentMethod = "card" | "bank_transfer";
 
 /**
  * Estados de pago para órdenes
@@ -13,8 +13,7 @@ export type PaymentStatus = "pending" | "paid" | "canceled";
  */
 export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
   card: "Tarjeta de crédito/débito",
-  bank_transfer: "Transferencia / depósito bancario (SPEI)",
-  cash: "Pago en efectivo (Oxxo / ventanilla)",
+  bank_transfer: "Transferencia / Depósito",
 };
 
 /**

--- a/src/lib/shipping/freeShipping.ts
+++ b/src/lib/shipping/freeShipping.ts
@@ -4,6 +4,7 @@
  */
 
 export const FREE_SHIPPING_THRESHOLD_MXN = 2000; // Umbral para envío gratis en MXN
+export const FREE_SHIPPING_THRESHOLD_CENTS = 200000; // Umbral para envío gratis en centavos (2,000.00 MXN)
 
 /**
  * Aplica la regla de envío gratis si el subtotal es >= umbral

--- a/src/lib/store/checkoutStore.ts
+++ b/src/lib/store/checkoutStore.ts
@@ -49,6 +49,7 @@ export type UiShippingOption = {
   etaMinDays: number | null;
   etaMaxDays: number | null;
   externalRateId: string;
+  originalPriceCents?: number; // Precio original antes de aplicar promo (para mostrar "antes $XXX")
 };
 
 type CheckoutPersisted = {


### PR DESCRIPTION
## Resumen de cambios

### Limpieza de métodos de pago

- **Eliminado método "cash"**: Se removió completamente el método de pago en efectivo directo
- **Métodos disponibles**: Ahora solo quedan:
  - `card` → Tarjeta de crédito/débito (Stripe)
  - `bank_transfer` → Transferencia o depósito en efectivo (incluye depósito en banco, Oxxo, 7-Eleven, etc.)
- **Actualización de tipos**: `PaymentMethod` ahora solo incluye `"card" | "bank_transfer"`
- **Nueva opción en checkout**: La opción de transferencia muestra el label "Transferencia o depósito en efectivo" con descripción clara
- **Instrucciones mejoradas**: La página `/checkout/pago-pendiente` ahora muestra instrucciones detalladas para transferencia/depósito con:
  - Datos bancarios (placeholders para completar)
  - Formas de realizar el depósito (app bancaria, sucursal, Oxxo, 7-Eleven)
  - Recordatorio de enviar comprobante
- **Limpieza de referencias**: Eliminadas todas las referencias a "cash" en código, validaciones y metadata

### Promo de envío gratis desde $2,000 MXN

- **Constante definida**: `FREE_SHIPPING_THRESHOLD_CENTS = 200000` (2,000.00 MXN)
- **Aplicación automática**: Si el subtotal del pedido es >= $2,000 MXN:
  - Las opciones de envío a domicilio (Skydropx) se muestran con precio $0.00
  - Se mantiene el precio original en `originalPriceCents` para mostrar "antes $XXX"
  - El campo `shipping_price_cents` se guarda como `0` en la base de datos
- **Visual en checkout**: Cuando aplica la promo, se muestra:
  - Título: "Envío a domicilio (Skydropx)"
  - Subtítulo: "Envío GRATIS en pedidos desde $2,000 (antes $XXX)"
- **"Recoger en tienda"**: Sigue siendo gratis siempre (no afectado por la promo)
- **API actualizada**: `/api/shipping/rates` ahora acepta `subtotalCents` y aplica la regla automáticamente

## Checklist de pruebas manuales

- [ ] Stripe tarjeta sigue funcionando
- [ ] Pedido con transferencia queda como "pending"
- [ ] Admin puede cambiar de "pending" a "paid"
- [ ] En la cuenta del cliente se ven correctamente método y estado de pago
- [ ] Pedido de $1,999 muestra envío con costo
- [ ] Pedido de $2,000 o más muestra envío gratis con texto de promo
- [ ] "Recoger en tienda" siempre muestra $0.00

## Verificaciones técnicas

✅ `pnpm lint` - Pasó (solo warnings pre-existentes)
✅ `pnpm typecheck` - Pasó sin errores
✅ `pnpm build` - Compilación exitosa

