### PR TITLE
fix(auth): add /auth/confirm verifyOtp flow for password recovery

### DIFF
--- a/src/app/auth/confirm/api/route.ts
+++ b/src/app/auth/confirm/api/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabase } from "@/lib/supabase/server-auth";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /auth/confirm
+ * 
+ * Verifica el token_hash usando verifyOtp (patrón recomendado de Supabase).
+ * Protegido contra link scanners: solo consume el token cuando el usuario hace POST.
+ * 
+ * El email link apunta a /auth/confirm?token_hash=...&type=recovery&next=/reset-password
+ * pero la page.tsx muestra un botón "Continuar" que hace POST aquí.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const tokenHash = formData.get("token_hash") as string | null;
+    const type = formData.get("type") as string | null;
+    const nextParam = formData.get("next") as string | null;
+
+    if (!tokenHash) {
+      return NextResponse.redirect(
+        new URL("/auth/error?error=missing_token", request.nextUrl.origin),
+      );
+    }
+
+    const supabase = createServerSupabase();
+
+    // verifyOtp con token_hash (patrón recomendado de Supabase)
+    const { error } = await supabase.auth.verifyOtp({
+      token_hash: tokenHash,
+      type: (type as "recovery" | "email" | "magiclink" | "signup") || "recovery",
+    });
+
+    if (error) {
+      console.error("[auth/confirm] Error verifying OTP:", {
+        error: error.message,
+        type,
+        hasTokenHash: !!tokenHash,
+      });
+      return NextResponse.redirect(
+        new URL(
+          `/auth/error?error=${encodeURIComponent(error.message)}`,
+          request.nextUrl.origin,
+        ),
+      );
+    }
+
+    // Determinar next path (sanitizar)
+    let nextPath = "/reset-password";
+    if (nextParam && nextParam.startsWith("/")) {
+      nextPath = nextParam;
+    } else if (type === "signup" || type === "magiclink") {
+      nextPath = "/cuenta?verified=1";
+    }
+    // Si type === "recovery" o no hay nextParam, nextPath ya es "/reset-password"
+
+    // Éxito: redirigir con sesión válida
+    return NextResponse.redirect(new URL(nextPath, request.nextUrl.origin));
+  } catch (err) {
+    console.error("[auth/confirm] Unexpected error:", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.redirect(
+      new URL("/auth/error?error=unexpected", request.nextUrl.origin),
+    );
+  }
+}
+

