### PR TITLE
feat: improve free shipping messaging in cart and checkout

### DIFF
--- a/src/components/checkout/CheckoutOrderSummary.tsx
+++ b/src/components/checkout/CheckoutOrderSummary.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useCheckoutStore } from "@/lib/store/checkoutStore";
 import { formatMXNFromCents } from "@/lib/utils/currency";
 import { getSelectedItems, getSelectedSubtotalCents } from "@/lib/checkout/selection";
+import { FREE_SHIPPING_THRESHOLD_CENTS } from "@/lib/shipping/freeShipping";
 
 interface CheckoutOrderSummaryProps {
   className?: string;
@@ -140,6 +141,19 @@ export default function CheckoutOrderSummary({
               </span>
               <span className="font-medium">
                 {formatMXNFromCents(shippingCents)}
+              </span>
+            </div>
+          )}
+          {shippingCents === 0 && (
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-600">Envío:</span>
+              <span className="font-medium">
+                {formatMXNFromCents(0)}
+                {shippingMethod === "pickup" ? (
+                  <span className="text-gray-500 text-xs ml-1">(recoger en tienda)</span>
+                ) : subtotalCents >= FREE_SHIPPING_THRESHOLD_CENTS ? (
+                  <span className="text-green-600 text-xs ml-1">(promo envío gratis desde $2,000)</span>
+                ) : null}
               </span>
             </div>
           )}


### PR DESCRIPTION
## Resumen de cambios

### Mensaje de promo en el carrito

- **Ubicación**: Resumen del carrito en `/carrito`
- **Comportamiento**:
  - Si `subtotalCents <= 0`: no se muestra nada
  - Si `0 < subtotalCents < $2,000`: muestra "Te faltan $X MXN para obtener envío GRATIS"
  - Si `subtotalCents >= $2,000`: muestra "¡Envío GRATIS aplicado en este pedido!"
- **Estilo**: Badge con fondo verde/azul según el caso, integrado en el resumen del carrito

### Mensaje mejorado en resumen de pago

- **Ubicación**: Componente `CheckoutOrderSummary` en `/checkout/pago`
- **Comportamiento**:
  - Cuando `shippingCost === 0`:
    - Si método es "Recoger en tienda": muestra "$0.00 (recoger en tienda)" sin mencionar promo
    - Si método es paquetería (Skydropx) Y `subtotalCents >= $2,000`: muestra "$0.00 (promo envío gratis desde $2,000)"
  - Cuando `shippingCost > 0`: comportamiento normal sin cambios
- **Uso de constantes**: Utiliza `FREE_SHIPPING_THRESHOLD_CENTS` centralizado

## Checklist de pruebas manuales

- [ ] Carrito con subtotal = 0 no muestra mensaje
- [ ] Carrito con subtotal entre $1 y $1,999 muestra "Te faltan $X…" correctamente
- [ ] Carrito con subtotal >= $2,000 muestra "¡Envío GRATIS aplicado en este pedido!"
- [ ] En `/checkout/pago`, si el envío es gratis por promo (paquetería), se ve el texto de promo en el renglón de envío
- [ ] En `/checkout/pago`, si el método es "Recoger en tienda", el envío se ve como $0 pero sin texto de promo
- [ ] El total final sigue siendo correcto en todos los casos

## Verificaciones técnicas

✅ `pnpm lint` - Pasó (solo warnings pre-existentes)
✅ `pnpm typecheck` - Pasó sin errores
✅ `pnpm build` - Compilación exitosa

