### PR TITLE
feat(admin): add Skydropx requote functionality for expired rates

### DIFF
--- a/CONFIGURACION.md
+++ b/CONFIGURACION.md
@@ -221,6 +221,31 @@ Edita `src/components/WhatsappFloating.tsx`:
 const phoneNumber = "525512345678"; // Tu número con código de país
 ```
 
+## 🔄 Recotización de envíos Skydropx (Admin)
+
+Si una tarifa de Skydropx expira (+24 horas desde `quoted_at`), puedes recotizar desde Admin sin cancelar la orden:
+
+1. Ve a Admin → Pedidos → [Orden]
+2. Busca la sección "Recotizar envío"
+3. Click en "Recotizar envío (Skydropx)"
+4. Se mostrarán las tarifas disponibles actualizadas
+5. Selecciona una tarifa y click en "Aplicar esta tarifa"
+
+**Notas importantes:**
+- La recotización solo está disponible para órdenes con `shipping_provider = "skydropx"` y que NO sean pickup
+- Si ya se creó la guía (tiene `shipping_tracking_number` o `shipping_label_url`), no se puede recotizar. Primero cancela la guía existente
+- El sistema guarda `metadata.shipping.quoted_at` con la fecha/hora de la cotización (ISO string)
+- Si el precio de la nueva tarifa es mayor, se mostrará un badge "+ $X" para que el admin decida si absorber la diferencia o contactar al cliente
+- La tarifa expira después de 24 horas. El sistema muestra un warning si está próxima a expirar (20-24h) o ya expirada
+
+**Campos guardados en metadata.shipping:**
+- `quoted_at`: Fecha/hora de la cotización (ISO string)
+- `rate.external_id`: ID de la tarifa en Skydropx
+- `rate.provider`: Proveedor (ej: "estafeta", "dhl")
+- `rate.service`: Nombre del servicio
+- `rate.eta_min_days` / `rate.eta_max_days`: Tiempo estimado de entrega
+- `price_cents`: Precio de la tarifa en centavos
+
 ## ❓ Solución de problemas
 
 ### "No autenticado"

--- a/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
+++ b/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useState } from "react";
+import { formatMXNFromCents } from "@/lib/utils/currency";
+
+type RequoteSkydropxRatesClientProps = {
+  orderId: string;
+  currentRatePriceCents: number | null;
+  quotedAt: string | null; // ISO string
+};
+
+type Rate = {
+  external_id: string;
+  provider: string;
+  service: string;
+  option_code?: string;
+  eta_min_days: number | null;
+  eta_max_days: number | null;
+  price_cents: number;
+};
+
+/**
+ * Componente para recotizar envíos de Skydropx en Admin
+ */
+export default function RequoteSkydropxRatesClient({
+  orderId,
+  currentRatePriceCents,
+  quotedAt,
+}: RequoteSkydropxRatesClientProps) {
+  const [loading, setLoading] = useState(false);
+  const [applying, setApplying] = useState<string | null>(null);
+  const [rates, setRates] = useState<Rate[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Verificar si la tarifa está expirada o próxima a expirar
+  const isExpiredOrExpiring = (): boolean => {
+    if (!quotedAt) return true; // Si no hay quoted_at, considerar expirada
+
+    const quotedDate = new Date(quotedAt);
+    const now = new Date();
+    const hoursSinceQuote = (now.getTime() - quotedDate.getTime()) / (1000 * 60 * 60);
+
+    return hoursSinceQuote >= 24; // Expira a las 24 horas
+  };
+
+  const isExpiringSoon = (): boolean => {
+    if (!quotedAt) return false;
+
+    const quotedDate = new Date(quotedAt);
+    const now = new Date();
+    const hoursSinceQuote = (now.getTime() - quotedDate.getTime()) / (1000 * 60 * 60);
+
+    return hoursSinceQuote >= 20 && hoursSinceQuote < 24; // Próxima a expirar entre 20-24h
+  };
+
+  const handleRequote = async () => {
+    setLoading(true);
+    setError(null);
+    setRates(null);
+
+    try {
+      const res = await fetch("/api/admin/shipping/skydropx/requote", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ orderId }),
+      });
+
+      const data = await res.json();
+
+      if (!data.ok) {
+        const errorMessage =
+          data.code === "unauthorized"
+            ? "No tienes permisos para realizar esta acción."
+            : data.code === "order_not_found"
+              ? "La orden no existe."
+              : data.code === "unsupported_provider"
+                ? "Esta orden no usa Skydropx como proveedor de envío."
+                : data.code === "pickup_not_quotable"
+                  ? "No se pueden recotizar envíos de recogida en tienda."
+                  : data.code === "missing_address_data"
+                    ? "No se encontraron datos de dirección en la orden."
+                    : data.message || "Error al recotizar el envío.";
+
+        setError(errorMessage);
+        return;
+      }
+
+      setRates(data.rates || []);
+    } catch (err) {
+      console.error("[RequoteSkydropxRatesClient] Error:", err);
+      setError("Error de red al recotizar el envío.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApplyRate = async (rate: Rate) => {
+    setApplying(rate.external_id);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/admin/shipping/skydropx/apply-rate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          orderId,
+          rateExternalId: rate.external_id,
+          service: rate.service,
+          provider: rate.provider,
+          priceCents: rate.price_cents,
+          etaMin: rate.eta_min_days,
+          etaMax: rate.eta_max_days,
+          optionCode: rate.option_code,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!data.ok) {
+        const errorMessage =
+          data.code === "unauthorized"
+            ? "No tienes permisos para realizar esta acción."
+            : data.code === "order_not_found"
+              ? "La orden no existe."
+              : data.code === "label_already_created"
+                ? "No se puede cambiar la tarifa porque ya se creó la guía. Primero cancela la guía existente."
+                : data.message || "Error al aplicar la tarifa.";
+
+        setError(errorMessage);
+        setApplying(null);
+        return;
+      }
+
+      // Refrescar página para mostrar cambios
+      window.location.reload();
+    } catch (err) {
+      console.error("[RequoteSkydropxRatesClient] Error:", err);
+      setError("Error de red al aplicar la tarifa.");
+      setApplying(null);
+    }
+  };
+
+  const getPriceDifference = (newPriceCents: number): number => {
+    if (!currentRatePriceCents) return newPriceCents;
+    return newPriceCents - currentRatePriceCents;
+  };
+
+  const formatETA = (min: number | null, max: number | null): string => {
+    if (min === null && max === null) return "No disponible";
+    if (min === null) return `${max} días`;
+    if (max === null) return `${min} días`;
+    if (min === max) return `${min} días`;
+    return `${min}-${max} días`;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Warning si está expirada o próxima a expirar */}
+      {(isExpiredOrExpiring() || isExpiringSoon()) && (
+        <div
+          className={`rounded-lg border p-4 ${
+            isExpiredOrExpiring()
+              ? "bg-yellow-50 border-yellow-200"
+              : "bg-orange-50 border-orange-200"
+          }`}
+        >
+          <div className="flex items-start">
+            <div className="flex-shrink-0">
+              <span className="text-xl">⚠️</span>
+            </div>
+            <div className="ml-3">
+              <h3
+                className={`text-sm font-medium ${
+                  isExpiredOrExpiring() ? "text-yellow-800" : "text-orange-800"
+                }`}
+              >
+                {isExpiredOrExpiring()
+                  ? "Tarifa expirada"
+                  : "Tarifa próxima a expirar"}
+              </h3>
+              <p
+                className={`mt-1 text-sm ${
+                  isExpiredOrExpiring() ? "text-yellow-700" : "text-orange-700"
+                }`}
+              >
+                {isExpiredOrExpiring()
+                  ? "Esta tarifa tiene más de 24 horas desde su cotización y puede estar expirada. Recotiza para obtener tarifas actualizadas."
+                  : "Esta tarifa está próxima a expirar (20-24 horas). Recotiza si necesitas actualizar el precio."}
+                {quotedAt && (
+                  <span className="block mt-1 text-xs opacity-75">
+                    Cotizada: {new Date(quotedAt).toLocaleString("es-MX")}
+                  </span>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Botón Recotizar */}
+      <div>
+        <button
+          onClick={handleRequote}
+          disabled={loading}
+          className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+        >
+          {loading ? "Recotizando..." : "Recotizar envío (Skydropx)"}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+          <p className="text-sm text-red-800">{error}</p>
+        </div>
+      )}
+
+      {/* Lista de rates */}
+      {rates && rates.length > 0 && (
+        <div className="space-y-3">
+          <h4 className="text-sm font-semibold text-gray-900">Tarifas disponibles:</h4>
+          {rates.map((rate) => {
+            const priceDiff = getPriceDifference(rate.price_cents);
+            return (
+              <div
+                key={rate.external_id}
+                className="rounded-lg border border-gray-200 bg-white p-4 space-y-3"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-gray-900">
+                        {rate.provider} - {rate.service}
+                      </span>
+                      {priceDiff > 0 && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">
+                          +{formatMXNFromCents(priceDiff)}
+                        </span>
+                      )}
+                      {priceDiff < 0 && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                          {formatMXNFromCents(priceDiff)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-1 text-sm text-gray-600">
+                      <span className="font-semibold text-gray-900">
+                        {formatMXNFromCents(rate.price_cents)}
+                      </span>
+                      {" • "}
+                      <span>ETA: {formatETA(rate.eta_min_days, rate.eta_max_days)}</span>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleApplyRate(rate)}
+                  disabled={applying === rate.external_id}
+                  className="w-full px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+                >
+                  {applying === rate.external_id ? "Aplicando..." : "Aplicar esta tarifa"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {rates && rates.length === 0 && (
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+          <p className="text-sm text-yellow-800">
+            No se encontraron tarifas disponibles para esta dirección.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getOrderWithItemsAdmin } from "@/lib/supabase/orders.server";
 import { formatMXNFromCents } from "@/lib/utils/currency";
 import CreateSkydropxLabelClient from "./CreateSkydropxLabelClient";
 import CancelSkydropxLabelClient from "./CancelSkydropxLabelClient";
+import RequoteSkydropxRatesClient from "./RequoteSkydropxRatesClient";
 import { getShippingStatusLabel, getShippingStatusVariant } from "@/lib/orders/shippingStatus";
 import { getPaymentMethodLabel, getPaymentStatusLabel, getPaymentStatusVariant } from "@/lib/orders/paymentStatus";
 import { variantDetailFromJSON } from "@/lib/products/parseVariantDetail";
@@ -386,6 +387,35 @@ export default async function AdminPedidoDetailPage({
                   </div>
                 )}
               </div>
+
+              {/* Botón para recotizar envío si es Skydropx */}
+              {(order.shipping_provider === "skydropx" || order.shipping_provider === "Skydropx") &&
+                (order.metadata as Record<string, unknown> | null)?.shipping_method !==
+                  "pickup" && (
+                  <div className="mb-4">
+                    <h3 className="text-md font-semibold mb-2">Recotizar envío</h3>
+                    <RequoteSkydropxRatesClient
+                      orderId={order.id}
+                      currentRatePriceCents={order.shipping_price_cents}
+                      quotedAt={
+                        (order.metadata as Record<string, unknown> | null)?.shipping &&
+                        typeof (order.metadata as Record<string, unknown>).shipping === "object"
+                          ? ((order.metadata as Record<string, unknown>).shipping as Record<
+                              string,
+                              unknown
+                            >)?.quoted_at
+                            ? String(
+                                ((order.metadata as Record<string, unknown>).shipping as Record<
+                                  string,
+                                  unknown
+                                >).quoted_at,
+                              )
+                            : null
+                          : null
+                      }
+                    />
+                  </div>
+                )}
 
               {/* Botón para crear guía si es Skydropx */}
               <CreateSkydropxLabelClient

--- a/src/app/api/admin/shipping/skydropx/apply-rate/route.ts
+++ b/src/app/api/admin/shipping/skydropx/apply-rate/route.ts
@@ -1,0 +1,200 @@
+import { NextRequest, NextResponse } from "next/server";
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { getOrderWithItemsAdmin } from "@/lib/supabase/orders.server";
+
+export const dynamic = "force-dynamic";
+
+type ApplyRateResponse =
+  | {
+      ok: true;
+      message: string;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+/**
+ * POST /api/admin/shipping/skydropx/apply-rate
+ * 
+ * Aplica una nueva tarifa a una orden existente
+ */
+export async function POST(req: NextRequest) {
+  try {
+    // Verificar acceso admin
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unauthorized",
+          message: "No tienes permisos para realizar esta acción.",
+        } satisfies ApplyRateResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await req.json();
+    const {
+      orderId,
+      rateExternalId,
+      service,
+      provider,
+      priceCents,
+      etaMin,
+      etaMax,
+      optionCode,
+    } = body;
+
+    // Validaciones básicas
+    if (!orderId || typeof orderId !== "string") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "orderId es requerido.",
+        } satisfies ApplyRateResponse,
+        { status: 400 },
+      );
+    }
+
+    if (
+      !rateExternalId ||
+      typeof rateExternalId !== "string" ||
+      !service ||
+      typeof service !== "string" ||
+      !provider ||
+      typeof provider !== "string" ||
+      typeof priceCents !== "number"
+    ) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "Campos requeridos: rateExternalId, service, provider, priceCents.",
+        } satisfies ApplyRateResponse,
+        { status: 400 },
+      );
+    }
+
+    // Obtener orden
+    const order = await getOrderWithItemsAdmin(orderId);
+    if (!order) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "order_not_found",
+          message: "La orden no existe.",
+        } satisfies ApplyRateResponse,
+        { status: 404 },
+      );
+    }
+
+    // Validar que la orden no tenga tracking_number/label_url ya creada
+    if (order.shipping_tracking_number || order.shipping_label_url) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "label_already_created",
+          message:
+            "No se puede cambiar la tarifa porque ya se creó la guía. Primero cancela la guía existente.",
+        } satisfies ApplyRateResponse,
+        { status: 409 },
+      );
+    }
+
+    // Preparar actualizaciones para orders
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !serviceRoleKey) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "config_error",
+          message: "Configuración de Supabase incompleta.",
+        } satisfies ApplyRateResponse,
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+    const now = new Date().toISOString();
+
+    // Obtener metadata actual
+    const currentMetadata = (order.metadata as Record<string, unknown>) || {};
+    const currentShippingMeta = (currentMetadata.shipping as Record<string, unknown>) || {};
+
+    // Actualizar metadata.shipping
+    const updatedShippingMeta = {
+      ...currentShippingMeta,
+      rate: {
+        external_id: rateExternalId,
+        provider,
+        service,
+        eta_min_days: typeof etaMin === "number" ? etaMin : null,
+        eta_max_days: typeof etaMax === "number" ? etaMax : null,
+        option_code: typeof optionCode === "string" ? optionCode : undefined,
+      },
+      quoted_at: now,
+      price_cents: priceCents,
+    };
+
+    // Merge seguro de metadata
+    const updatedMetadata = {
+      ...currentMetadata,
+      shipping: updatedShippingMeta,
+    };
+
+    // Actualizar order
+    const { error: updateError } = await supabase
+      .from("orders")
+      .update({
+        shipping_rate_ext_id: rateExternalId,
+        shipping_provider: "skydropx",
+        shipping_service_name: service,
+        shipping_price_cents: priceCents,
+        shipping_eta_min_days: typeof etaMin === "number" ? etaMin : null,
+        shipping_eta_max_days: typeof etaMax === "number" ? etaMax : null,
+        shipping_status: "rate_selected",
+        metadata: updatedMetadata,
+        updated_at: now,
+      })
+      .eq("id", orderId);
+
+    if (updateError) {
+      console.error("[apply-rate] Error al actualizar orden:", updateError);
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "update_failed",
+          message: "Error al actualizar la orden. Revisa los logs.",
+        } satisfies ApplyRateResponse,
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      message: "Tarifa actualizada correctamente.",
+    } satisfies ApplyRateResponse);
+  } catch (error) {
+    console.error("[apply-rate] Error inesperado:", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "internal_error",
+        message: "Error al aplicar la tarifa. Revisa los logs.",
+      } satisfies ApplyRateResponse,
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/shipping/skydropx/requote/route.ts
+++ b/src/app/api/admin/shipping/skydropx/requote/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from "next/server";
+import "server-only";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { getOrderWithItemsAdmin } from "@/lib/supabase/orders.server";
+import { getSkydropxRates } from "@/lib/shipping/skydropx.server";
+import type { SkydropxRate } from "@/lib/shipping/skydropx.server";
+
+export const dynamic = "force-dynamic";
+
+type RequoteResponse =
+  | {
+      ok: true;
+      rates: Array<{
+        external_id: string;
+        provider: string;
+        service: string;
+        option_code?: string;
+        eta_min_days: number | null;
+        eta_max_days: number | null;
+        price_cents: number;
+      }>;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+/**
+ * Extrae dirección de destino desde metadata (reutiliza lógica de create-label)
+ */
+function extractAddressFromMetadata(metadata: unknown): {
+  postalCode: string;
+  state: string;
+  city: string;
+  country: string;
+} | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  const meta = metadata as Record<string, unknown>;
+
+  // PRIORIDAD 1: metadata.shipping_address (nuevo formato estructurado)
+  let addressData: Record<string, unknown> | null = null;
+  if (meta.shipping_address && typeof meta.shipping_address === "object") {
+    addressData = meta.shipping_address as Record<string, unknown>;
+  }
+  // PRIORIDAD 2: metadata.shipping.address (compatibilidad)
+  else if (meta.shipping && typeof meta.shipping === "object") {
+    const shipping = meta.shipping as Record<string, unknown>;
+    if (shipping.address && typeof shipping.address === "object") {
+      addressData = shipping.address as Record<string, unknown>;
+    }
+  }
+  // PRIORIDAD 3: metadata.address (legacy)
+  else if (meta.address && typeof meta.address === "object") {
+    addressData = meta.address as Record<string, unknown>;
+  }
+
+  if (!addressData) {
+    return null;
+  }
+
+  // Extraer campos con múltiples variantes para compatibilidad
+  const postalCode = addressData.postal_code || addressData.cp || addressData.postalCode;
+  const state = addressData.state || addressData.estado;
+  const city = addressData.city || addressData.ciudad;
+  const country = addressData.country || addressData.country_code || "MX";
+
+  // Validar campos mínimos requeridos
+  if (
+    typeof postalCode === "string" &&
+    typeof state === "string" &&
+    typeof city === "string" &&
+    postalCode.length > 0 &&
+    state.length > 0 &&
+    city.length > 0
+  ) {
+    return {
+      postalCode,
+      state,
+      city,
+      country: typeof country === "string" ? country : "MX",
+    };
+  }
+
+  return null;
+}
+
+/**
+ * POST /api/admin/shipping/skydropx/requote
+ * 
+ * Recotiza envío para una orden existente
+ */
+export async function POST(req: NextRequest) {
+  try {
+    // Verificar acceso admin
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unauthorized",
+          message: "No tienes permisos para realizar esta acción.",
+        } satisfies RequoteResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await req.json();
+    const { orderId } = body;
+
+    if (!orderId || typeof orderId !== "string") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "orderId es requerido.",
+        } satisfies RequoteResponse,
+        { status: 400 },
+      );
+    }
+
+    // Obtener orden
+    const order = await getOrderWithItemsAdmin(orderId);
+    if (!order) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "order_not_found",
+          message: "La orden no existe.",
+        } satisfies RequoteResponse,
+        { status: 404 },
+      );
+    }
+
+    // Validar shipping_provider=skydropx y shipping_method != pickup
+    if (order.shipping_provider !== "skydropx" && order.shipping_provider !== "Skydropx") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unsupported_provider",
+          message: "Esta orden no usa Skydropx como proveedor de envío.",
+        } satisfies RequoteResponse,
+        { status: 400 },
+      );
+    }
+
+    // Validar que no sea pickup (está en metadata.shipping_method)
+    const metadata = (order.metadata as Record<string, unknown>) || {};
+    const shippingMethod = metadata.shipping_method;
+    if (shippingMethod === "pickup") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "pickup_not_quotable",
+          message: "No se pueden recotizar envíos de recogida en tienda.",
+        } satisfies RequoteResponse,
+        { status: 400 },
+      );
+    }
+
+    // Extraer dirección de destino desde metadata
+    const addressTo = extractAddressFromMetadata(order.metadata);
+    if (!addressTo) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "missing_address_data",
+          message: "No se encontraron datos de dirección en la orden.",
+        } satisfies RequoteResponse,
+        { status: 400 },
+      );
+    }
+
+    // Construir package template (usar defaults: 1kg, 20x20x10 cm)
+    // TODO: Mejorar calculando desde order_items si están disponibles
+    const weightGrams = 1000; // Default 1kg
+
+    // Llamar a Skydropx para obtener rates
+    const rates = await getSkydropxRates(
+      {
+        postalCode: addressTo.postalCode,
+        state: addressTo.state,
+        city: addressTo.city,
+        country: addressTo.country,
+      },
+      {
+        weightGrams,
+      },
+    );
+
+    // Normalizar y devolver rates
+    const normalizedRates = rates.map((rate: SkydropxRate) => ({
+      external_id: rate.externalRateId,
+      provider: rate.provider,
+      service: rate.service,
+      option_code: undefined, // SkydropxRate no incluye option_code por ahora
+      eta_min_days: rate.etaMinDays,
+      eta_max_days: rate.etaMaxDays,
+      price_cents: rate.totalPriceCents,
+    }));
+
+    return NextResponse.json({
+      ok: true,
+      rates: normalizedRates,
+    } satisfies RequoteResponse);
+  } catch (error) {
+    console.error("[requote] Error inesperado:", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "internal_error",
+        message: "Error al recotizar el envío. Revisa los logs.",
+      } satisfies RequoteResponse,
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Objetivo
Agregar funcionalidad en Admin para recotizar envíos de Skydropx cuando las tarifas expiran (+24h) sin necesidad de cancelar la orden.

## Problema resuelto
Cuando una tarifa de Skydropx expira (más de 24 horas desde su cotización), no se puede crear la guía porque el \ate_id\ ya no es válido. Esto requería cancelar y recrear la orden completa. Ahora se puede recotizar directamente desde Admin.

## Cambios
- Endpoint POST \/api/admin/shipping/skydropx/requote\ para obtener nuevas tarifas
- Endpoint POST \/api/admin/shipping/skydropx/apply-rate\ para aplicar una tarifa nueva
- Componente \RequoteSkydropxRatesClient.tsx\ con UX mínima
- Integración en página de detalle de pedido Admin
- Documentación en CONFIGURACION.md

## Validaciones
- ✅ \pnpm typecheck\ OK
- ✅ \pnpm build\ OK
- ✅ \pnpm lint\ OK