### PR TITLE
docs(auth): snapshot Supabase email templates

### DIFF
--- a/docs/auth-email-templates/README.md
+++ b/docs/auth-email-templates/README.md
@@ -1,0 +1,89 @@
+# Templates de Email de Supabase Auth
+
+Este directorio contiene snapshots de los templates de email configurados en Supabase Dashboard para autenticación.
+
+## 📋 Uso
+
+Estos templates se copian y pegan directamente en **Supabase Dashboard > Authentication > Email Templates**.
+
+**⚠️ IMPORTANTE**: 
+- Estos son snapshots de los templates actuales en producción.
+- Cualquier cambio en el dashboard debe reflejarse aquí para mantener trazabilidad.
+- Los templates son "copy/paste friendly" para facilitar su uso en el dashboard.
+
+## 📊 Resumen de Templates
+
+| Template | Dónde se configura | Variable principal | Acción / Ruta destino |
+|----------|---------------------|-------------------|----------------------|
+| **Reset Password** | Authentication > Email Templates > Reset Password | `{{ .TokenHash }}` | `/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password` |
+| **Confirm Signup** | Authentication > Email Templates > Confirm Signup | `{{ .ConfirmationURL }}` | `/auth/callback` (o ruta configurada en `redirectTo`) |
+| **Magic Link** | Authentication > Email Templates > Magic Link | `{{ .ConfirmationURL }}` | `/auth/callback` (o ruta configurada en `redirectTo`) |
+| **Change Email Address** | Authentication > Email Templates > Change Email Address | `{{ .ConfirmationURL }}` | `/auth/callback` (o ruta configurada en `redirectTo`) |
+| **Invite User** | Authentication > Email Templates > Invite User | `{{ .ConfirmationURL }}` | `/auth/callback` (o ruta configurada en `redirectTo`) |
+| **Reauthentication** | Authentication > Email Templates > Reauthentication | `{{ .ConfirmationURL }}` | `/auth/callback` (o ruta configurada en `redirectTo`) |
+
+## 🔒 Nota sobre Protección contra Link Scanners
+
+El template **Reset Password** usa el flujo `/auth/confirm` que implementa protección contra link scanners:
+
+- El link del email apunta a `/auth/confirm?token_hash=...&type=recovery&next=/reset-password`
+- La página `/auth/confirm` muestra un botón "Continuar" (no consume el token automáticamente)
+- Solo cuando el usuario hace clic en "Continuar", se hace POST a `/auth/confirm/api` que consume el token con `verifyOtp(token_hash)`
+- Esto evita que scanners de email (Gmail, antivirus, etc.) consuman el token al hacer GET automático
+
+## ✅ Checklist de Configuración en Supabase
+
+Antes de hacer deploy o después de cambios, verificar:
+
+### 1. Site URL y Redirect URLs
+
+En **Supabase Dashboard > Authentication > URL Configuration**:
+
+- [ ] **Site URL** = `https://ddnshop.mx`
+- [ ] **Redirect URLs** incluyen:
+  - `https://ddnshop.mx/**` (permite cualquier ruta)
+  - `https://ddnshop.mx/auth/confirm**` (específico para confirmación con token_hash)
+  - `https://ddnshop.mx/reset-password` (específico para reset password)
+  - `https://ddnshop.mx/auth/callback**` (para otros flujos como signup, magic link)
+
+### 2. Templates de Email
+
+En **Supabase Dashboard > Authentication > Email Templates**:
+
+- [ ] **Reset Password**: 
+  - Verificar que el link use: `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password`
+  - ⚠️ **NO usar** `{{ .ConfirmationURL }}` (ese usa `/auth/v1/verify` que puede perder query params)
+- [ ] **Confirm Signup**: Verificar que use `{{ .ConfirmationURL }}` o ruta personalizada
+- [ ] **Magic Link**: Verificar que use `{{ .ConfirmationURL }}` o ruta personalizada
+- [ ] **Change Email Address**: Verificar que use `{{ .ConfirmationURL }}` o ruta personalizada
+- [ ] **Invite User**: Verificar que use `{{ .ConfirmationURL }}` o ruta personalizada
+- [ ] **Reauthentication**: Verificar que use `{{ .ConfirmationURL }}` o ruta personalizada
+
+### 3. Variables Disponibles en Templates
+
+Supabase proporciona estas variables en los templates:
+
+- `{{ .SiteURL }}` - URL base del sitio (ej: `https://ddnshop.mx`)
+- `{{ .TokenHash }}` - Hash del token (usado en Reset Password con `/auth/confirm`)
+- `{{ .Token }}` - Token completo (usado en algunos flujos)
+- `{{ .ConfirmationURL }}` - URL completa de confirmación (usa `/auth/v1/verify` de Supabase)
+- `{{ .Email }}` - Email del usuario
+- `{{ .RedirectTo }}` - URL de redirección después de confirmación
+
+**Nota**: Para Reset Password, preferir `{{ .TokenHash }}` con `/auth/confirm` en lugar de `{{ .ConfirmationURL }}` para evitar pérdida de query params.
+
+## 🔄 Actualizar Templates
+
+Si se modifica un template en Supabase Dashboard:
+
+1. Copiar el HTML completo del template
+2. Pegarlo en el archivo correspondiente en `docs/auth-email-templates/`
+3. Hacer commit con mensaje descriptivo: `docs(auth): update [template-name] email template`
+4. Actualizar este README si cambia la ruta destino o variables usadas
+
+## 📚 Referencias
+
+- [Supabase Auth Email Templates Docs](https://supabase.com/docs/guides/auth/auth-email-templates)
+- [Supabase Auth URL Configuration](https://supabase.com/docs/guides/auth/auth-urls)
+- [Reset Password Setup](./../RESET_PASSWORD_SETUP.md)
+

--- a/docs/auth-email-templates/change-email-address.html
+++ b/docs/auth-email-templates/change-email-address.html
@@ -1,0 +1,11 @@
+<h2>Confirma tu nuevo correo electrónico</h2>
+<p>Hola,</p>
+<p>Recibimos una solicitud para cambiar tu correo electrónico en Depósito Dental Noriega.</p>
+<p>Para confirmar tu nuevo correo, haz clic en el siguiente enlace:</p>
+<p><a href="{{ .ConfirmationURL }}">Confirmar nuevo correo</a></p>
+<p>Si no solicitaste este cambio, puedes ignorar este correo y tu correo actual seguirá siendo válido.</p>
+<p>Este enlace expira en 1 hora.</p>
+<hr>
+<p><small>Depósito Dental Noriega - Insumos y equipos dentales</small></p>
+<p><small>Si tienes problemas, contacta a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a></small></p>
+

--- a/docs/auth-email-templates/confirm-signup.html
+++ b/docs/auth-email-templates/confirm-signup.html
@@ -1,0 +1,11 @@
+<h2>Confirma tu cuenta</h2>
+<p>Hola,</p>
+<p>Gracias por registrarte en Depósito Dental Noriega.</p>
+<p>Para completar tu registro, confirma tu cuenta haciendo clic en el siguiente enlace:</p>
+<p><a href="{{ .ConfirmationURL }}">Confirmar cuenta</a></p>
+<p>Si no creaste esta cuenta, puedes ignorar este correo.</p>
+<p>Este enlace expira en 24 horas.</p>
+<hr>
+<p><small>Depósito Dental Noriega - Insumos y equipos dentales</small></p>
+<p><small>Si tienes problemas, contacta a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a></small></p>
+

--- a/docs/auth-email-templates/invite-user.html
+++ b/docs/auth-email-templates/invite-user.html
@@ -1,0 +1,10 @@
+<h2>Invitación a Depósito Dental Noriega</h2>
+<p>Hola,</p>
+<p>Has sido invitado a crear una cuenta en Depósito Dental Noriega.</p>
+<p>Para aceptar la invitación y crear tu cuenta, haz clic en el siguiente enlace:</p>
+<p><a href="{{ .ConfirmationURL }}">Aceptar invitación</a></p>
+<p>Este enlace expira en 7 días.</p>
+<hr>
+<p><small>Depósito Dental Noriega - Insumos y equipos dentales</small></p>
+<p><small>Si tienes problemas, contacta a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a></small></p>
+

--- a/docs/auth-email-templates/magic-link.html
+++ b/docs/auth-email-templates/magic-link.html
@@ -1,0 +1,10 @@
+<h2>Inicia sesión en Depósito Dental Noriega</h2>
+<p>Hola,</p>
+<p>Haz clic en el siguiente enlace para iniciar sesión sin contraseña:</p>
+<p><a href="{{ .ConfirmationURL }}">Iniciar sesión</a></p>
+<p>Si no solicitaste este enlace, puedes ignorar este correo.</p>
+<p>Este enlace expira en 1 hora y solo puede usarse una vez.</p>
+<hr>
+<p><small>Depósito Dental Noriega - Insumos y equipos dentales</small></p>
+<p><small>Si tienes problemas, contacta a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a></small></p>
+

--- a/docs/auth-email-templates/reauthentication.html
+++ b/docs/auth-email-templates/reauthentication.html
@@ -1,0 +1,11 @@
+<h2>Verificación de seguridad</h2>
+<p>Hola,</p>
+<p>Se requiere verificación adicional para completar una acción sensible en tu cuenta de Depósito Dental Noriega.</p>
+<p>Haz clic en el siguiente enlace para verificar tu identidad:</p>
+<p><a href="{{ .ConfirmationURL }}">Verificar identidad</a></p>
+<p>Si no solicitaste esta verificación, contacta inmediatamente a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a>.</p>
+<p>Este enlace expira en 15 minutos.</p>
+<hr>
+<p><small>Depósito Dental Noriega - Insumos y equipos dentales</small></p>
+<p><small>Si tienes problemas, contacta a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a></small></p>
+

--- a/docs/auth-email-templates/reset-password.html
+++ b/docs/auth-email-templates/reset-password.html
@@ -1,0 +1,11 @@
+<h2>Restablece tu contraseña</h2>
+<p>Hola,</p>
+<p>Recibimos una solicitud para restablecer tu contraseña en Depósito Dental Noriega.</p>
+<p>Haz clic en el siguiente enlace para continuar:</p>
+<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/reset-password">Restablecer contraseña</a></p>
+<p>Si no solicitaste este cambio, puedes ignorar este correo.</p>
+<p>Este enlace expira en 1 hora.</p>
+<hr>
+<p><small>Depósito Dental Noriega - Insumos y equipos dentales</small></p>
+<p><small>Si tienes problemas, contacta a <a href="mailto:ventas@mail.ddnshop.mx">ventas@mail.ddnshop.mx</a></small></p>
+


### PR DESCRIPTION
## Qué
Snapshot de templates de email de Supabase Auth + README + checklist de deploy.

## Por qué
- Los cambios hechos manualmente en Supabase Dashboard no se pierden
- Facilita onboarding rápido para nuevos desarrolladores
- Trazabilidad de qué templates están en producción
- Checklist post-deploy evita bugs de configuración

## Cambios
- **Nuevos archivos**:
  - `docs/auth-email-templates/` (carpeta con 6 templates HTML)
  - `docs/auth-email-templates/README.md` (explicación, tabla resumen, checklist)
- **Modificados**:
  - `docs/RESET_PASSWORD_SETUP.md` (agregada sección "Post-deploy Checklist")

## Impacto
**SOLO documentación, sin cambios en runtime.**

No se modificó lógica de auth, solo se documentaron los templates que ya están configurados en Supabase Dashboard.

## Archivos creados
- `docs/auth-email-templates/reset-password.html`
- `docs/auth-email-templates/confirm-signup.html`
- `docs/auth-email-templates/magic-link.html`
- `docs/auth-email-templates/change-email-address.html`
- `docs/auth-email-templates/invite-user.html`
- `docs/auth-email-templates/reauthentication.html`
- `docs/auth-email-templates/README.md`

