### PR TITLE
feat(analytics): track search, related products and loyalty

### DIFF
--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -250,7 +250,11 @@ export default async function BuscarPage({ searchParams }: Props) {
               <h2 className="text-xl font-semibold text-gray-900 mb-4">
                 Te recomendamos estos productos destacados
               </h2>
-              <FeaturedGrid items={filteredFeatured.slice(0, 8)} />
+              <FeaturedGrid
+                items={filteredFeatured.slice(0, 8)}
+                source="search_no_results"
+                query={q}
+              />
             </div>
           )}
         </>
@@ -259,7 +263,7 @@ export default async function BuscarPage({ searchParams }: Props) {
       {items.length > 0 && (
         <>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {items.map((it) => (
+            {items.map((it, index) => (
               <SearchResultCard
                 key={it.id}
                 item={{
@@ -273,6 +277,7 @@ export default async function BuscarPage({ searchParams }: Props) {
                   is_active: true,
                 }}
                 highlightQuery={q}
+                position={index + 1}
               />
             ))}
           </div>
@@ -299,7 +304,11 @@ export default async function BuscarPage({ searchParams }: Props) {
               <p className="text-sm text-slate-600 mb-4">
                 Otros productos similares que suelen revisar nuestros clientes.
               </p>
-              <FeaturedGrid items={filteredFeatured.slice(0, 8)} />
+              <FeaturedGrid
+                items={filteredFeatured.slice(0, 8)}
+                source="search_low_results"
+                query={q}
+              />
             </div>
           )}
         </>

--- a/src/app/checkout/gracias/GraciasContent.tsx
+++ b/src/app/checkout/gracias/GraciasContent.tsx
@@ -1125,6 +1125,7 @@ export default function GraciasContent() {
               <OrderPointsInfo
                 totalCents={orderDataFromStorage.total_cents}
                 messageType="earned"
+                orderId={orderRef || undefined}
               />
             </div>
           )}

--- a/src/app/checkout/pago-pendiente/PagoPendienteClient.tsx
+++ b/src/app/checkout/pago-pendiente/PagoPendienteClient.tsx
@@ -173,6 +173,7 @@ export default function PagoPendienteClient({ order, error }: Props) {
                     <OrderPointsInfo
                       totalCents={order.total_cents}
                       messageType="pending"
+                      orderId={order.id}
                     />
                   </div>
                 )}

--- a/src/app/cuenta/pedidos/page.tsx
+++ b/src/app/cuenta/pedidos/page.tsx
@@ -743,7 +743,11 @@ export default function PedidosPage() {
                             : "Ver detalle"}
                         </button>
                         {isAuthenticated && userEmail && (
-                          <RepeatOrderButton orderId={order.id} />
+                          <RepeatOrderButton
+                            orderId={order.id}
+                            itemsCount={0} // OrderSummary no tiene items, se calculará en el cliente
+                            subtotalCents={order.metadata?.subtotal_cents || order.total_cents || 0}
+                          />
                         )}
                       </div>
                     </div>

--- a/src/app/cuenta/puntos/LoyaltyPageTracker.client.tsx
+++ b/src/app/cuenta/puntos/LoyaltyPageTracker.client.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { trackLoyaltyAccountViewed } from "@/lib/analytics/events";
+import { getTierForPoints } from "@/lib/loyalty/config";
+
+type Props = {
+  currentPoints: number;
+  totalPoints: number;
+};
+
+/**
+ * Componente client que trackea cuando se ve la página de puntos de lealtad
+ */
+export default function LoyaltyPageTracker({ currentPoints, totalPoints }: Props) {
+  const trackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!trackedRef.current) {
+      trackedRef.current = true;
+      const tier = getTierForPoints(currentPoints);
+      trackLoyaltyAccountViewed({
+        currentPoints,
+        totalPoints,
+        tierId: tier.id,
+        tierName: tier.name,
+      });
+    }
+  }, [currentPoints, totalPoints]);
+
+  return null;
+}
+

--- a/src/app/cuenta/puntos/page.tsx
+++ b/src/app/cuenta/puntos/page.tsx
@@ -8,6 +8,7 @@ import LoyaltyRewardsTable from "@/components/loyalty/LoyaltyRewardsTable";
 import LoyaltyHistoryTable from "@/components/loyalty/LoyaltyHistoryTable";
 import LoyaltyAchievements from "@/components/loyalty/LoyaltyAchievements";
 import AccountSectionHeader from "@/components/account/AccountSectionHeader";
+import LoyaltyPageTracker from "./LoyaltyPageTracker.client";
 
 /**
  * Página dedicada de puntos de lealtad
@@ -61,6 +62,12 @@ export default async function PuntosPage() {
       />
 
       <div className="mt-6 space-y-6">
+        {/* Tracker de analytics */}
+        <LoyaltyPageTracker
+          currentPoints={loyaltySummary?.pointsBalance ?? 0}
+          totalPoints={loyaltySummary?.lifetimeEarned ?? 0}
+        />
+
         {/* Sección 1: Resumen de puntos */}
         <LoyaltySummaryCard
           pointsBalance={loyaltySummary?.pointsBalance ?? 0}

