### PR TITLE
feat(pdp): selector de color + persistencia en order_items

### DIFF
--- a/ops/sql/add_variant_detail_to_order_items.sql
+++ b/ops/sql/add_variant_detail_to_order_items.sql
@@ -1,0 +1,10 @@
+-- Agregar columna variant_detail (JSONB) a order_items para guardar detalles de variantes (colores, etc.)
+-- Ejecutar en Supabase SQL Editor
+
+ALTER TABLE public.order_items
+ADD COLUMN IF NOT EXISTS variant_detail JSONB;
+
+-- Comentario para documentación
+COMMENT ON COLUMN public.order_items.variant_detail IS 
+  'Detalles de variantes del producto (ej: {"color": "Azul"} o {"color": "Surtido", "notes": "2 azules y 1 rojo"})';
+

--- a/src/app/carrito/page.tsx
+++ b/src/app/carrito/page.tsx
@@ -121,6 +121,11 @@ export default function CarritoPage() {
               </div>
               <div className="flex-1">
                 <h3 className="font-semibold mb-1">{item.title}</h3>
+                {item.variant_detail && (
+                  <p className="text-xs text-gray-600 mt-1 italic">
+                    {item.variant_detail}
+                  </p>
+                )}
                 <p className="text-sm text-gray-500">ID: {item.id}</p>
                 <p className="text-primary-600 font-bold mt-2">
                   {formatMXN(item.price)}

--- a/src/app/checkout/pago/PagoClient.tsx
+++ b/src/app/checkout/pago/PagoClient.tsx
@@ -469,17 +469,13 @@ export default function PagoClient() {
                 ? Math.round(item.price * 100)
                 : 0;
           
-          // Incluir variant_detail en el título si existe
-          const titleWithVariant = item.variant_detail
-            ? `${item.title} — ${item.variant_detail}`
-            : item.title;
-          
           return {
             id: item.id,
             qty,
             price_cents: priceCents,
-            title: titleWithVariant,
+            title: item.title,
             image_url: item.image_url || null,
+            variant_detail: item.variant_detail || null,
           };
         }).filter((item) => item.price_cents > 0),
       };
@@ -693,17 +689,13 @@ export default function PagoClient() {
             });
           }
           
-          // Incluir variant_detail en el título si existe
-          const titleWithVariant = item.variant_detail
-            ? `${item.title} — ${item.variant_detail}`
-            : item.title;
-          
           return {
             id: item.id,
             qty,
             price_cents: priceCents,
-            title: titleWithVariant, // Título del producto con variant_detail si existe
-            image_url: item.image_url || null, // URL de imagen del producto
+            title: item.title,
+            image_url: item.image_url || null,
+            variant_detail: item.variant_detail || null,
           };
         }).filter((item) => item.price_cents > 0), // Filtrar items sin precio válido
       };

