### PR TITLE
fix(skydropx): add consignment_note and package_type required fields for PRO shipments

### DIFF
--- a/CONFIGURACION.md
+++ b/CONFIGURACION.md
@@ -49,6 +49,23 @@ SKYDROPX_QUOTATIONS_BASE_URL=https://api-pro.skydropx.com
 #   2. ${SKYDROPX_BASE_URL}/v1/shipments (fallback si 404)
 SKYDROPX_BASE_URL=https://api-pro.skydropx.com
 
+# Carta Porte (SAT) - REQUERIDO para crear shipments/labels en Skydropx PRO
+# consignment_note = código Carta Porte (SAT) del producto/servicio
+# package_type = código de tipo de empaque (SAT)
+# Ambos pueden depender de la paquetería/rate seleccionado y se obtienen del listado oficial de Skydropx.
+# También pueden guardarse por orden en metadata.shipping.consignment_note / metadata.shipping.package_type
+SKYDROPX_DEFAULT_CONSIGNMENT_NOTE=tu_codigo_carta_porte
+SKYDROPX_DEFAULT_PACKAGE_TYPE=tu_codigo_tipo_empaque
+
+# Datos de origen (requeridos para crear shipments)
+SKYDROPX_ORIGIN_NAME=Depósito Dental Noriega
+SKYDROPX_ORIGIN_STATE=Ciudad de México
+SKYDROPX_ORIGIN_CITY=Ciudad de México
+SKYDROPX_ORIGIN_POSTAL_CODE=01234
+SKYDROPX_ORIGIN_ADDRESS_LINE_1=Calle Principal 123
+SKYDROPX_ORIGIN_PHONE=5512345678
+SKYDROPX_ORIGIN_EMAIL=envios@ddnshop.mx
+
 # App URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```

--- a/src/lib/shipping/skydropx.server.ts
+++ b/src/lib/shipping/skydropx.server.ts
@@ -636,6 +636,8 @@ export async function createSkydropxShipment(input: {
             height: heightCm,
             width: widthCm,
             length: lengthCm,
+            consignment_note: process.env.SKYDROPX_DEFAULT_CONSIGNMENT_NOTE || "",
+            package_type: process.env.SKYDROPX_DEFAULT_PACKAGE_TYPE || "",
           },
         ],
         declared_value: 0,

--- a/src/lib/skydropx/client.ts
+++ b/src/lib/skydropx/client.ts
@@ -680,8 +680,8 @@ export type SkydropxShipmentPayload = {
       width: number; // cm
       length: number; // cm
       declared_value?: number; // opcional
-      consignment_note?: string; // opcional
-      package_type?: string; // opcional
+      consignment_note: string; // REQUIRED para PRO: código Carta Porte (SAT)
+      package_type: string; // REQUIRED para PRO: código tipo empaque (SAT)
     }>;
     declared_value?: number;
     printing_format?: "standard" | "thermal";
@@ -1004,6 +1004,8 @@ export async function createShipmentFromRate(input: {
     width: number;
     length: number;
   }>;
+  consignmentNote?: string; // Código Carta Porte (SAT) - requerido para PRO
+  packageType?: string; // Código tipo empaque (SAT) - requerido para PRO
 }): Promise<{
   trackingNumber: string;
   labelUrl: string | null;
@@ -1060,6 +1062,8 @@ export async function createShipmentFromRate(input: {
         height: p.height,
         width: p.width,
         length: p.length,
+        consignment_note: input.consignmentNote || "",
+        package_type: input.packageType || "",
       })),
       declared_value: 0,
       printing_format: "standard",


### PR DESCRIPTION
## Problema
Error 422 de Skydropx PRO al crear shipment/label desde Admin:
- "consignment_note requerido en todos los paquetes"
- "package_type requerido en todos los paquetes"

El payload PRO ya incluye wrapper `{ shipment: {...} }` y packages, pero faltan estos campos requeridos.

## Solución

