### PR TITLE
feat(ui): PDP polish + RecentlyViewed improvements (follow-up)

### DIFF
--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -185,7 +185,7 @@ export default async function ProductDetailPage({ params }: Props) {
         />
 
         {/* Breadcrumb */}
-        <div className="bg-white dark:bg-gray-800 border-b dark:border-gray-700">
+        <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
           <div className="max-w-6xl mx-auto px-4 py-3">
             <Breadcrumbs
               items={[
@@ -215,7 +215,7 @@ export default async function ProductDetailPage({ params }: Props) {
             {/* Información del producto */}
             <div className="space-y-4 sm:space-y-6">
               <div>
-                <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100 mb-2">
+                <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
                   {product.title}
                 </h1>
                 <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 capitalize">
@@ -225,7 +225,7 @@ export default async function ProductDetailPage({ params }: Props) {
 
               {/* Precio y disponibilidad */}
               <div className="space-y-2">
-                <div className="text-4xl font-bold text-primary-600 dark:text-primary-400">
+                <div className="text-4xl sm:text-5xl font-bold text-primary-600 dark:text-primary-400">
                   {price}
                 </div>
                 <div className="flex items-center space-x-2 flex-wrap gap-2">
@@ -235,8 +235,8 @@ export default async function ProductDetailPage({ params }: Props) {
                       <span
                         className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
                           product.in_stock
-                            ? "bg-emerald-50 text-emerald-700"
-                            : "bg-red-50 text-red-700"
+                            ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800"
+                            : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800"
                         }`}
                       >
                         {product.in_stock ? "En stock" : "Agotado"}
@@ -313,7 +313,7 @@ export default async function ProductDetailPage({ params }: Props) {
           {/* Descripción del producto */}
           {product.description && (
             <section className="mt-12 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm p-6">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
                 Descripción del producto
               </h2>
               <div className="prose prose-sm max-w-none text-gray-700 dark:text-gray-300">
@@ -326,44 +326,164 @@ export default async function ProductDetailPage({ params }: Props) {
             </section>
           )}
 
-          {/* Envíos y devoluciones */}
-          <section className="mt-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
-            <details className="group">
-              <summary className="flex items-center justify-between p-4 cursor-pointer list-none hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
-                <span className="text-base font-semibold text-gray-900 dark:text-gray-100">
-                  Envíos y devoluciones
-                </span>
-                <svg
-                  className="w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform group-open:rotate-180"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </summary>
-              <div className="px-4 pb-4 text-sm text-gray-700 dark:text-gray-300 space-y-2">
-                <p>
-                  • <strong>Envío gratis</strong> en compras superiores a $2,000 MXN
-                </p>
-                <p>
-                  • <strong>Envíos a todo México</strong> con tiempos de entrega de 3-7 días hábiles, dependiendo de tu ubicación
-                </p>
-                <p>
-                  • <strong>Devoluciones</strong> disponibles dentro de los primeros 15 días posteriores a la recepción, siempre que el producto esté en su empaque original y sin uso
-                </p>
-                <p>
-                  • <strong>Asesoría por WhatsApp</strong> para resolver cualquier duda sobre envíos o devoluciones
-                </p>
-              </div>
-            </details>
-          </section>
+          {/* Acordeones de información */}
+          <div className="mt-6 space-y-4">
+            {/* Envíos y devoluciones */}
+            <section className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
+              <details className="group">
+                <summary className="flex items-center justify-between p-4 cursor-pointer list-none hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                  <span className="text-base font-semibold text-gray-900 dark:text-white">
+                    Envíos y devoluciones
+                  </span>
+                  <svg
+                    className="w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform group-open:rotate-180"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </summary>
+                <div className="px-4 pb-4 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                  <p>
+                    • <strong>Envío gratis</strong> en compras superiores a $2,000 MXN
+                  </p>
+                  <p>
+                    • <strong>Envíos a todo México</strong> con tiempos de entrega de 3-7 días hábiles, dependiendo de tu ubicación
+                  </p>
+                  <p>
+                    • <strong>Devoluciones</strong> disponibles dentro de los primeros 15 días posteriores a la recepción, siempre que el producto esté en su empaque original y sin uso
+                  </p>
+                  <p>
+                    • <strong>Asesoría por WhatsApp</strong> para resolver cualquier duda sobre envíos o devoluciones
+                  </p>
+                </div>
+              </details>
+            </section>
+
+            {/* Pagos y facturación */}
+            <section className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
+              <details className="group">
+                <summary className="flex items-center justify-between p-4 cursor-pointer list-none hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                  <span className="text-base font-semibold text-gray-900 dark:text-white">
+                    Pagos y facturación
+                  </span>
+                  <svg
+                    className="w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform group-open:rotate-180"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </summary>
+                <div className="px-4 pb-4 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                  <p>
+                    • <strong>Pago seguro</strong> con tarjeta de crédito o débito mediante Stripe
+                  </p>
+                  <p>
+                    • <strong>Facturación disponible</strong> para todas tus compras. Solicítala al finalizar tu pedido
+                  </p>
+                  <p>
+                    • <strong>Precios en MXN</strong> (pesos mexicanos), sin conversiones ni sorpresas
+                  </p>
+                  <p>
+                    • <strong>Procesamiento inmediato</strong> de pagos con confirmación por email
+                  </p>
+                </div>
+              </details>
+            </section>
+
+            {/* Garantía */}
+            <section className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
+              <details className="group">
+                <summary className="flex items-center justify-between p-4 cursor-pointer list-none hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                  <span className="text-base font-semibold text-gray-900 dark:text-white">
+                    Garantía
+                  </span>
+                  <svg
+                    className="w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform group-open:rotate-180"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </summary>
+                <div className="px-4 pb-4 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                  <p>
+                    • Todos nuestros productos cuentan con <strong>garantía de calidad</strong>
+                  </p>
+                  <p>
+                    • Si recibes un producto defectuoso, te lo <strong>reemplazamos sin costo</strong>
+                  </p>
+                  <p>
+                    • <strong>Devoluciones</strong> disponibles dentro de 15 días posteriores a la recepción
+                  </p>
+                  <p>
+                    • <strong>Contacto directo</strong> por WhatsApp para resolver cualquier incidencia
+                  </p>
+                </div>
+              </details>
+            </section>
+
+            {/* Soporte */}
+            <section className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
+              <details className="group">
+                <summary className="flex items-center justify-between p-4 cursor-pointer list-none hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                  <span className="text-base font-semibold text-gray-900 dark:text-white">
+                    Soporte
+                  </span>
+                  <svg
+                    className="w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform group-open:rotate-180"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </summary>
+                <div className="px-4 pb-4 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                  <p>
+                    • <strong>Atención personalizada</strong> por WhatsApp de lunes a viernes
+                  </p>
+                  <p>
+                    • <strong>Respuesta rápida</strong> en minutos, no horas
+                  </p>
+                  <p>
+                    • <strong>Horario de atención</strong>: Lunes a Viernes de 9:00 a 18:00 hrs
+                  </p>
+                  <p>
+                    • <strong>Asesoría técnica</strong> para ayudarte a elegir el producto adecuado
+                  </p>
+                </div>
+              </details>
+            </section>
+          </div>
 
           {/* Productos relacionados */}
           <PdpRelatedSection

--- a/src/components/catalog/RecentlyViewed.client.tsx
+++ b/src/components/catalog/RecentlyViewed.client.tsx
@@ -27,12 +27,12 @@ export default function RecentlyViewed() {
   }
 
   return (
-    <section className="mt-12 pt-10 border-t border-gray-200 space-y-5">
+    <section className="mt-12 pt-10 border-t border-gray-200 dark:border-gray-700 space-y-5">
       <div>
-        <h2 className="text-2xl font-semibold text-gray-900">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">
           Vistos recientemente
         </h2>
-        <p className="text-sm text-gray-600 mt-1">
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
           Retoma productos que revisaste hace unos momentos.
         </p>
       </div>
@@ -46,10 +46,10 @@ export default function RecentlyViewed() {
             <Link
               key={item.id}
               href={productUrl}
-              className="group block bg-white rounded-lg border border-gray-200 overflow-hidden hover:shadow-md transition-shadow"
+              className="group block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-md dark:hover:shadow-lg transition-shadow"
             >
               {/* Imagen */}
-              <div className="relative w-full aspect-square bg-gray-50">
+              <div className="relative w-full aspect-square bg-gray-50 dark:bg-gray-900">
                 <ImageWithFallback
                   src={item.image_url}
                   alt={item.title}
@@ -62,18 +62,18 @@ export default function RecentlyViewed() {
 
               {/* Información */}
               <div className="p-4 space-y-2">
-                <h3 className="font-medium text-sm text-gray-900 line-clamp-2 group-hover:text-primary-600 transition-colors">
+                <h3 className="font-medium text-sm text-gray-900 dark:text-white line-clamp-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
                   {item.title}
                 </h3>
 
                 {/* Precio y stock */}
                 <div className="flex items-center justify-between">
                   {priceCents > 0 ? (
-                    <span className="text-lg font-semibold text-primary-600">
+                    <span className="text-lg font-semibold text-primary-600 dark:text-primary-400">
                       {formatMXN(price)}
                     </span>
                   ) : (
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
                       Consultar precio
                     </span>
                   )}
@@ -82,8 +82,8 @@ export default function RecentlyViewed() {
                     <span
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
                         item.inStock
-                          ? "bg-emerald-50 text-emerald-700"
-                          : "bg-red-50 text-red-700"
+                          ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800"
+                          : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400 border border-red-200 dark:border-red-800"
                       }`}
                     >
                       {item.inStock ? "En stock" : "Agotado"}

--- a/src/components/pdp/PdpStickyCTA.client.tsx
+++ b/src/components/pdp/PdpStickyCTA.client.tsx
@@ -44,7 +44,7 @@ export default function PdpStickyCTA({ product }: PdpStickyCTAProps) {
   const canBuy = product.in_stock !== false;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 md:hidden bg-white border-t border-gray-200 shadow-lg">
+    <div className="fixed bottom-0 left-0 right-0 z-40 md:hidden bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg">
       <div
         className="px-4 py-3 flex gap-3"
         style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}

--- a/src/components/pdp/TrustBadgesPDP.tsx
+++ b/src/components/pdp/TrustBadgesPDP.tsx
@@ -43,8 +43,8 @@ export default function TrustBadgesPDP() {
     <div className="flex flex-wrap items-center justify-start gap-3 py-3">
       {badges.map((badge, index) => {
         const content = (
-          <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-700 transition-all duration-200 hover:bg-gray-100 hover:border-gray-300">
-            <span className="flex-shrink-0 text-gray-600">{badge.icon}</span>
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm text-gray-700 dark:text-gray-300 transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-600">
+            <span className="flex-shrink-0 text-gray-600 dark:text-gray-400">{badge.icon}</span>
             <span className="font-medium text-xs sm:text-sm whitespace-nowrap">{badge.label}</span>
           </div>
         );


### PR DESCRIPTION
# feat(ui): PDP polish + RecentlyViewed improvements (follow-up)

## Descripción

Este PR porta mejoras adicionales del PR #351 que no se incluyeron en #352. Mejoras UI/UX enfocadas en la PDP y el componente RecentlyViewed, incluyendo soporte dark mode completo y mejor jerarquía visual.

## Cambios Implementados

### 1. PDP - Mejoras de jerarquía visual
- **Título**: `font-semibold` → `font-bold`, `dark:text-gray-100` → `dark:text-white`
- **Precio**: Agregado `sm:text-5xl` (además de `text-4xl`) para mejor destaque en desktop
- **Badges de stock**: Mejorados con dark mode (`dark:bg-emerald-900/30`, `dark:text-emerald-400`, borders)
- **Descripción h2**: `dark:text-gray-100` → `dark:text-white`

### 2. PDP - Acordeones mejorados
- Reemplazado 1 acordeón `<details>` por 4 secciones separadas:
  - **Envíos y devoluciones**
  - **Pagos y facturación**
  - **Garantía**
  - **Soporte**
- Cada sección con hover mejorado (`dark:hover:bg-gray-700/50`)
- Títulos con `dark:text-white` para mejor contraste

### 3. TrustBadgesPDP
- Soporte dark mode completo: `dark:bg-gray-800`, `dark:border-gray-700`, `dark:text-gray-300`
- Hover states con dark mode: `dark:hover:bg-gray-700`, `dark:hover:border-gray-600`

### 4. PdpStickyCTA
- Soporte dark mode: `dark:bg-gray-800`, `dark:border-gray-700`

### 5. RecentlyViewed
- Soporte dark mode completo:
  - Section border: `dark:border-gray-700`
  - Título y descripción: `dark:text-white`, `dark:text-gray-400`
  - Cards: `dark:bg-gray-800`, `dark:border-gray-700`, `dark:hover:shadow-lg`
  - Imagen background: `dark:bg-gray-900`
  - Texto: `dark:text-white`, `dark:text-gray-400`
  - Precio: `dark:text-primary-400`
  - Badges de stock: dark mode con borders (igual que PDP)

## Validaciones Técnicas

- ✅ `pnpm lint` - OK
- ✅ `pnpm typecheck` - OK
- ✅ `pnpm build` - OK

## Smoke Test Manual (Local)

- [ ] `/` - Dark toggle funciona
- [ ] `/tienda` - Grid de productos OK en ambos modos
- [ ] `/buscar` - Resultados OK en ambos modos
- [ ] PDP (2 productos diferentes):
  - [ ] Título más bold, precio más grande en desktop
  - [ ] 4 acordeones abren/cierran correctamente
  - [ ] Trust badges se ven bien en dark mode
  - [ ] Sticky CTA en mobile funciona y no tapa contenido
  - [ ] "Vistos recientemente" se ve bien en dark y light
  - [ ] Badges de stock tienen mejor contraste en dark mode
- [ ] `/checkout` - No afectado visualmente

## Notas Importantes

- **NO se modificó lógica de negocio** (Zustand stores, Supabase queries, Stripe/webhook, Skydropx)
- **NO se tocaron** `src/app/layout.tsx` ni `src/app/globals.css` (ya resueltos en #352)
- **NO se agregaron dependencias nuevas**
- Solo cambios UI/UX (estilos, dark mode, jerarquía visual)