--- a/src/components/pdp/ColorSelector.tsx
+++ b/src/components/pdp/ColorSelector.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { getColorOptions, SURTIDO_OPTION, formatColorVariantDetail } from "@/lib/products/colors";
+
+type Props = {
+  productSlug: string;
+  productTitle?: string;
+  value: string | null; // Color seleccionado o null
+  notes: string | null; // Notas si es surtido
+  onChange: (color: string | null, notes: string | null) => void;
+  required?: boolean;
+};
+
+export default function ColorSelector({
+  productSlug,
+  productTitle,
+  value,
+  notes,
+  onChange,
+  required = false,
+}: Props) {
+  const colors = getColorOptions(productSlug, productTitle);
+  const [localNotes, setLocalNotes] = useState(notes || "");
+
+  if (colors.length === 0) {
+    return null;
+  }
+
+  const isSurtido = value === SURTIDO_OPTION;
+
+  const handleColorChange = (color: string) => {
+    if (color === SURTIDO_OPTION) {
+      onChange(SURTIDO_OPTION, localNotes || null);
+    } else {
+      onChange(color, null);
+    }
+  };
+
+  const handleNotesChange = (newNotes: string) => {
+    setLocalNotes(newNotes);
+    if (isSurtido) {
+      onChange(SURTIDO_OPTION, newNotes.trim() || null);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Color {required && <span className="text-red-500">*</span>}
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {colors.map((color) => (
+            <button
+              key={color}
+              type="button"
+              onClick={() => handleColorChange(color)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+                value === color
+                  ? "bg-primary-600 text-white shadow-md"
+                  : "bg-white border-2 border-gray-300 text-gray-700 hover:border-primary-400 hover:bg-primary-50"
+              }`}
+              aria-pressed={value === color}
+              aria-label={`Seleccionar color ${color}`}
+            >
+              {color}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => handleColorChange(SURTIDO_OPTION)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+              isSurtido
+                ? "bg-primary-600 text-white shadow-md"
+                : "bg-white border-2 border-gray-300 text-gray-700 hover:border-primary-400 hover:bg-primary-50"
+            }`}
+            aria-pressed={isSurtido}
+            aria-label="Seleccionar surtido (mix)"
+          >
+            {SURTIDO_OPTION}
+          </button>
+        </div>
+      </div>
+
+      {/* Input de notas si es surtido */}
+      {isSurtido && (
+        <div>
+          <label
+            htmlFor="color-notes"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Preferencia de colores (opcional)
+          </label>
+          <textarea
+            id="color-notes"
+            value={localNotes}
+            onChange={(e) => handleNotesChange(e.target.value)}
+            placeholder="Ej: 2 azules y 1 rojo"
+            rows={2}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            aria-label="Preferencia de colores para surtido"
+          />
+        </div>
+      )}
+
+      {/* Aviso de disponibilidad */}
+      <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+        <p>
+          Los colores están sujetos a disponibilidad. Si el color seleccionado no está disponible, te enviaremos uno igual o lo más parecido posible. Si necesitas un color específico sin sustitución, indícalo en notas o contáctanos por WhatsApp antes de comprar.
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/products/colors.ts
+++ b/src/lib/products/colors.ts
@@ -1,0 +1,88 @@
+/**
+ * Configuración de productos con opciones de color
+ */
+
+export type ColorProduct = {
+  productSlug: string;
+  productTitle?: string; // Opcional, para búsqueda por título también
+  colors: string[];
+};
+
+// Lista de productos que tienen opciones de color
+const COLOR_PRODUCTS: ColorProduct[] = [
+  {
+    productSlug: "modulo-de-llave",
+    productTitle: "MODULO DE LLAVE",
+    colors: [
+      "Azul",
+      "Rojo",
+      "Verde",
+      "Amarillo",
+      "Rosa",
+      "Naranja",
+      "Morado",
+      "Negro",
+      "Blanco",
+      "Gris",
+    ],
+  },
+];
+
+/**
+ * Verifica si un producto tiene opciones de color
+ */
+export function hasColorOptions(productSlug: string, productTitle?: string): boolean {
+  return COLOR_PRODUCTS.some(
+    (p) =>
+      p.productSlug.toLowerCase() === productSlug.toLowerCase() ||
+      (productTitle && p.productTitle?.toUpperCase() === productTitle.toUpperCase()),
+  );
+}
+
+/**
+ * Obtiene las opciones de color para un producto
+ */
+export function getColorOptions(productSlug: string, productTitle?: string): string[] {
+  const product = COLOR_PRODUCTS.find(
+    (p) =>
+      p.productSlug.toLowerCase() === productSlug.toLowerCase() ||
+      (productTitle && p.productTitle?.toUpperCase() === productTitle.toUpperCase()),
+  );
+  return product?.colors || [];
+}
+
+/**
+ * Opción especial para "Surtido (mix)"
+ */
+export const SURTIDO_OPTION = "Surtido (mix)";
+
+/**
+ * Formatea el variant_detail para color
+ */
+export function formatColorVariantDetail(color: string, notes?: string | null): string {
+  if (color === SURTIDO_OPTION) {
+    return notes ? `Color: ${color} · Preferencia: ${notes}` : `Color: ${color}`;
+  }
+  return `Color: ${color}`;
+}
+
+/**
+ * Parsea variant_detail para extraer color y notas
+ */
+export function parseColorVariantDetail(variantDetail: string): {
+  color: string | null;
+  notes: string | null;
+} {
+  if (!variantDetail) return { color: null, notes: null };
+
+  // Buscar "Color: ..."
+  const colorMatch = variantDetail.match(/Color:\s*([^·]+)/);
+  const color = colorMatch ? colorMatch[1].trim() : null;
+
+  // Buscar "Preferencia: ..."
+  const notesMatch = variantDetail.match(/Preferencia:\s*(.+)/);
+  const notes = notesMatch ? notesMatch[1].trim() : null;
+
+  return { color, notes };
+}
+

--- a/src/lib/products/parseVariantDetail.ts
+++ b/src/lib/products/parseVariantDetail.ts
@@ -1,0 +1,75 @@
+/**
+ * Utilidades para parsear y convertir variant_detail entre string y JSON
+ */
+
+import { parseColorVariantDetail } from "./colors";
+
+export type VariantDetailJSON = {
+  color?: string;
+  notes?: string;
+  // Para otras variantes (arcos, brackets, etc.)
+  [key: string]: string | undefined;
+};
+
+/**
+ * Convierte variant_detail (string) a JSON para guardar en order_items.variant_detail
+ * Ejemplo: "Color: Azul · Medida: 0.016" -> { color: "Azul", medida: "0.016" }
+ */
+export function variantDetailToJSON(variantDetail: string | null | undefined): VariantDetailJSON | null {
+  if (!variantDetail) return null;
+
+  const result: VariantDetailJSON = {};
+
+  // Separar por " · " (separador usado en formatVariantDetail)
+  const parts = variantDetail.split(" · ");
+
+  for (const part of parts) {
+    const match = part.match(/^([^:]+):\s*(.+)$/);
+    if (match) {
+      const key = match[1].trim().toLowerCase();
+      const value = match[2].trim();
+
+      // Mapear claves conocidas
+      if (key === "color") {
+        result.color = value;
+      } else if (key === "preferencia") {
+        result.notes = value;
+      } else {
+        // Otras variantes (medida, arcada, pieza, sistema, etc.)
+        result[key] = value;
+      }
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Convierte variant_detail JSON a string para mostrar en UI
+ */
+export function variantDetailFromJSON(variantDetailJSON: VariantDetailJSON | null | undefined): string | null {
+  if (!variantDetailJSON || Object.keys(variantDetailJSON).length === 0) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  // Color siempre primero
+  if (variantDetailJSON.color) {
+    parts.push(`Color: ${variantDetailJSON.color}`);
+    if (variantDetailJSON.notes) {
+      parts.push(`Preferencia: ${variantDetailJSON.notes}`);
+    }
+  }
+
+  // Otras variantes
+  for (const [key, value] of Object.entries(variantDetailJSON)) {
+    if (key !== "color" && key !== "notes" && value) {
+      const label = key.charAt(0).toUpperCase() + key.slice(1);
+      parts.push(`${label}: ${value}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+


### PR DESCRIPTION
## Objetivo

Implementar selector de color para productos con variedad (ej: MODULO DE LLAVE) sin crear variantes en DB, guardando la selección en `order_items.variant_detail` como JSONB.

## Cambios

### Nuevos archivos
- `src/lib/products/colors.ts`: Helpers para identificar productos con colores y formatear variant_detail
- `src/components/pdp/ColorSelector.tsx`: Componente de selector de color con chips y opción "Surtido (mix)"
- `src/lib/products/parseVariantDetail.ts`: Utilidades para convertir variant_detail entre string y JSON
- `ops/sql/add_variant_detail_to_order_items.sql`: Script SQL para agregar columna `variant_detail` (JSONB) a `order_items`

### Archivos modificados
- `src/components/product/ProductActions.client.tsx`: Integración de ColorSelector, validación de color requerido
- `src/app/api/checkout/create-order/route.ts`: Guardado de variant_detail como JSON en order_items
- `src/app/api/checkout/save-order/route.ts`: Guardado de variant_detail como JSON en order_items
- `src/app/checkout/pago/PagoClient.tsx`: Envío de variant_detail en payload de orden
- `src/app/carrito/page.tsx`: Visualización de variant_detail en carrito
- `src/app/cuenta/pedidos/ClientPage.tsx`: Visualización de variant_detail desde JSON en pedidos

## Características

- ✅ Selector de color con chips para colores disponibles
- ✅ Opción "Surtido (mix)" con input opcional para preferencias
- ✅ Aviso de disponibilidad de colores
- ✅ Validación: color obligatorio si el producto tiene colores (default: "Surtido (mix)" preseleccionado)
- ✅ Persistencia: variant_detail guardado como JSON en `order_items.variant_detail`
- ✅ Visualización: color mostrado en PDP, carrito, checkout y pedidos
- ✅ Compatibilidad: funciona junto con otras variantes (arcos, brackets, etc.)

## Estructura de datos

- **En carrito**: `variant_detail` como string (ej: "Color: Azul" o "Color: Surtido · Preferencia: 2 azules y 1 rojo")
- **En order_items**: `variant_detail` como JSONB (ej: `{"color": "Azul"}` o `{"color": "Surtido", "notes": "2 azules y 1 rojo"}`)

## Productos configurados

- `modulo-de-llave` (MODULO DE LLAVE) — 10 colores disponibles

## ⚠️ Paso obligatorio post-merge

**Ejecutar en Supabase SQL Editor:**

```sql
ALTER TABLE public.order_items
ADD COLUMN IF NOT EXISTS variant_detail JSONB;

COMMENT ON COLUMN public.order_items.variant_detail IS 
  'Detalles de variantes del producto (ej: {"color": "Azul"} o {"color": "Surtido", "notes": "2 azules y 1 rojo"})';
```

O ejecutar el script completo:
- `ops/sql/add_variant_detail_to_order_items.sql`

## Validaciones

- ✅ `pnpm typecheck`: OK
- ✅ `pnpm build`: OK
- ✅ `pnpm lint`: Solo warnings preexistentes (no relacionados)
- ⚠️ `pnpm test`: Algunos tests fallando (preexistentes, no relacionados con estos cambios)

## Checklist

- [x] Código compila sin errores
- [x] Build exitoso
- [x] Lint sin errores nuevos
- [x] Selector de color funcional
- [x] Persistencia en order_items implementada
- [x] Visualización en todas las vistas
- [x] Script SQL incluido
- [ ] Script SQL ejecutado en Supabase (pendiente post-merge)