### 1. Payload actualizado
- ✅ Cada package en `shipment.packages` ahora incluye:
  - `consignment_note` (string, REQUIRED)
  - `package_type` (string, REQUIRED)
- ✅ Origen de valores (prioridad):
  1. `order.metadata.shipping.consignment_note` o `metadata.shipping.consignment_note_code`
  2. `order.metadata.shipping.package_type`
  3. Env vars: `SKYDROPX_DEFAULT_CONSIGNMENT_NOTE` y `SKYDROPX_DEFAULT_PACKAGE_TYPE`
- ✅ Validación 422 local antes de llamar a Skydropx si faltan

### 2. Validación 422 local
- ✅ Si faltan `consignment_note` o `package_type`, responde 422 con:
  - `code: "invalid_shipping_payload"`
  - `missingFields: ["packages[].consignment_note", "packages[].package_type"]`
- ✅ No llama a Skydropx si faltan estos campos (evita 422 upstream)

### 3. UI Admin mejorada
- ✅ Mensaje claro cuando faltan códigos Carta Porte:
  "Faltan códigos Carta Porte: consignment_note y package_type. Configura env vars (SKYDROPX_DEFAULT_CONSIGNMENT_NOTE, SKYDROPX_DEFAULT_PACKAGE_TYPE) o guarda en metadata.shipping."
- ✅ También detecta cuando Skydropx devuelve 422 con estos campos faltantes
- ✅ Muestra lista de errores o missingFields según corresponda

### 4. Documentación
- ✅ Actualizado `CONFIGURACION.md` con:
  - Explicación de `consignment_note` (código Carta Porte SAT)
  - Explicación de `package_type` (código tipo empaque SAT)
  - Nota sobre dependencia de paquetería/rate
  - Ejemplo de env vars
  - Nota sobre guardar en metadata por orden

## Cambios
- `src/lib/skydropx/client.ts`: Tipos actualizados (required), `createShipmentFromRate` acepta `consignmentNote`/`packageType`, los incluye en packages
- `src/lib/shipping/skydropx.server.ts`: Agregados `consignment_note` y `package_type` en packages (desde env vars)
- `src/app/api/admin/shipping/skydropx/create-label/route.ts`: Extracción desde metadata/env vars, validación 422 local
- `src/app/admin/pedidos/[id]/CreateSkydropxLabelClient.tsx`: UI mejorada para mostrar mensaje claro sobre códigos Carta Porte
- `CONFIGURACION.md`: Documentación de nuevas env vars

## Validaciones
- ✅ `pnpm typecheck` OK
- ✅ `pnpm build` OK
- ✅ `pnpm lint` OK (solo warnings preexistentes)

## Cómo probar

### 1. Configurar env vars (local o Vercel):
```bash
SKYDROPX_DEFAULT_CONSIGNMENT_NOTE=tu_codigo_carta_porte
SKYDROPX_DEFAULT_PACKAGE_TYPE=tu_codigo_tipo_empaque
```

### 2. Probar creación de guía:
1. Ir a Admin → Pedidos → [Orden pagada con Skydropx]
2. Click "Crear guía en Skydropx"
3. **Caso éxito**: Debe crear la guía sin error 422
4. **Caso sin env vars**: Debe mostrar 422 local claro con mensaje sobre códigos Carta Porte
5. **Caso con metadata**: Si `order.metadata.shipping.consignment_note` existe, debe usarlo en lugar de env var

### 3. Probar con metadata (opcional):
```json
{
  "shipping": {
    "consignment_note": "codigo_desde_metadata",
    "package_type": "tipo_desde_metadata"
  }
}
```

## Notas
- Los códigos Carta Porte dependen de la paquetería/rate y se obtienen del listado oficial de Skydropx
- Es recomendable guardar estos valores en metadata por orden si varían según el tipo de producto
- Si no se configuran env vars ni metadata, el endpoint devuelve 422 local claro (no llama a Skydropx)