--- a/src/components/FeaturedGrid.tsx
+++ b/src/components/FeaturedGrid.tsx
@@ -1,6 +1,10 @@
+"use client";
+
+import { useEffect, useRef } from "react";
 import ProductCard from "@/components/catalog/ProductCard";
 import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
 import type { ProductCardProps } from "@/components/catalog/ProductCard";
+import { trackRelatedProductsShown, trackRelatedProductClicked } from "@/lib/analytics/events";
 
 /**
  * Adaptador para FeaturedItem -> ProductCardProps
@@ -25,26 +29,63 @@ function toProductCardProps(
   };
 }
 
-export default function FeaturedGrid({ 
-  items,
-  hideSoldOutLabel: _hideSoldOutLabel = false
-}: { 
+type FeaturedGridProps = {
   items: FeaturedItem[];
   hideSoldOutLabel?: boolean;
-}) {
+  source?: "cart" | "checkout" | "search_no_results" | "search_low_results";
+  query?: string;
+  cartItemsCount?: number;
+};
+
+export default function FeaturedGrid({ 
+  items,
+  hideSoldOutLabel: _hideSoldOutLabel = false,
+  source,
+  query,
+  cartItemsCount,
+}: FeaturedGridProps) {
+  const trackedRef = useRef(false);
+
+  useEffect(() => {
+    if (source && items.length > 0 && !trackedRef.current) {
+      trackedRef.current = true;
+      trackRelatedProductsShown({
+        source,
+        productsCount: items.length,
+        cartItemsCount,
+        query,
+      });
+    }
+  }, [source, items.length, cartItemsCount, query]);
+
   if (!items?.length) return null;
+
+  const handleProductClick = (item: FeaturedItem, position: number) => {
+    if (source) {
+      trackRelatedProductClicked({
+        source,
+        productId: item.product_id,
+        sectionSlug: item.section,
+        position,
+      });
+    }
+  };
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
       {items.map((item, index) => (
-        <ProductCard
+        <div
           key={item.product_id}
-          {...toProductCardProps(
-            item,
-            index < 4, // priority para primeros 4
-            "(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
-          )}
-        />
+          onClick={() => handleProductClick(item, index + 1)}
+        >
+          <ProductCard
+            {...toProductCardProps(
+              item,
+              index < 4, // priority para primeros 4
+              "(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            )}
+          />
+        </div>
       ))}
     </div>
   );

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -3,11 +3,12 @@
 import ProductCard from "@/components/catalog/ProductCard";
 import type { CatalogItem } from "@/lib/supabase/catalog";
 import type { ProductCardProps } from "@/components/catalog/ProductCard";
-import { track } from "@/lib/analytics";
+import { trackSearchClickResult } from "@/lib/analytics/events";
 
 type Props = {
   item: CatalogItem;
   highlightQuery?: string;
+  position?: number;
 };
 
 /**
@@ -30,13 +31,16 @@ function toProductCardProps(item: CatalogItem, highlightQuery?: string): Product
 /**
  * SearchResultCard: wrapper que usa ProductCard canónico con highlight
  */
