### PR TITLE
feat: include bank transfer info in admin whatsapp message

### DIFF
--- a/src/app/admin/pedidos/[id]/WhatsappContactClient.tsx
+++ b/src/app/admin/pedidos/[id]/WhatsappContactClient.tsx
@@ -2,6 +2,7 @@
 
 import { formatE164ToReadable } from "@/lib/utils/phone";
 import { formatMXNFromCents } from "@/lib/utils/currency";
+import { BANK_TRANSFER_INFO } from "@/lib/payments/bank-transfer-constants";
 
 type Props = {
   shortId: string;
@@ -11,10 +12,43 @@ type Props = {
   whatsappE164?: string | null;
 };
 
+/**
+ * Construye el mensaje de WhatsApp para el admin
+ */
+function buildWhatsappMessage(
+  shortId: string,
+  totalCents: number | null,
+  contactName: string | null,
+): string {
+  const name = contactName || "Cliente";
+  const total =
+    totalCents !== null
+      ? formatMXNFromCents(totalCents)
+      : "tu pedido";
+
+  const lines = [
+    `Hola ${name}, te escribimos de Depósito Dental Noriega 👋`,
+    ``,
+    `Te compartimos los datos para completar el pago de tu pedido #${shortId}.`,
+    `Total a pagar: ${total}.`,
+    ``,
+    `Datos para transferencia o depósito:`,
+    `Banco: ${BANK_TRANSFER_INFO.bankName}`,
+    `Beneficiario: ${BANK_TRANSFER_INFO.beneficiary}`,
+    `CLABE: ${BANK_TRANSFER_INFO.clabe}`,
+    `Tarjeta de débito: ${BANK_TRANSFER_INFO.debitCard}`,
+    ``,
+    BANK_TRANSFER_INFO.conceptNote,
+    ``,
+    `Cuando hagas tu pago, por favor responde este mensaje con tu comprobante para marcar tu pedido como pagado ✅`,
+  ];
+
+  return lines.join("\n");
+}
+
 export default function WhatsappContactClient({
   shortId,
   totalCents,
-  paymentMethod,
   contactName,
   whatsappE164,
 }: Props) {
@@ -33,23 +67,7 @@ export default function WhatsappContactClient({
   }
 
   // Construir mensaje de WhatsApp
-  const paymentMethodLabel =
-    paymentMethod === "card"
-      ? "Tarjeta de crédito/débito"
-      : paymentMethod === "bank_transfer"
-        ? "Transferencia / depósito"
-        : "Otro método";
-
-  const totalFormatted = totalCents !== null ? formatMXNFromCents(totalCents) : "N/A";
-
-  const message = `Hola${contactName ? ` ${contactName}` : ""}, soy de Depósito Dental Noriega 👋
-
-Tu pedido #${shortId} está registrado con:
-• Método de pago: ${paymentMethodLabel}
-• Total: ${totalFormatted}
-
-Cuando tengas tu comprobante, por favor mándalo por aquí.`;
-
+  const message = buildWhatsappMessage(shortId, totalCents, contactName ?? null);
   const whatsappUrl = `https://wa.me/${whatsappE164}?text=${encodeURIComponent(message)}`;
 
   const handleOpenWhatsApp = () => {

--- a/src/lib/payments/bank-transfer-constants.ts
+++ b/src/lib/payments/bank-transfer-constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Constantes para transferencias bancarias BANAMEX
+ * Usadas en mensajes de WhatsApp y emails de instrucciones de pago
+ */
+export const BANK_TRANSFER_INFO = {
+  bankName: "BANAMEX",
+  beneficiary: "Carlos Javier Noriega Álvarez",
+  clabe: "002180051867448125",
+  debitCard: "5204 1674 6723 1890",
+  conceptNote: "Favor de poner en CONCEPTO tu nombre y apellido.",
+} as const;
+


### PR DESCRIPTION
## Resumen de la funcionalidad

Se actualizó el mensaje de WhatsApp en el admin para incluir los datos completos de transferencia BANAMEX. Ahora cuando el admin hace clic en el botón de WhatsApp, el mensaje prellenado incluye toda la información necesaria para que el cliente complete su pago.

### Cambios realizados

**Archivos nuevos:**
- `src/lib/payments/bank-transfer-constants.ts` - Constantes centralizadas con los datos bancarios BANAMEX

**Archivos modificados:**
- `src/app/admin/pedidos/[id]/WhatsappContactClient.tsx` - Actualizado para construir un mensaje más completo con datos bancarios

### Funcionalidad

1. **Mensaje de WhatsApp mejorado:**
   - Saludo personalizado con nombre del cliente (o "Cliente" si no está disponible)
   - Número de orden corto (primeros 8 caracteres)
   - Total a pagar formateado en MXN
   - Datos completos de transferencia BANAMEX:
     - Banco: BANAMEX
     - Beneficiario: Carlos Javier Noriega Álvarez
     - CLABE: 002180051867448125
     - Tarjeta de débito: 5204 1674 6723 1890
   - Nota sobre el concepto: "Favor de poner en CONCEPTO tu nombre y apellido."
   - Recordatorio de enviar comprobante por el mismo chat

2. **Constantes centralizadas:**
   - Los datos bancarios están en un archivo separado para facilitar mantenimiento
   - Pueden ser reutilizados en otros lugares (emails, etc.)

### Compatibilidad

- El componente sigue funcionando igual para órdenes sin teléfono (muestra mensaje informativo)
- El botón se muestra solo si hay un número de WhatsApp válido
- No se requieren cambios en la base de datos ni en el flujo de checkout

## Lista de pruebas manuales

- [ ] Crear un pedido de prueba con método de pago "Transferencia / Depósito"
- [ ] Ir al admin → pedidos → ver detalle del pedido
- [ ] Verificar que el botón verde "Abrir chat de WhatsApp" aparece
- [ ] Hacer clic en el botón y verificar que:
  - Se abre WhatsApp Web / app
  - El mensaje prellenado incluye:
    - Saludo con nombre del cliente (o "Cliente")
    - Número de orden corto (ej: "d4045787")
    - Total a pagar formateado (ej: "$1,500.00 MXN")
    - Banco: BANAMEX
    - Beneficiario: Carlos Javier Noriega Álvarez
    - CLABE: 002180051867448125
    - Tarjeta de débito: 5204 1674 6723 1890
    - Nota sobre el concepto
    - Recordatorio de enviar comprobante
- [ ] Verificar que el formato del mensaje es legible y bien estructurado
- [ ] Probar con un pedido sin nombre de contacto (debe usar "Cliente")
- [ ] Verificar que órdenes sin teléfono muestran el mensaje informativo (no botón)