--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+
+function AuthConfirmContent() {
+  const searchParams = useSearchParams();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const tokenHash = searchParams?.get("token_hash") || null;
+  const type = searchParams?.get("type") || null;
+  const nextParam = searchParams?.get("next") || null;
+
+  const handleConfirm = async () => {
+    if (!tokenHash) {
+      setError("No se encontró token de verificación");
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("token_hash", tokenHash);
+      if (type) formData.append("type", type);
+      if (nextParam) formData.append("next", nextParam);
+
+      const response = await fetch("/auth/confirm/api", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (response.redirected) {
+        // La redirección se maneja automáticamente
+        window.location.href = response.url;
+      } else if (!response.ok) {
+        const errorText = await response.text();
+        setError(`Error: ${errorText || "Error al verificar el enlace"}`);
+        setIsProcessing(false);
+      }
+    } catch (err) {
+      console.error("[auth/confirm] Error:", err);
+      setError("Error inesperado al procesar el enlace");
+      setIsProcessing(false);
+    }
+  };
+
+  if (!tokenHash) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center max-w-md mx-auto px-4">
+          <div className="mb-4 text-red-600">
+            <svg
+              className="mx-auto h-12 w-12"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900 mb-2">
+            Enlace inválido
+          </h1>
+          <p className="text-sm text-gray-600 mb-4">
+            No se encontró token de verificación en el enlace.
+          </p>
+          <Link
+            href="/forgot-password"
+            className="inline-block btn btn-primary"
+          >
+            Solicitar nuevo enlace
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="text-center max-w-md mx-auto px-4">
+        <div className="mb-6">
+          <div className="mx-auto h-16 w-16 rounded-full bg-primary-100 flex items-center justify-center mb-4">
+            <svg
+              className="h-8 w-8 text-primary-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-semibold text-gray-900 mb-2">
+            Verificar enlace
+          </h1>
+          <p className="text-sm text-gray-600">
+            {type === "recovery"
+              ? "Haz clic en el botón para continuar con el restablecimiento de contraseña."
+              : "Haz clic en el botón para verificar tu enlace."}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 bg-red-50 border border-red-200 text-red-700 p-4 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={handleConfirm}
+          disabled={isProcessing}
+          className="w-full btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isProcessing ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg
+                className="animate-spin h-4 w-4"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+              Verificando...
+            </span>
+          ) : (
+            "Continuar"
+          )}
+        </button>
+
+        <div className="mt-6 text-center">
+          <Link
+            href="/cuenta"
+            className="text-sm text-primary-600 hover:text-primary-700 hover:underline"
+          >
+            ← Volver a iniciar sesión
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthConfirmPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-gray-50">
+          <div className="text-center">
+            <div className="mb-4">
+              <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary-200 border-t-primary-600"></div>
+            </div>
+            <h1 className="text-xl font-semibold text-gray-900">Cargando...</h1>
+          </div>
+        </div>
+      }
+    >
+      <AuthConfirmContent />
+    </Suspense>
+  );
+}
+

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+
+function AuthErrorContent() {
+  const searchParams = useSearchParams();
+  const error = searchParams?.get("error") || "Error desconocido";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="text-center max-w-md mx-auto px-4">
+        <div className="mb-4 text-red-600">
+          <svg
+            className="mx-auto h-12 w-12"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900 mb-2">
+          Error de autenticación
+        </h1>
+        <p className="text-sm text-gray-600 mb-4">{error}</p>
+        <div className="space-y-2">
+          <Link href="/forgot-password" className="btn btn-primary block">
+            Solicitar nuevo enlace
+          </Link>
+          <Link
+            href="/cuenta"
+            className="text-sm text-primary-600 hover:text-primary-700 hover:underline block"
+          >
+            ← Volver a iniciar sesión
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthErrorPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-gray-50">
+          <div className="text-center">
+            <div className="mb-4">
+              <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary-200 border-t-primary-600"></div>
+            </div>
+            <h1 className="text-xl font-semibold text-gray-900">Cargando...</h1>
+          </div>
+        </div>
+      }
+    >
+      <AuthErrorContent />
+    </Suspense>
+  );
+}
+

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -117,9 +117,9 @@ export async function forgotPasswordAction(input: unknown) {
 
   const supabase = createActionSupabase();
 
-  // Plan B robusto: apuntar directamente a /reset-password
-  // Esto elimina la dependencia de /auth/callback y evita pérdida de query params
-  const redirectTo = `${SITE_URL}/reset-password`;
+  // Usar patrón recomendado de Supabase: /auth/confirm con token_hash
+  // El template del email debe usar: {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password
+  const redirectTo = `${SITE_URL}/auth/confirm?type=recovery&next=/reset-password`;
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
     redirectTo,


### PR DESCRIPTION
## Problema
El link de recovery llega a `/reset-password` sin params en producción, mostrando "No se encontró código de autenticación ni tokens". El flujo anterior dependía de `/auth/v1/verify` o de hashes/codes que se pierden en redirects.

## Solución
Implementar el patrón recomendado de Supabase: `/auth/confirm` + `verifyOtp(token_hash)`.

### Cambios principales:
- **`/auth/confirm/page.tsx`**: Muestra botón "Continuar" (protección contra link scanners)
- **`/auth/confirm/api/route.ts`**: POST endpoint que consume el token con `verifyOtp(token_hash)`
- **`/reset-password`**: Simplificado para depender solo de sesión (eliminado parseo de hash/search)
- **`forgotPasswordAction`**: Actualizado `redirectTo` para usar `/auth/confirm`
- **`/auth/error`**: Nueva página para manejo de errores

### Flujo:
1. Email → `/auth/confirm?token_hash=...&type=recovery&next=/reset-password`
2. Usuario hace clic en "Continuar" → POST a `/auth/confirm/api` → `verifyOtp(token_hash)` → crea sesión
3. Redirige a `/reset-password` con sesión válida
4. Usuario cambia contraseña

## Checklist Supabase (antes de merge)

### Email Template (Reset Password):
```html
<a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password">Restablecer contraseña</a>
```

**⚠️ IMPORTANTE**: NO usar `{{ .ConfirmationURL }}` (ese usa `/auth/v1/verify`).

### Configuración:
- [ ] Site URL = `https://ddnshop.mx`
- [ ] Redirect URLs incluyen `https://ddnshop.mx/**`
- [ ] Redirect URLs incluyen `https://ddnshop.mx/auth/confirm**`
- [ ] Template Reset Password usa `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password`

## Cómo probar
1. Solicita reset en `/forgot-password`
2. Abre el link del email (debe apuntar a `/auth/confirm?token_hash=...`)
3. Haz clic en "Continuar"
4. Debe redirigir a `/reset-password` con sesión válida
5. Cambia la contraseña y verifica que funcione