-export default function SearchResultCard({ item, highlightQuery }: Props) {
+export default function SearchResultCard({ item, highlightQuery, position }: Props) {
   const handleClick = () => {
-    track("select_item", {
-      id: item.id,
-      title: item.title,
-      section: item.section,
-    });
+    if (highlightQuery && position !== undefined) {
+      trackSearchClickResult({
+        query: highlightQuery,
+        productId: item.id,
+        sectionSlug: item.section,
+        position,
+      });
+    }
   };
 
   return (

--- a/src/components/SearchTracker.client.tsx
+++ b/src/components/SearchTracker.client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { track } from "@/lib/analytics";
+import { trackSearchPerformed } from "@/lib/analytics/events";
 
 type Props = {
   query: string;
@@ -17,13 +17,13 @@ export default function SearchTracker({ query, resultsCount }: Props) {
     // Solo trackear una vez por query
     if (
       trimmedQuery &&
-      resultsCount > 0 &&
       trackedRef.current !== trimmedQuery
     ) {
       trackedRef.current = trimmedQuery;
-      track("search", {
-        q: trimmedQuery,
-        total: resultsCount,
+      trackSearchPerformed({
+        query: trimmedQuery,
+        resultsCount,
+        hasResults: resultsCount > 0,
       });
     }
   }, [query, resultsCount]);

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -130,3 +130,154 @@ export function trackWhatsappClick(params: {
   });
 }
 
+/**
+ * Trackea cuando el usuario realiza una búsqueda
+ */
+export function trackSearchPerformed(params: {
+  query: string;
+  resultsCount: number;
+  hasResults: boolean;
+}): void {
+  trackEvent("search_performed", {
+    query: params.query,
+    results_count: params.resultsCount,
+    has_results: params.hasResults,
+  });
+}
+
+/**
+ * Trackea cuando el usuario hace clic en un resultado de búsqueda
+ */
+export function trackSearchClickResult(params: {
+  query: string;
+  productId: string;
+  sectionSlug?: string;
+  position: number;
+}): void {
+  trackEvent("search_click_result", {
+    query: params.query,
+    product_id: params.productId,
+    section_slug: params.sectionSlug ?? null,
+    position: params.position,
+  });
+}
+
+/**
+ * Trackea cuando se muestran productos relacionados
+ */
+export function trackRelatedProductsShown(params: {
+  source: "cart" | "checkout" | "search_no_results" | "search_low_results";
+  productsCount: number;
+  cartItemsCount?: number;
+  query?: string;
+}): void {
+  trackEvent("related_products_shown", {
+    source: params.source,
+    products_count: params.productsCount,
+    cart_items_count: params.cartItemsCount ?? null,
+    query: params.query ?? null,
+  });
+}
+
+/**
+ * Trackea cuando el usuario hace clic en un producto relacionado
+ */
+export function trackRelatedProductClicked(params: {
+  source: "cart" | "checkout" | "search_no_results" | "search_low_results";
+  productId: string;
+  sectionSlug?: string;
+  position: number;
+}): void {
+  trackEvent("related_product_clicked", {
+    source: params.source,
+    product_id: params.productId,
+    section_slug: params.sectionSlug ?? null,
+    position: params.position,
+  });
+}
+
+/**
+ * Trackea cuando el usuario agrega un producto relacionado al carrito desde checkout
+ */
+export function trackRelatedProductAddToCart(params: {
+  source: "checkout";
+  productId: string;
+  cartItemsBefore: number;
+}): void {
+  trackEvent("related_product_add_to_cart", {
+    source: params.source,
+    product_id: params.productId,
+    cart_items_before: params.cartItemsBefore,
+  });
+}
+
+/**
+ * Trackea cuando el usuario gana puntos de lealtad
+ */
+export function trackLoyaltyPointsEarned(params: {
+  orderId: string;
+  points: number;
+  estimatedValueMxn: number;
+  status: "earned" | "pending";
+}): void {
+  trackEvent("loyalty_points_earned", {
+    order_id: params.orderId,
+    points: params.points,
+    estimated_value_mxn: params.estimatedValueMxn,
+    status: params.status,
+  });
+}
+
+/**
+ * Trackea cuando el usuario ve su página de puntos de lealtad
+ */
+export function trackLoyaltyAccountViewed(params: {
+  currentPoints: number;
+  totalPoints: number;
+  tierId: string;
+  tierName: string;
+}): void {
+  trackEvent("loyalty_account_viewed", {
+    current_points: params.currentPoints,
+    total_points: params.totalPoints,
+    tier_id: params.tierId,
+    tier_name: params.tierName,
+  });
+}
+
+/**
+ * Trackea cuando el usuario hace clic en repetir pedido
+ */
+export function trackLoyaltyRepeatOrderClicked(params: {
+  orderId: string;
+  itemsCount: number;
+  subtotalCents: number;
+}): void {
+  trackEvent("loyalty_repeat_order_clicked", {
+    order_id: params.orderId,
+    items_count: params.itemsCount,
+    subtotal_cents: params.subtotalCents,
+  });
+}
+
+/**
+ * Trackea cuando se muestra el header de beneficios en checkout
+ */
+export function trackCheckoutBenefitsShown(params: {
+  subtotalCents: number;
+  hasFreeShipping: boolean;
+  freeShippingRemainingCents: number;
+  estimatedPoints: number;
+  estimatedValueMxn: number;
+  shippingMethod: "pickup" | "standard" | "express";
+}): void {
+  trackEvent("checkout_benefits_shown", {
+    subtotal_cents: params.subtotalCents,
+    has_free_shipping: params.hasFreeShipping,
+    free_shipping_remaining_cents: params.freeShippingRemainingCents,
+    estimated_points: params.estimatedPoints,
+    estimated_value_mxn: params.estimatedValueMxn,
+    shipping_method: params.shippingMethod,
+  });
+}
+


### PR DESCRIPTION
Esta PR agrega instrumentación de analytics (GA4 bridge) solo en capa de UI:

- search: search_performed, search_click_result
- relacionados: related_products_shown, related_product_clicked, related_product_add_to_cart (compact checkout)
- loyalty: loyalty_points_earned/pending, loyalty_account_viewed, loyalty_repeat_order_clicked
- checkout: checkout_benefits_shown (header de beneficios)

Sin cambios en Stripe, Skydropx ni lógica de lealtad. Incluye guardas con useRef para evitar eventos duplicados y se limita a componentes cliente.

Checks esperados: pnpm lint, pnpm typecheck, pnpm build