### PR TITLE
feat: admin whatsapp contact button

### DIFF
--- a/src/app/admin/pedidos/[id]/WhatsappContactClient.tsx
+++ b/src/app/admin/pedidos/[id]/WhatsappContactClient.tsx
@@ -2,20 +2,16 @@
 
 import { formatE164ToReadable } from "@/lib/utils/phone";
 import { formatMXNFromCents } from "@/lib/utils/currency";
-import { getPaymentMethodLabel } from "@/lib/orders/paymentStatus";
 
 type Props = {
-  orderId: string;
   shortId: string;
   totalCents: number | null;
   paymentMethod: "card" | "bank_transfer" | null;
-  paymentStatus: "pending" | "paid" | "canceled" | null;
   contactName?: string | null;
   whatsappE164?: string | null;
 };
 
 export default function WhatsappContactClient({
-  orderId,
   shortId,
   totalCents,
   paymentMethod,

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -462,11 +462,9 @@ export default async function AdminPedidoDetailPage({
 
           {/* Contacto por WhatsApp */}
           <WhatsappContactClient
-            orderId={order.id}
             shortId={orderShortId}
             totalCents={totalCents}
             paymentMethod={order.payment_method as "card" | "bank_transfer" | null}
-            paymentStatus={order.payment_status as "pending" | "paid" | "canceled" | null}
             contactName={contactName}
             whatsappE164={whatsappE164}
           />

--- a/src/lib/utils/phone.ts
+++ b/src/lib/utils/phone.ts
@@ -17,7 +17,7 @@ export function normalizePhoneToE164Mx(raw: unknown): string | null {
   let cleaned = String(raw).trim();
 
   // Quitar espacios, guiones, paréntesis y otros caracteres no numéricos
-  cleaned = cleaned.replace(/[\s\-\(\)\.]/g, "");
+  cleaned = cleaned.replace(/[\s\-().]/g, "");
 
   // Si no quedan solo dígitos, es inválido
   if (!/^\d+$/.test(cleaned)) {


### PR DESCRIPTION
## Resumen de la funcionalidad

Se agregó un botón de contacto por WhatsApp en el detalle de pedido del admin que permite abrir WhatsApp Web con un mensaje prellenado dirigido al cliente.

### Cambios realizados

**Archivos nuevos:**
- `src/lib/utils/phone.ts` - Helper para normalizar teléfonos a formato E.164 MX y formatear para visualización
- `src/app/admin/pedidos/[id]/WhatsappContactClient.tsx` - Componente cliente que muestra el botón de WhatsApp o mensaje informativo

**Archivos modificados:**
- `src/app/admin/pedidos/[id]/page.tsx` - Integración del componente y extracción de teléfono desde metadata

### Funcionalidad

1. **Extracción de teléfono:**
   - Orden de prioridad desde `metadata`: `whatsapp` → `phone` → `contact_phone`
   - Normalización a formato E.164 MX (ej: `525551234567`)

2. **Normalización de teléfono:**
   - Quita espacios, guiones, paréntesis
   - Si tiene 10 dígitos y código de área válido → antepone `52`
   - Si ya tiene `52` y 12 dígitos → usa tal cual
   - Cualquier otro caso → inválido (no muestra botón)

3. **Mensaje de WhatsApp:**
   - Saludo personalizado con nombre del cliente (si está disponible)
   - Número de orden corto (primeros 8 caracteres)
   - Método de pago legible
   - Total en MXN
   - Recordatorio de enviar comprobante

4. **UI:**
   - Si hay teléfono válido: muestra botón verde "Abrir chat de WhatsApp" con icono
   - Si no hay teléfono: muestra mensaje gris informativo
   - Se muestra en la sección "Estado de Pago", debajo del botón de reenviar instrucciones

## Lista de pruebas manuales

- [ ] Pedido con `metadata.whatsapp` válido → botón visible, abre WhatsApp Web con mensaje prellenado
- [ ] Pedido con `metadata.phone` válido (sin whatsapp) → botón visible, funciona correctamente
- [ ] Pedido con `metadata.contact_phone` válido (sin whatsapp ni phone) → botón visible, funciona correctamente
- [ ] Pedido sin teléfono en metadata → muestra mensaje "Este pedido no tiene número de WhatsApp registrado"
- [ ] Pedido con teléfono inválido (formato incorrecto) → muestra mensaje informativo, no botón
- [ ] Verificar que el número se muestra formateado correctamente (ej: "+52 55 1234 5678")
- [ ] Verificar que el mensaje incluye nombre del cliente si está disponible
- [ ] Verificar que el mensaje incluye método de pago correcto (Tarjeta / Transferencia)
- [ ] Verificar que el mensaje incluye total en MXN
- [ ] Cambios de estado de pago/envío siguen funcionando (sin "Orden no encontrada")
- [ ] Botón funciona tanto para pagos con tarjeta como con transferencia

