### PR TITLE
feat(pdp): ProductGallery con product_images (miniaturas + swipe + lightbox)

### DIFF
--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -2,7 +2,9 @@ import "server-only";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getProduct } from "@/lib/catalog/getProduct.server";
-import ImageWithFallback from "@/components/ui/ImageWithFallback";
+import { getProductImages } from "@/lib/catalog/getProductImages.server";
+import { sortProductImages } from "@/lib/catalog/sortProductImages";
+import ProductGallery from "@/components/pdp/ProductGallery";
 import ProductActions from "@/components/product/ProductActions.client";
 import ProductViewTracker from "@/components/ProductViewTracker.client";
 import RecentlyViewedTracker from "@/components/catalog/RecentlyViewedTracker.client";
@@ -110,6 +112,10 @@ export default async function ProductDetailPage({ params }: Props) {
     return notFound(); // 404 limpio, no error
   }
 
+  // Obtener imágenes del producto desde product_images
+  const productImages = await getProductImages(product.id);
+  const sortedImages = sortProductImages(productImages);
+
   const image_url = product.image_url;
   const price = new Intl.NumberFormat("es-MX", {
     style: "currency",
@@ -193,19 +199,13 @@ export default async function ProductDetailPage({ params }: Props) {
 
         <div className="max-w-6xl mx-auto px-4 py-6 sm:py-8">
           <div className="grid lg:grid-cols-2 gap-6 sm:gap-8">
-            {/* Imagen */}
+            {/* Galería de imágenes */}
             <div className="space-y-4">
-              <div className="relative w-full aspect-square bg-white rounded-lg overflow-hidden shadow-sm">
-                <ImageWithFallback
-                  src={image_url}
-                  alt={product.title}
-                  width={800}
-                  height={800}
-                  className="w-full h-full object-contain"
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  priority
-                />
-              </div>
+              <ProductGallery
+                images={sortedImages}
+                title={product.title}
+                fallbackImage={image_url}
+              />
             </div>
 
             {/* Información del producto */}

--- a/src/components/pdp/ProductGallery.tsx
+++ b/src/components/pdp/ProductGallery.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState, useRef } from "react";
+import ImageWithFallback from "@/components/ui/ImageWithFallback";
+
+type ProductImage = {
+  url: string;
+  is_primary?: boolean | null;
+};
+
+type Props = {
+  images: ProductImage[];
+  title: string;
+  fallbackImage?: string | null;
+};
+
+export default function ProductGallery({ images, title, fallbackImage }: Props) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+  const touchStartX = useRef<number | null>(null);
+  const touchEndX = useRef<number | null>(null);
+  const minSwipeDistance = 50;
+
+  // Si no hay imágenes, usar fallback
+  const displayImages = images.length > 0 ? images : fallbackImage ? [{ url: fallbackImage }] : [];
+
+  if (displayImages.length === 0) {
+    return (
+      <div className="relative w-full aspect-square bg-gray-100 rounded-lg overflow-hidden">
+        <div className="w-full h-full flex items-center justify-center text-gray-400">
+          Sin imagen
+        </div>
+      </div>
+    );
+  }
+
+  const handleThumbnailClick = (index: number) => {
+    setSelectedIndex(index);
+  };
+
+  const handleSwipeStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleSwipeMove = (e: React.TouchEvent) => {
+    touchEndX.current = e.touches[0].clientX;
+  };
+
+  const handleSwipeEnd = () => {
+    if (!touchStartX.current || !touchEndX.current) return;
+
+    const distance = touchStartX.current - touchEndX.current;
+    const isLeftSwipe = distance > minSwipeDistance;
+    const isRightSwipe = distance < -minSwipeDistance;
+
+    if (isLeftSwipe && selectedIndex < displayImages.length - 1) {
+      setSelectedIndex(selectedIndex + 1);
+    }
+    if (isRightSwipe && selectedIndex > 0) {
+      setSelectedIndex(selectedIndex - 1);
+    }
+
+    touchStartX.current = null;
+    touchEndX.current = null;
+  };
+
+  const handlePrevious = () => {
+    if (selectedIndex > 0) {
+      setSelectedIndex(selectedIndex - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (selectedIndex < displayImages.length - 1) {
+      setSelectedIndex(selectedIndex + 1);
+    }
+  };
+
+  const currentImage = displayImages[selectedIndex];
+
+  return (
+    <>
+      <div className="space-y-4">
+        {/* Imagen principal */}
+        <div className="relative w-full aspect-square bg-white rounded-lg overflow-hidden shadow-sm">
+          <button
+            type="button"
+            onClick={() => setIsLightboxOpen(true)}
+            className="w-full h-full focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-lg"
+            aria-label={`Ver imagen ${selectedIndex + 1} de ${displayImages.length} en pantalla completa`}
+          >
+            <div
+              className="w-full h-full touch-none"
+              onTouchStart={handleSwipeStart}
+              onTouchMove={handleSwipeMove}
+              onTouchEnd={handleSwipeEnd}
+            >
+              <ImageWithFallback
+                src={currentImage.url}
+                alt={`${title} - Imagen ${selectedIndex + 1}`}
+                width={800}
+                height={800}
+                className="w-full h-full object-contain"
+                sizes="(max-width: 768px) 100vw, 50vw"
+                priority={selectedIndex === 0}
+              />
+            </div>
+          </button>
+
+          {/* Indicadores de navegación en móvil (solo si hay más de 1 imagen) */}
+          {displayImages.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={handlePrevious}
+                disabled={selectedIndex === 0}
+                className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 disabled:opacity-30 disabled:cursor-not-allowed text-white rounded-full p-2 md:hidden focus:outline-none focus:ring-2 focus:ring-white"
+                aria-label="Imagen anterior"
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={handleNext}
+                disabled={selectedIndex === displayImages.length - 1}
+                className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 disabled:opacity-30 disabled:cursor-not-allowed text-white rounded-full p-2 md:hidden focus:outline-none focus:ring-2 focus:ring-white"
+                aria-label="Imagen siguiente"
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </button>
+            </>
+          )}
+
+          {/* Indicador de imagen actual (móvil) */}
+          {displayImages.length > 1 && (
+            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 bg-black/50 text-white text-xs px-2 py-1 rounded md:hidden">
+              {selectedIndex + 1} / {displayImages.length}
+            </div>
+          )}
+        </div>
+
+        {/* Miniaturas */}
+        {displayImages.length > 1 && (
+          <div className="w-full">
+            <div className="flex gap-2 overflow-x-auto pb-2 -mx-2 px-2">
+              {displayImages.map((image, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => handleThumbnailClick(index)}
+                  className={`flex-shrink-0 relative w-20 h-20 rounded-lg overflow-hidden border-2 transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+                    selectedIndex === index
+                      ? "border-primary-600 ring-2 ring-primary-200"
+                      : "border-gray-200 hover:border-gray-300"
+                  }`}
+                  aria-label={`Ver imagen ${index + 1} de ${displayImages.length}`}
+                  aria-pressed={selectedIndex === index}
+                >
+                  <ImageWithFallback
+                    src={image.url}
+                    alt={`${title} - Miniatura ${index + 1}`}
+                    width={80}
+                    height={80}
+                    className="w-full h-full object-cover"
+                    sizes="80px"
+                    loading="lazy"
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Lightbox */}
+      {isLightboxOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4"
+          onClick={() => setIsLightboxOpen(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Vista ampliada de imagen"
+        >
+          <button
+            type="button"
+            onClick={() => setIsLightboxOpen(false)}
+            className="absolute top-4 right-4 text-white hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-white rounded-full p-2"
+            aria-label="Cerrar vista ampliada"
+          >
+            <svg
+              className="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+
+          {displayImages.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handlePrevious();
+                }}
+                disabled={selectedIndex === 0}
+                className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 disabled:opacity-30 disabled:cursor-not-allowed text-white rounded-full p-3 focus:outline-none focus:ring-2 focus:ring-white"
+                aria-label="Imagen anterior"
+              >
+                <svg
+                  className="w-8 h-8"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleNext();
+                }}
+                disabled={selectedIndex === displayImages.length - 1}
+                className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 disabled:opacity-30 disabled:cursor-not-allowed text-white rounded-full p-3 focus:outline-none focus:ring-2 focus:ring-white"
+                aria-label="Imagen siguiente"
+              >
+                <svg
+                  className="w-8 h-8"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </button>
+            </>
+          )}
+
+          <div
+            className="max-w-5xl max-h-[90vh] w-full h-full flex items-center justify-center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ImageWithFallback
+              src={currentImage.url}
+              alt={`${title} - Vista ampliada`}
+              width={1200}
+              height={1200}
+              className="max-w-full max-h-full object-contain"
+              sizes="100vw"
+            />
+          </div>
+
+          {displayImages.length > 1 && (
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white text-sm">
+              {selectedIndex + 1} / {displayImages.length}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/src/lib/catalog/getProductImages.server.ts
+++ b/src/lib/catalog/getProductImages.server.ts
@@ -1,0 +1,41 @@
+import "server-only";
+import { unstable_noStore as noStore } from "next/cache";
+import { createClient } from "@/lib/supabase/public";
+
+export type ProductImage = {
+  url: string;
+  is_primary: boolean | null;
+  created_at: string;
+};
+
+/**
+ * Obtiene las imágenes de un producto desde product_images.
+ * Ordena por is_primary desc, luego por created_at asc.
+ */
+export async function getProductImages(
+  productId: string,
+): Promise<ProductImage[]> {
+  noStore();
+  const sb = createClient();
+
+  const { data, error } = await sb
+    .from("product_images")
+    .select("url, is_primary, created_at")
+    .eq("product_id", productId)
+    .order("is_primary", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: true });
+
+  if (error || !data) {
+    if (process.env.NODE_ENV !== "production" && error) {
+      console.warn("[getProductImages] Error:", error);
+    }
+    return [];
+  }
+
+  return data.map((img) => ({
+    url: img.url,
+    is_primary: img.is_primary,
+    created_at: img.created_at,
+  }));
+}
+

--- a/src/lib/catalog/sortProductImages.ts
+++ b/src/lib/catalog/sortProductImages.ts
@@ -1,0 +1,30 @@
+export type ProductImage = {
+  url: string;
+  is_primary?: boolean | null;
+  created_at?: string;
+};
+
+/**
+ * Ordena imágenes de producto:
+ * 1. Primero las marcadas como is_primary = true
+ * 2. Luego por created_at ascendente
+ */
+export function sortProductImages(
+  images: ProductImage[],
+): ProductImage[] {
+  return [...images].sort((a, b) => {
+    // Primero: is_primary = true va primero
+    const aIsPrimary = a.is_primary === true;
+    const bIsPrimary = b.is_primary === true;
+
+    if (aIsPrimary && !bIsPrimary) return -1;
+    if (!aIsPrimary && bIsPrimary) return 1;
+
+    // Segundo: ordenar por created_at ascendente
+    const aDate = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const bDate = b.created_at ? new Date(b.created_at).getTime() : 0;
+
+    return aDate - bDate;
+  });
+}
+

--- a/src/test/lib/catalog/sortProductImages.test.ts
+++ b/src/test/lib/catalog/sortProductImages.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { sortProductImages } from "@/lib/catalog/sortProductImages";
+
+describe("sortProductImages", () => {
+  it("debe poner primero las imágenes con is_primary = true", () => {
+    const images = [
+      { url: "/img2.jpg", is_primary: false },
+      { url: "/img1.jpg", is_primary: true },
+      { url: "/img3.jpg", is_primary: null },
+    ];
+
+    const sorted = sortProductImages(images);
+
+    expect(sorted[0].url).toBe("/img1.jpg");
+    expect(sorted[0].is_primary).toBe(true);
+  });
+
+  it("debe ordenar por created_at ascendente cuando no hay is_primary", () => {
+    const images = [
+      { url: "/img2.jpg", created_at: "2024-01-02T00:00:00Z" },
+      { url: "/img1.jpg", created_at: "2024-01-01T00:00:00Z" },
+      { url: "/img3.jpg", created_at: "2024-01-03T00:00:00Z" },
+    ];
+
+    const sorted = sortProductImages(images);
+
+    expect(sorted[0].url).toBe("/img1.jpg");
+    expect(sorted[1].url).toBe("/img2.jpg");
+    expect(sorted[2].url).toBe("/img3.jpg");
+  });
+
+  it("debe combinar is_primary y created_at correctamente", () => {
+    const images = [
+      { url: "/img2.jpg", is_primary: false, created_at: "2024-01-01T00:00:00Z" },
+      { url: "/img1.jpg", is_primary: true, created_at: "2024-01-02T00:00:00Z" },
+      { url: "/img3.jpg", is_primary: true, created_at: "2024-01-01T00:00:00Z" },
+    ];
+
+    const sorted = sortProductImages(images);
+
+    // Primero las is_primary, ordenadas por created_at
+    expect(sorted[0].url).toBe("/img3.jpg"); // is_primary + created_at más antiguo
+    expect(sorted[1].url).toBe("/img1.jpg"); // is_primary + created_at más reciente
+    expect(sorted[2].url).toBe("/img2.jpg"); // no primary
+  });
+
+  it("debe manejar imágenes sin created_at", () => {
+    const images = [
+      { url: "/img2.jpg", is_primary: false },
+      { url: "/img1.jpg", is_primary: true },
+    ];
+
+    const sorted = sortProductImages(images);
+
+    expect(sorted[0].url).toBe("/img1.jpg");
+    expect(sorted[1].url).toBe("/img2.jpg");
+  });
+
+  it("debe mantener el orden si todas tienen is_primary = true", () => {
+    const images = [
+      { url: "/img2.jpg", is_primary: true, created_at: "2024-01-02T00:00:00Z" },
+      { url: "/img1.jpg", is_primary: true, created_at: "2024-01-01T00:00:00Z" },
+    ];
+
+    const sorted = sortProductImages(images);
+
+    expect(sorted[0].url).toBe("/img1.jpg");
+    expect(sorted[1].url).toBe("/img2.jpg");
+  });
+});
+


### PR DESCRIPTION
## Objetivo

Implementar galería de imágenes en la PDP usando las imágenes guardadas en \public.product_images\, reemplazando la imagen única actual.

## Cambios

### Nuevos archivos
- \src/lib/catalog/getProductImages.server.ts\: Función server-side para obtener imágenes desde \product_images\
- \src/lib/catalog/sortProductImages.ts\: Helper para ordenar imágenes (is_primary primero, luego created_at)
- \src/components/pdp/ProductGallery.tsx\: Componente de galería con imagen principal, miniaturas, swipe móvil y lightbox
- \src/test/lib/catalog/sortProductImages.test.ts\: Tests unitarios (5 tests pasando)

### Archivos modificados
- \src/app/catalogo/[section]/[slug]/page.tsx\: Integración de ProductGallery en la PDP

## Características

- ✅ Galería con imagen principal (aspect-square, object-contain)
- ✅ Miniaturas con scroll horizontal
- ✅ Swipe en móvil (touch handlers sin librerías externas)
- ✅ Lightbox al hacer click en imagen principal
- ✅ Ordenamiento: is_primary primero, luego created_at
- ✅ Fallback a image_url del producto si no hay imágenes en product_images
- ✅ Accesibilidad: ARIA labels, navegación por teclado
- ✅ Performance: priority solo en primera imagen, lazy en miniaturas

## Validaciones

- ✅ \pnpm typecheck\: OK
- ✅ \pnpm test\: 5 tests pasando
- ✅ \pnpm build\: OK
- ✅ \pnpm lint\: Sin errores

## Checklist

- [x] Código compila sin errores
- [x] Tests unitarios pasando
- [x] Build exitoso
- [x] Lint sin errores
- [x] Swipe móvil funcional
- [x] Lightbox funcional
- [x] Fallback a image_url implementado
- [x] Accesibilidad (ARIA labels)