### PR TITLE
feat(admin): add shipping package profiles and product dimensions for Skydropx

### DIFF
--- a/CONFIGURACION.md
+++ b/CONFIGURACION.md
@@ -221,12 +221,75 @@ Edita `src/components/WhatsappFloating.tsx`:
 const phoneNumber = "525512345678"; // Tu número con código de país
 ```
 
+## 📦 Perfiles de empaque y dimensiones de envío (Admin)
+
+### Seleccionar empaque en pedidos
+
+Para obtener cotizaciones precisas de Skydropx, es importante seleccionar el empaque correcto antes de recotizar o crear guías:
+
+1. Ve a Admin → Pedidos → [Orden con Skydropx]
+2. Busca la sección "Empaque de envío"
+3. Selecciona un perfil predefinido:
+   - **Sobre (ENVELOPE)**: 32×23×1 cm, 50g base - Para documentos/productos planos
+   - **Caja Pequeña (BOX_S)**: 25×20×15 cm, 150g base - Para productos pequeños
+   - **Caja Mediana (BOX_M)**: 35×30×25 cm, 300g base - Para productos medianos
+4. O elige "Personalizado" e ingresa dimensiones y peso manualmente
+5. Click "Guardar empaque"
+
+**Notas importantes:**
+- El empaque guardado se usa automáticamente en `/requote` y `/create-label`
+- Si no hay empaque guardado, el sistema usa BOX_S por defecto y muestra un warning
+- No se puede cambiar el empaque si ya se creó la guía (tiene `shipping_tracking_number` o `shipping_label_url`)
+
+**Estructura de `metadata.shipping_package`:**
+```typescript
+{
+  mode: "profile" | "custom",
+  profile: "ENVELOPE" | "BOX_S" | "BOX_M" | null,
+  length_cm: number,
+  width_cm: number,
+  height_cm: number,
+  weight_g: number
+}
+```
+
+### Dimensiones de productos
+
+Para ayudar con la estimación de empaques, puedes guardar peso y dimensiones por producto:
+
+1. Ve a Admin → Productos → [Producto] → Editar
+2. Busca la sección "Dimensiones de envío"
+3. Completa:
+   - **Peso (g)**: Peso del producto en gramos
+   - **Largo/Ancho/Alto (cm)**: Dimensiones del producto
+   - **Perfil recomendado**: Sugerencia de perfil (ENVELOPE/BOX_S/BOX_M/CUSTOM)
+4. Click "Guardar dimensiones"
+
+**Columnas agregadas a `products`:**
+- `shipping_weight_g`: Peso en gramos (INTEGER, nullable)
+- `shipping_length_cm`: Largo en centímetros (INTEGER, nullable)
+- `shipping_width_cm`: Ancho en centímetros (INTEGER, nullable)
+- `shipping_height_cm`: Alto en centímetros (INTEGER, nullable)
+- `shipping_profile`: Perfil recomendado (TEXT, nullable: "ENVELOPE", "BOX_S", "BOX_M", "CUSTOM")
+
+**Migración SQL:**
+Ejecuta `ops/sql/2025-01-XX_add_shipping_fields_to_products.sql` en Supabase SQL Editor.
+
+### Flujo recomendado
+
+1. **Configurar productos**: Editar dimensiones de productos individuales (opcional pero recomendado)
+2. **Crear pedido**: El cliente realiza su pedido normalmente
+3. **Seleccionar empaque**: En Admin → Pedidos → [Orden], seleccionar empaque apropiado
+4. **Recotizar**: Click "Recotizar envío" para obtener tarifas actualizadas usando el empaque seleccionado
+5. **Aplicar tarifa**: Seleccionar y aplicar la mejor tarifa
+6. **Crear guía**: Click "Crear guía en Skydropx" usando el mismo empaque
+
 ## 🔄 Recotización de envíos Skydropx (Admin)
 
 Si una tarifa de Skydropx expira (+24 horas desde `quoted_at`), puedes recotizar desde Admin sin cancelar la orden:
 
 1. Ve a Admin → Pedidos → [Orden]
-2. Busca la sección "Recotizar envío"
+2. Selecciona el empaque (si no está guardado)
 3. Click en "Recotizar envío (Skydropx)"
 4. Se mostrarán las tarifas disponibles actualizadas
 5. Selecciona una tarifa y click en "Aplicar esta tarifa"

--- a/ops/sql/2025-01-XX_add_shipping_fields_to_products.sql
+++ b/ops/sql/2025-01-XX_add_shipping_fields_to_products.sql
@@ -1,0 +1,66 @@
+-- Agregar columnas de envío a la tabla products
+-- Permite almacenar peso y dimensiones de cada producto para cotizaciones precisas
+
+-- Verificar si las columnas ya existen antes de agregarlas (idempotente)
+DO $$
+BEGIN
+  -- shipping_weight_g: peso del producto en gramos
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'products' 
+    AND column_name = 'shipping_weight_g'
+  ) THEN
+    ALTER TABLE public.products 
+    ADD COLUMN shipping_weight_g INTEGER DEFAULT NULL;
+    COMMENT ON COLUMN public.products.shipping_weight_g IS 'Peso del producto para envío en gramos. Usado para cotizaciones precisas de Skydropx.';
+  END IF;
+
+  -- shipping_length_cm: largo del producto en centímetros
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'products' 
+    AND column_name = 'shipping_length_cm'
+  ) THEN
+    ALTER TABLE public.products 
+    ADD COLUMN shipping_length_cm INTEGER DEFAULT NULL;
+    COMMENT ON COLUMN public.products.shipping_length_cm IS 'Largo del producto para envío en centímetros. Usado para cotizaciones precisas de Skydropx.';
+  END IF;
+
+  -- shipping_width_cm: ancho del producto en centímetros
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'products' 
+    AND column_name = 'shipping_width_cm'
+  ) THEN
+    ALTER TABLE public.products 
+    ADD COLUMN shipping_width_cm INTEGER DEFAULT NULL;
+    COMMENT ON COLUMN public.products.shipping_width_cm IS 'Ancho del producto para envío en centímetros. Usado para cotizaciones precisas de Skydropx.';
+  END IF;
+
+  -- shipping_height_cm: alto del producto en centímetros
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'products' 
+    AND column_name = 'shipping_height_cm'
+  ) THEN
+    ALTER TABLE public.products 
+    ADD COLUMN shipping_height_cm INTEGER DEFAULT NULL;
+    COMMENT ON COLUMN public.products.shipping_height_cm IS 'Alto del producto para envío en centímetros. Usado para cotizaciones precisas de Skydropx.';
+  END IF;
+
+  -- shipping_profile: perfil recomendado de empaque (ENVELOPE, BOX_S, BOX_M, CUSTOM)
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'products' 
+    AND column_name = 'shipping_profile'
+  ) THEN
+    ALTER TABLE public.products 
+    ADD COLUMN shipping_profile TEXT DEFAULT NULL;
+    COMMENT ON COLUMN public.products.shipping_profile IS 'Perfil recomendado de empaque: ENVELOPE, BOX_S, BOX_M, o CUSTOM. Usado como sugerencia al seleccionar empaque en pedidos.';
+  END IF;
+END $$;

--- a/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
+++ b/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
@@ -88,6 +88,11 @@ export default function RequoteSkydropxRatesClient({
       }
 
       setRates(data.rates || []);
+      
+      // Mostrar warning si viene del backend
+      if (data.warning) {
+        setError(data.warning);
+      }
     } catch (err) {
       console.error("[RequoteSkydropxRatesClient] Error:", err);
       setError("Error de red al recotizar el envío.");

--- a/src/app/admin/pedidos/[id]/ShippingPackagePickerClient.tsx
+++ b/src/app/admin/pedidos/[id]/ShippingPackagePickerClient.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { PACKAGE_PROFILES, type PackageProfileKey, validatePackageDimensions } from "@/lib/shipping/packageProfiles";
+
+type ShippingPackagePickerClientProps = {
+  orderId: string;
+  currentPackage: {
+    mode?: "profile" | "custom";
+    profile?: PackageProfileKey | null;
+    length_cm?: number;
+    width_cm?: number;
+    height_cm?: number;
+    weight_g?: number;
+  } | null;
+};
+
+/**
+ * Componente para seleccionar perfil de empaque o dimensiones personalizadas
+ */
+export default function ShippingPackagePickerClient({
+  orderId,
+  currentPackage,
+}: ShippingPackagePickerClientProps) {
+  const [mode, setMode] = useState<"profile" | "custom">(
+    currentPackage?.mode || "profile",
+  );
+  const [selectedProfile, setSelectedProfile] = useState<PackageProfileKey>(
+    (currentPackage?.profile as PackageProfileKey) || "BOX_S",
+  );
+  const [customLength, setCustomLength] = useState<string>(
+    currentPackage?.mode === "custom" ? String(currentPackage.length_cm) : "25",
+  );
+  const [customWidth, setCustomWidth] = useState<string>(
+    currentPackage?.mode === "custom" ? String(currentPackage.width_cm) : "20",
+  );
+  const [customHeight, setCustomHeight] = useState<string>(
+    currentPackage?.mode === "custom" ? String(currentPackage.height_cm) : "15",
+  );
+  const [customWeight, setCustomWeight] = useState<string>(
+    currentPackage?.mode === "custom" ? String(currentPackage.weight_g) : "150",
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Reset success message after 3 seconds
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => setSuccess(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
+
+  const handleSave = async () => {
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const body: { orderId: string; profile?: PackageProfileKey; custom?: any } = {
+        orderId,
+      };
+
+      if (mode === "profile") {
+        body.profile = selectedProfile;
+      } else {
+        // Validar dimensiones personalizadas
+        const length = parseFloat(customLength);
+        const width = parseFloat(customWidth);
+        const height = parseFloat(customHeight);
+        const weight = parseFloat(customWeight);
+
+        if (
+          isNaN(length) ||
+          isNaN(width) ||
+          isNaN(height) ||
+          isNaN(weight)
+        ) {
+          setError("Todos los campos personalizados deben ser números válidos.");
+          setLoading(false);
+          return;
+        }
+
+        const validation = validatePackageDimensions(length, width, height, weight);
+        if (!validation.valid) {
+          setError(validation.error || "Dimensiones inválidas.");
+          setLoading(false);
+          return;
+        }
+
+        body.custom = {
+          length_cm: length,
+          width_cm: width,
+          height_cm: height,
+          weight_g: weight,
+        };
+      }
+
+      const res = await fetch("/api/admin/orders/set-shipping-package", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      const data = await res.json();
+
+      if (!data.ok) {
+        const errorMessage =
+          data.code === "unauthorized"
+            ? "No tienes permisos para realizar esta acción."
+            : data.code === "order_not_found"
+              ? "La orden no existe."
+              : data.code === "label_already_created"
+                ? "No se puede cambiar el empaque porque ya se creó la guía. Primero cancela la guía existente."
+                : data.code === "invalid_profile"
+                  ? "Perfil inválido."
+                  : data.code === "invalid_dimensions"
+                    ? data.message || "Dimensiones inválidas."
+                    : data.message || "Error al guardar el empaque.";
+
+        setError(errorMessage);
+        return;
+      }
+
+      setSuccess(true);
+      // Refrescar página para mostrar cambios
+      window.location.reload();
+    } catch (err) {
+      console.error("[ShippingPackagePickerClient] Error:", err);
+      setError("Error de red al guardar el empaque.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const currentProfile = mode === "profile" ? PACKAGE_PROFILES[selectedProfile] : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-md font-semibold">Empaque de envío</h3>
+        {currentPackage && (
+          <span className="text-xs text-gray-500">
+            Actualmente: {currentPackage.mode === "profile" && currentPackage.profile
+              ? PACKAGE_PROFILES[currentPackage.profile].label
+              : "Personalizado"}
+          </span>
+        )}
+      </div>
+
+      {/* Modo: Profile o Custom */}
+      <div className="flex gap-4">
+        <label className="flex items-center">
+          <input
+            type="radio"
+            name="mode"
+            value="profile"
+            checked={mode === "profile"}
+            onChange={(e) => setMode(e.target.value as "profile" | "custom")}
+            className="mr-2"
+          />
+          <span className="text-sm">Perfil predefinido</span>
+        </label>
+        <label className="flex items-center">
+          <input
+            type="radio"
+            name="mode"
+            value="custom"
+            checked={mode === "custom"}
+            onChange={(e) => setMode(e.target.value as "profile" | "custom")}
+            className="mr-2"
+          />
+          <span className="text-sm">Personalizado</span>
+        </label>
+      </div>
+
+      {/* Selector de perfil */}
+      {mode === "profile" && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Perfil
+          </label>
+          <select
+            value={selectedProfile}
+            onChange={(e) => setSelectedProfile(e.target.value as PackageProfileKey)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="ENVELOPE">
+              {PACKAGE_PROFILES.ENVELOPE.label} (
+              {PACKAGE_PROFILES.ENVELOPE.length_cm}×
+              {PACKAGE_PROFILES.ENVELOPE.width_cm}×
+              {PACKAGE_PROFILES.ENVELOPE.height_cm} cm,{" "}
+              {PACKAGE_PROFILES.ENVELOPE.weight_g}g)
+            </option>
+            <option value="BOX_S">
+              {PACKAGE_PROFILES.BOX_S.label} (
+              {PACKAGE_PROFILES.BOX_S.length_cm}×
+              {PACKAGE_PROFILES.BOX_S.width_cm}×
+              {PACKAGE_PROFILES.BOX_S.height_cm} cm,{" "}
+              {PACKAGE_PROFILES.BOX_S.weight_g}g)
+            </option>
+            <option value="BOX_M">
+              {PACKAGE_PROFILES.BOX_M.label} (
+              {PACKAGE_PROFILES.BOX_M.length_cm}×
+              {PACKAGE_PROFILES.BOX_M.width_cm}×
+              {PACKAGE_PROFILES.BOX_M.height_cm} cm,{" "}
+              {PACKAGE_PROFILES.BOX_M.weight_g}g)
+            </option>
+          </select>
+          {currentProfile && (
+            <p className="mt-2 text-xs text-gray-500">
+              Dimensiones: {currentProfile.length_cm}×{currentProfile.width_cm}×
+              {currentProfile.height_cm} cm | Peso base: {currentProfile.weight_g}g
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Campos personalizados */}
+      {mode === "custom" && (
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Largo (cm)
+            </label>
+            <input
+              type="number"
+              value={customLength}
+              onChange={(e) => setCustomLength(e.target.value)}
+              min="1"
+              max="200"
+              step="0.1"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Ancho (cm)
+            </label>
+            <input
+              type="number"
+              value={customWidth}
+              onChange={(e) => setCustomWidth(e.target.value)}
+              min="1"
+              max="200"
+              step="0.1"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Alto (cm)
+            </label>
+            <input
+              type="number"
+              value={customHeight}
+              onChange={(e) => setCustomHeight(e.target.value)}
+              min="1"
+              max="200"
+              step="0.1"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Peso (g)
+            </label>
+            <input
+              type="number"
+              value={customWeight}
+              onChange={(e) => setCustomWeight(e.target.value)}
+              min="1"
+              max="50000"
+              step="1"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3">
+          <p className="text-sm text-red-800">{error}</p>
+        </div>
+      )}
+
+      {/* Success */}
+      {success && (
+        <div className="rounded-lg border border-green-200 bg-green-50 p-3">
+          <p className="text-sm text-green-800">Empaque guardado correctamente.</p>
+        </div>
+      )}
+
+      {/* Botón Guardar */}
+      <button
+        onClick={handleSave}
+        disabled={loading}
+        className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+      >
+        {loading ? "Guardando..." : "Guardar empaque"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -6,6 +6,7 @@ import { formatMXNFromCents } from "@/lib/utils/currency";
 import CreateSkydropxLabelClient from "./CreateSkydropxLabelClient";
 import CancelSkydropxLabelClient from "./CancelSkydropxLabelClient";
 import RequoteSkydropxRatesClient from "./RequoteSkydropxRatesClient";
+import ShippingPackagePickerClient from "./ShippingPackagePickerClient";
 import { getShippingStatusLabel, getShippingStatusVariant } from "@/lib/orders/shippingStatus";
 import { getPaymentMethodLabel, getPaymentStatusLabel, getPaymentStatusVariant } from "@/lib/orders/paymentStatus";
 import { variantDetailFromJSON } from "@/lib/products/parseVariantDetail";
@@ -387,6 +388,31 @@ export default async function AdminPedidoDetailPage({
                   </div>
                 )}
               </div>
+
+              {/* Selector de empaque de envío */}
+              {(order.shipping_provider === "skydropx" || order.shipping_provider === "Skydropx") &&
+                (order.metadata as Record<string, unknown> | null)?.shipping_method !==
+                  "pickup" && (
+                  <div className="mb-4 pb-4 border-b border-gray-200">
+                    <ShippingPackagePickerClient
+                      orderId={order.id}
+                      currentPackage={
+                        (order.metadata as Record<string, unknown> | null)?.shipping_package &&
+                        typeof (order.metadata as Record<string, unknown>).shipping_package ===
+                          "object"
+                          ? {
+                              mode: ((order.metadata as Record<string, unknown>).shipping_package as { mode?: string })?.mode as "profile" | "custom" | undefined,
+                              profile: ((order.metadata as Record<string, unknown>).shipping_package as { profile?: string | null })?.profile as any,
+                              length_cm: ((order.metadata as Record<string, unknown>).shipping_package as { length_cm?: number })?.length_cm,
+                              width_cm: ((order.metadata as Record<string, unknown>).shipping_package as { width_cm?: number })?.width_cm,
+                              height_cm: ((order.metadata as Record<string, unknown>).shipping_package as { height_cm?: number })?.height_cm,
+                              weight_g: ((order.metadata as Record<string, unknown>).shipping_package as { weight_g?: number })?.weight_g,
+                            }
+                          : null
+                      }
+                    />
+                  </div>
+                )}
 
               {/* Botón para recotizar envío si es Skydropx */}
               {(order.shipping_provider === "skydropx" || order.shipping_provider === "Skydropx") &&

--- a/src/app/admin/productos/[id]/editar/ProductShippingEditorClient.tsx
+++ b/src/app/admin/productos/[id]/editar/ProductShippingEditorClient.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { type PackageProfileKey } from "@/lib/shipping/packageProfiles";
+
+type ProductShippingEditorClientProps = {
+  productId: string;
+  initialWeightG: number | null;
+  initialLengthCm: number | null;
+  initialWidthCm: number | null;
+  initialHeightCm: number | null;
+  initialProfile: PackageProfileKey | null;
+};
+
+/**
+ * Componente para editar dimensiones de envío de un producto
+ */
+export default function ProductShippingEditorClient({
+  productId,
+  initialWeightG,
+  initialLengthCm,
+  initialWidthCm,
+  initialHeightCm,
+  initialProfile,
+}: ProductShippingEditorClientProps) {
+  const [weightG, setWeightG] = useState<string>(
+    initialWeightG !== null && initialWeightG !== undefined ? String(initialWeightG) : "",
+  );
+  const [lengthCm, setLengthCm] = useState<string>(
+    initialLengthCm !== null && initialLengthCm !== undefined ? String(initialLengthCm) : "",
+  );
+  const [widthCm, setWidthCm] = useState<string>(
+    initialWidthCm !== null && initialWidthCm !== undefined ? String(initialWidthCm) : "",
+  );
+  const [heightCm, setHeightCm] = useState<string>(
+    initialHeightCm !== null && initialHeightCm !== undefined ? String(initialHeightCm) : "",
+  );
+  const [profile, setProfile] = useState<PackageProfileKey | "">(
+    initialProfile || "",
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Reset success message after 3 seconds
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => setSuccess(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
+
+  const handleSave = async () => {
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const body: {
+        productId: string;
+        weight_g?: number | null;
+        length_cm?: number | null;
+        width_cm?: number | null;
+        height_cm?: number | null;
+        shipping_profile?: PackageProfileKey | null;
+      } = {
+        productId,
+      };
+
+      // Solo incluir valores si tienen contenido
+      if (weightG.trim() !== "") {
+        const parsed = parseFloat(weightG);
+        if (isNaN(parsed)) {
+          setError("El peso debe ser un número válido.");
+          setLoading(false);
+          return;
+        }
+        body.weight_g = parsed;
+      } else {
+        body.weight_g = null;
+      }
+
+      if (lengthCm.trim() !== "") {
+        const parsed = parseFloat(lengthCm);
+        if (isNaN(parsed)) {
+          setError("El largo debe ser un número válido.");
+          setLoading(false);
+          return;
+        }
+        body.length_cm = parsed;
+      } else {
+        body.length_cm = null;
+      }
+
+      if (widthCm.trim() !== "") {
+        const parsed = parseFloat(widthCm);
+        if (isNaN(parsed)) {
+          setError("El ancho debe ser un número válido.");
+          setLoading(false);
+          return;
+        }
+        body.width_cm = parsed;
+      } else {
+        body.width_cm = null;
+      }
+
+      if (heightCm.trim() !== "") {
+        const parsed = parseFloat(heightCm);
+        if (isNaN(parsed)) {
+          setError("El alto debe ser un número válido.");
+          setLoading(false);
+          return;
+        }
+        body.height_cm = parsed;
+      } else {
+        body.height_cm = null;
+      }
+
+      body.shipping_profile = profile === "" ? null : (profile as PackageProfileKey);
+
+      const res = await fetch("/api/admin/products/update-shipping", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      const data = await res.json();
+
+      if (!data.ok) {
+        const errorMessage =
+          data.code === "unauthorized"
+            ? "No tienes permisos para realizar esta acción."
+            : data.code === "invalid_request"
+              ? data.message || "Datos inválidos."
+              : data.code === "invalid_dimensions"
+                ? data.message || "Dimensiones inválidas."
+                : data.message || "Error al guardar las dimensiones.";
+
+        setError(errorMessage);
+        return;
+      }
+
+      setSuccess(true);
+      // Refrescar página para mostrar cambios
+      window.location.reload();
+    } catch (err) {
+      console.error("[ProductShippingEditorClient] Error:", err);
+      setError("Error de red al guardar las dimensiones.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-md font-semibold">Dimensiones de envío</h3>
+      <p className="text-sm text-gray-600">
+        Estas dimensiones se usan para estimar el empaque al crear pedidos.
+      </p>
+
+      {/* Perfil recomendado */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Perfil recomendado
+        </label>
+        <select
+          value={profile}
+          onChange={(e) => setProfile(e.target.value as PackageProfileKey | "")}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        >
+          <option value="">Sin perfil</option>
+          <option value="ENVELOPE">Sobre (ENVELOPE)</option>
+          <option value="BOX_S">Caja Pequeña (BOX_S)</option>
+          <option value="BOX_M">Caja Mediana (BOX_M)</option>
+          <option value="CUSTOM">Personalizado (CUSTOM)</option>
+        </select>
+        <p className="mt-1 text-xs text-gray-500">
+          Perfil sugerido para este producto. Se usa como referencia al seleccionar empaque en pedidos.
+        </p>
+      </div>
+
+      {/* Dimensiones */}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Peso (g)
+          </label>
+          <input
+            type="number"
+            value={weightG}
+            onChange={(e) => setWeightG(e.target.value)}
+            min="1"
+            max="50000"
+            step="1"
+            placeholder="Ej: 150"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Largo (cm)
+          </label>
+          <input
+            type="number"
+            value={lengthCm}
+            onChange={(e) => setLengthCm(e.target.value)}
+            min="1"
+            max="200"
+            step="0.1"
+            placeholder="Ej: 25"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Ancho (cm)
+          </label>
+          <input
+            type="number"
+            value={widthCm}
+            onChange={(e) => setWidthCm(e.target.value)}
+            min="1"
+            max="200"
+            step="0.1"
+            placeholder="Ej: 20"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Alto (cm)
+          </label>
+          <input
+            type="number"
+            value={heightCm}
+            onChange={(e) => setHeightCm(e.target.value)}
+            min="1"
+            max="200"
+            step="0.1"
+            placeholder="Ej: 15"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3">
+          <p className="text-sm text-red-800">{error}</p>
+        </div>
+      )}
+
+      {/* Success */}
+      {success && (
+        <div className="rounded-lg border border-green-200 bg-green-50 p-3">
+          <p className="text-sm text-green-800">Dimensiones guardadas correctamente.</p>
+        </div>
+      )}
+
+      {/* Botón Guardar */}
+      <button
+        onClick={handleSave}
+        disabled={loading}
+        className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+      >
+        {loading ? "Guardando..." : "Guardar dimensiones"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/admin/productos/[id]/editar/page.tsx
+++ b/src/app/admin/productos/[id]/editar/page.tsx
@@ -13,6 +13,7 @@ import {
   deleteProductImageAction,
   toggleProductActiveAction,
 } from "@/lib/actions/products.admin";
+import ProductShippingEditorClient from "./ProductShippingEditorClient";
 
 export const dynamic = "force-dynamic";
 
@@ -321,6 +322,18 @@ export default async function AdminProductosEditarPage({
             </div>
           </div>
         </form>
+      </div>
+
+      {/* Dimensiones de envío */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mt-6">
+        <ProductShippingEditorClient
+          productId={product.id}
+          initialWeightG={product.shippingWeightG}
+          initialLengthCm={product.shippingLengthCm}
+          initialWidthCm={product.shippingWidthCm}
+          initialHeightCm={product.shippingHeightCm}
+          initialProfile={(product.shippingProfile as any) || null}
+        />
       </div>
 
       {/* Estado y archivado */}

--- a/src/app/api/admin/orders/set-shipping-package/route.ts
+++ b/src/app/api/admin/orders/set-shipping-package/route.ts
@@ -1,0 +1,253 @@
+import { NextRequest, NextResponse } from "next/server";
+import "server-only";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { getOrderWithItemsAdmin } from "@/lib/supabase/orders.server";
+import { createClient } from "@supabase/supabase-js";
+import { getPackageProfile, type PackageProfileKey, validatePackageDimensions } from "@/lib/shipping/packageProfiles";
+
+export const dynamic = "force-dynamic";
+
+type SetShippingPackageResponse =
+  | {
+      ok: true;
+      shippingPackage: {
+        mode: "profile" | "custom";
+        profile: PackageProfileKey | null;
+        length_cm: number;
+        width_cm: number;
+        height_cm: number;
+        weight_g: number;
+      };
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+/**
+ * POST /api/admin/orders/set-shipping-package
+ * 
+ * Establece el perfil o dimensiones personalizadas de empaque para una orden
+ */
+export async function POST(req: NextRequest) {
+  try {
+    // Verificar acceso admin
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unauthorized",
+          message: "No tienes permisos para realizar esta acción.",
+        } satisfies SetShippingPackageResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await req.json();
+    const { orderId, profile, custom } = body;
+
+    // Validaciones básicas
+    if (!orderId || typeof orderId !== "string") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "orderId es requerido.",
+        } satisfies SetShippingPackageResponse,
+        { status: 400 },
+      );
+    }
+
+    // Validar que se proporcione profile o custom, pero no ambos
+    if (!profile && !custom) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "Se debe proporcionar 'profile' o 'custom'.",
+        } satisfies SetShippingPackageResponse,
+        { status: 400 },
+      );
+    }
+
+    if (profile && custom) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "No se pueden proporcionar 'profile' y 'custom' al mismo tiempo.",
+        } satisfies SetShippingPackageResponse,
+        { status: 400 },
+      );
+    }
+
+    // Obtener orden
+    const order = await getOrderWithItemsAdmin(orderId);
+    if (!order) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "order_not_found",
+          message: "La orden no existe.",
+        } satisfies SetShippingPackageResponse,
+        { status: 404 },
+      );
+    }
+
+    // Validar que la orden no tenga label ya creada (no permitir cambios después de label)
+    if (order.shipping_tracking_number || order.shipping_label_url) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "label_already_created",
+          message:
+            "No se puede cambiar el empaque porque ya se creó la guía. Primero cancela la guía existente.",
+        } satisfies SetShippingPackageResponse,
+        { status: 409 },
+      );
+    }
+
+    // Determinar modo y valores
+    let shippingPackage: {
+      mode: "profile" | "custom";
+      profile: PackageProfileKey | null;
+      length_cm: number;
+      width_cm: number;
+      height_cm: number;
+      weight_g: number;
+    };
+
+    if (profile) {
+      // Modo profile
+      if (!["ENVELOPE", "BOX_S", "BOX_M"].includes(profile)) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_profile",
+            message: "Perfil inválido. Debe ser ENVELOPE, BOX_S o BOX_M.",
+          } satisfies SetShippingPackageResponse,
+          { status: 400 },
+        );
+      }
+
+      const profileData = getPackageProfile(profile as PackageProfileKey);
+      shippingPackage = {
+        mode: "profile",
+        profile: profile as PackageProfileKey,
+        length_cm: profileData.length_cm,
+        width_cm: profileData.width_cm,
+        height_cm: profileData.height_cm,
+        weight_g: profileData.weight_g,
+      };
+    } else {
+      // Modo custom
+      if (
+        typeof custom.length_cm !== "number" ||
+        typeof custom.width_cm !== "number" ||
+        typeof custom.height_cm !== "number" ||
+        typeof custom.weight_g !== "number"
+      ) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_custom",
+            message: "custom debe incluir length_cm, width_cm, height_cm y weight_g numéricos.",
+          } satisfies SetShippingPackageResponse,
+          { status: 400 },
+        );
+      }
+
+      // Validar dimensiones
+      const validation = validatePackageDimensions(
+        custom.length_cm,
+        custom.width_cm,
+        custom.height_cm,
+        custom.weight_g,
+      );
+      if (!validation.valid) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_dimensions",
+            message: validation.error || "Dimensiones inválidas.",
+          } satisfies SetShippingPackageResponse,
+          { status: 400 },
+        );
+      }
+
+      shippingPackage = {
+        mode: "custom",
+        profile: null,
+        length_cm: custom.length_cm,
+        width_cm: custom.width_cm,
+        height_cm: custom.height_cm,
+        weight_g: custom.weight_g,
+      };
+    }
+
+    // Actualizar metadata
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !serviceRoleKey) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "config_error",
+          message: "Configuración de Supabase incompleta.",
+        } satisfies SetShippingPackageResponse,
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    const currentMetadata = (order.metadata as Record<string, unknown>) || {};
+    const updatedMetadata = {
+      ...currentMetadata,
+      shipping_package: shippingPackage,
+    };
+
+    const { error: updateError } = await supabase
+      .from("orders")
+      .update({
+        metadata: updatedMetadata,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", orderId);
+
+    if (updateError) {
+      console.error("[set-shipping-package] Error al actualizar orden:", updateError);
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "update_failed",
+          message: "Error al actualizar la orden. Revisa los logs.",
+        } satisfies SetShippingPackageResponse,
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      shippingPackage,
+    } satisfies SetShippingPackageResponse);
+  } catch (error) {
+    console.error("[set-shipping-package] Error inesperado:", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "internal_error",
+        message: "Error al establecer el empaque. Revisa los logs.",
+      } satisfies SetShippingPackageResponse,
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/products/update-shipping/route.ts
+++ b/src/app/api/admin/products/update-shipping/route.ts
@@ -1,0 +1,258 @@
+import { NextRequest, NextResponse } from "next/server";
+import "server-only";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { createClient } from "@supabase/supabase-js";
+import { validatePackageDimensions } from "@/lib/shipping/packageProfiles";
+import type { PackageProfileKey } from "@/lib/shipping/packageProfiles";
+
+export const dynamic = "force-dynamic";
+
+type UpdateProductShippingResponse =
+  | {
+      ok: true;
+      message: string;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+/**
+ * POST /api/admin/products/update-shipping
+ * 
+ * Actualiza peso y dimensiones de envío de un producto
+ */
+export async function POST(req: NextRequest) {
+  try {
+    // Verificar acceso admin
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unauthorized",
+          message: "No tienes permisos para realizar esta acción.",
+        } satisfies UpdateProductShippingResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await req.json();
+    const {
+      productId,
+      weight_g,
+      length_cm,
+      width_cm,
+      height_cm,
+      shipping_profile,
+    } = body;
+
+    // Validaciones básicas
+    if (!productId || typeof productId !== "string") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_request",
+          message: "productId es requerido.",
+        } satisfies UpdateProductShippingResponse,
+        { status: 400 },
+      );
+    }
+
+    // Validar valores numéricos si se proporcionan
+    if (weight_g !== null && weight_g !== undefined) {
+      if (typeof weight_g !== "number" && typeof weight_g !== "string") {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_request",
+            message: "weight_g debe ser un número o null.",
+          } satisfies UpdateProductShippingResponse,
+          { status: 400 },
+        );
+      }
+    }
+
+    if (length_cm !== null && length_cm !== undefined) {
+      if (typeof length_cm !== "number" && typeof length_cm !== "string") {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_request",
+            message: "length_cm debe ser un número o null.",
+          } satisfies UpdateProductShippingResponse,
+          { status: 400 },
+        );
+      }
+    }
+
+    if (width_cm !== null && width_cm !== undefined) {
+      if (typeof width_cm !== "number" && typeof width_cm !== "string") {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_request",
+            message: "width_cm debe ser un número o null.",
+          } satisfies UpdateProductShippingResponse,
+          { status: 400 },
+        );
+      }
+    }
+
+    if (height_cm !== null && height_cm !== undefined) {
+      if (typeof height_cm !== "number" && typeof height_cm !== "string") {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_request",
+            message: "height_cm debe ser un número o null.",
+          } satisfies UpdateProductShippingResponse,
+          { status: 400 },
+        );
+      }
+    }
+
+    // Validar shipping_profile si se proporciona
+    if (
+      shipping_profile !== null &&
+      shipping_profile !== undefined &&
+      !["ENVELOPE", "BOX_S", "BOX_M", "CUSTOM"].includes(shipping_profile)
+    ) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_profile",
+          message: "shipping_profile debe ser ENVELOPE, BOX_S, BOX_M, CUSTOM o null.",
+        } satisfies UpdateProductShippingResponse,
+        { status: 400 },
+        );
+    }
+
+    // Convertir valores a números si son strings
+    const weightGrams =
+      weight_g === null || weight_g === undefined
+        ? null
+        : typeof weight_g === "string"
+          ? parseFloat(weight_g)
+          : weight_g;
+    const lengthCm =
+      length_cm === null || length_cm === undefined
+        ? null
+        : typeof length_cm === "string"
+          ? parseFloat(length_cm)
+          : length_cm;
+    const widthCm =
+      width_cm === null || width_cm === undefined
+        ? null
+        : typeof width_cm === "string"
+          ? parseFloat(width_cm)
+          : width_cm;
+    const heightCm =
+      height_cm === null || height_cm === undefined
+        ? null
+        : typeof height_cm === "string"
+          ? parseFloat(height_cm)
+          : height_cm;
+
+    // Validar dimensiones si todas están presentes
+    if (
+      weightGrams !== null &&
+      lengthCm !== null &&
+      widthCm !== null &&
+      heightCm !== null
+    ) {
+      const validation = validatePackageDimensions(
+        lengthCm,
+        widthCm,
+        heightCm,
+        weightGrams,
+      );
+      if (!validation.valid) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "invalid_dimensions",
+            message: validation.error || "Dimensiones inválidas.",
+          } satisfies UpdateProductShippingResponse,
+          { status: 400 },
+        );
+      }
+    }
+
+    // Actualizar producto
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !serviceRoleKey) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "config_error",
+          message: "Configuración de Supabase incompleta.",
+        } satisfies UpdateProductShippingResponse,
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    // Construir objeto de actualización
+    const updateData: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    if (weightGrams !== null && weightGrams !== undefined) {
+      updateData.shipping_weight_g = Math.round(weightGrams);
+    }
+    if (lengthCm !== null && lengthCm !== undefined) {
+      updateData.shipping_length_cm = Math.round(lengthCm);
+    }
+    if (widthCm !== null && widthCm !== undefined) {
+      updateData.shipping_width_cm = Math.round(widthCm);
+    }
+    if (heightCm !== null && heightCm !== undefined) {
+      updateData.shipping_height_cm = Math.round(heightCm);
+    }
+    if (shipping_profile !== undefined) {
+      updateData.shipping_profile = shipping_profile as PackageProfileKey | null;
+    }
+
+    const { error: updateError } = await supabase
+      .from("products")
+      .update(updateData)
+      .eq("id", productId);
+
+    if (updateError) {
+      console.error("[update-product-shipping] Error al actualizar producto:", updateError);
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "update_failed",
+          message: "Error al actualizar el producto. Revisa los logs.",
+        } satisfies UpdateProductShippingResponse,
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      message: "Dimensiones de envío actualizadas correctamente.",
+    } satisfies UpdateProductShippingResponse);
+  } catch (error) {
+    console.error("[update-product-shipping] Error inesperado:", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "internal_error",
+        message: "Error al actualizar las dimensiones. Revisa los logs.",
+      } satisfies UpdateProductShippingResponse,
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/shipping/skydropx/create-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/create-label/route.ts
@@ -445,12 +445,42 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Calcular dimensiones del paquete (usar valores estándar si no están disponibles)
-    // TODO: Calcular desde order_items si están disponibles
-    const weightKg = 1.0; // Default 1kg
-    const heightCm = 10;
-    const widthCm = 20;
-    const lengthCm = 20;
+    // Obtener package desde metadata.shipping_package o usar default
+    const shippingPackage = orderMetadata.shipping_package as
+      | {
+          mode?: "profile" | "custom";
+          profile?: string | null;
+          length_cm?: number;
+          width_cm?: number;
+          height_cm?: number;
+          weight_g?: number;
+        }
+      | undefined;
+
+    let weightKg: number;
+    let lengthCm: number;
+    let widthCm: number;
+    let heightCm: number;
+
+    if (
+      shippingPackage &&
+      typeof shippingPackage.weight_g === "number" &&
+      typeof shippingPackage.length_cm === "number" &&
+      typeof shippingPackage.width_cm === "number" &&
+      typeof shippingPackage.height_cm === "number"
+    ) {
+      // Usar package guardado (convertir peso a kg)
+      weightKg = shippingPackage.weight_g / 1000;
+      lengthCm = shippingPackage.length_cm;
+      widthCm = shippingPackage.width_cm;
+      heightCm = shippingPackage.height_cm;
+    } else {
+      // Usar default (BOX_S: 25x20x15 cm, 1kg)
+      weightKg = 1.0;
+      lengthCm = 25;
+      widthCm = 20;
+      heightCm = 15;
+    }
 
     if (process.env.NODE_ENV !== "production") {
       console.log("[create-label] Creando envío:", {

--- a/src/lib/shipping/packageProfiles.ts
+++ b/src/lib/shipping/packageProfiles.ts
@@ -1,0 +1,75 @@
+/**
+ * Perfiles de empaque predefinidos para envíos
+ * Estos valores se usan como defaults y pueden ser personalizados por orden
+ */
+export type PackageProfileKey = "ENVELOPE" | "BOX_S" | "BOX_M" | "CUSTOM";
+
+export type PackageProfile = {
+  label: string;
+  length_cm: number;
+  width_cm: number;
+  height_cm: number;
+  weight_g: number; // Peso base del empaque vacío
+};
+
+export const PACKAGE_PROFILES: Record<PackageProfileKey, PackageProfile> = {
+  ENVELOPE: {
+    label: "Sobre",
+    length_cm: 32,
+    width_cm: 23,
+    height_cm: 1,
+    weight_g: 50, // Peso base del sobre vacío
+  },
+  BOX_S: {
+    label: "Caja Pequeña",
+    length_cm: 25,
+    width_cm: 20,
+    height_cm: 15,
+    weight_g: 150, // Peso base de caja pequeña vacía
+  },
+  BOX_M: {
+    label: "Caja Mediana",
+    length_cm: 35,
+    width_cm: 30,
+    height_cm: 25,
+    weight_g: 300, // Peso base de caja mediana vacía
+  },
+  CUSTOM: {
+    label: "Personalizado",
+    length_cm: 20,
+    width_cm: 20,
+    height_cm: 10,
+    weight_g: 100, // Default para personalizado (se sobreescribe)
+  },
+};
+
+/**
+ * Obtiene un perfil por su clave
+ */
+export function getPackageProfile(key: PackageProfileKey): PackageProfile {
+  return PACKAGE_PROFILES[key];
+}
+
+/**
+ * Valida que las dimensiones estén dentro de límites razonables
+ */
+export function validatePackageDimensions(
+  length_cm: number,
+  width_cm: number,
+  height_cm: number,
+  weight_g: number,
+): { valid: boolean; error?: string } {
+  if (length_cm <= 0 || width_cm <= 0 || height_cm <= 0) {
+    return { valid: false, error: "Las dimensiones deben ser mayores a 0" };
+  }
+  if (length_cm > 200 || width_cm > 200 || height_cm > 200) {
+    return { valid: false, error: "Las dimensiones no pueden exceder 200 cm" };
+  }
+  if (weight_g <= 0) {
+    return { valid: false, error: "El peso debe ser mayor a 0" };
+  }
+  if (weight_g > 50000) {
+    return { valid: false, error: "El peso no puede exceder 50 kg (50000 g)" };
+  }
+  return { valid: true };
+}

--- a/src/lib/supabase/products.admin.server.ts
+++ b/src/lib/supabase/products.admin.server.ts
@@ -58,6 +58,11 @@ export type AdminProduct = {
   description: string | null;
   sku: string | null;
   image_url: string | null;
+  shippingWeightG: number | null;
+  shippingLengthCm: number | null;
+  shippingWidthCm: number | null;
+  shippingHeightCm: number | null;
+  shippingProfile: string | null;
   createdAt: string;
   updatedAt: string | null;
 };
@@ -266,6 +271,11 @@ export async function getAdminProductById(
         description,
         sku,
         image_url,
+        shipping_weight_g,
+        shipping_length_cm,
+        shipping_width_cm,
+        shipping_height_cm,
+        shipping_profile,
         created_at,
         updated_at,
         sections!inner (
@@ -284,7 +294,7 @@ export async function getAdminProductById(
         // Intentar sin join si falla
         const { data: dataFallback, error: errorFallback } = await supabase
           .from("products")
-          .select("id, section_id, slug, title, price_cents, currency, stock_qty, active, description, sku, image_url, created_at, updated_at")
+          .select("id, section_id, slug, title, price_cents, currency, stock_qty, active, description, sku, image_url, shipping_weight_g, shipping_length_cm, shipping_width_cm, shipping_height_cm, shipping_profile, created_at, updated_at")
           .eq("id", productId)
           .maybeSingle();
 
@@ -306,6 +316,11 @@ export async function getAdminProductById(
           description: dataFallback.description || null,
           sku: dataFallback.sku || null,
           image_url: dataFallback.image_url || null,
+          shippingWeightG: (dataFallback as any).shipping_weight_g ?? null,
+          shippingLengthCm: (dataFallback as any).shipping_length_cm ?? null,
+          shippingWidthCm: (dataFallback as any).shipping_width_cm ?? null,
+          shippingHeightCm: (dataFallback as any).shipping_height_cm ?? null,
+          shippingProfile: (dataFallback as any).shipping_profile ?? null,
           createdAt: dataFallback.created_at || "",
           updatedAt: dataFallback.updated_at || null,
         };
@@ -330,6 +345,11 @@ export async function getAdminProductById(
       description: data.description || null,
       sku: data.sku || null,
       image_url: data.image_url || null,
+      shippingWeightG: (data as any).shipping_weight_g ?? null,
+      shippingLengthCm: (data as any).shipping_length_cm ?? null,
+      shippingWidthCm: (data as any).shipping_width_cm ?? null,
+      shippingHeightCm: (data as any).shipping_height_cm ?? null,
+      shippingProfile: (data as any).shipping_profile ?? null,
       createdAt: data.created_at || "",
       updatedAt: data.updated_at || null,
     };


### PR DESCRIPTION
## Objetivo
Implementar "Shipping Package Profiles" y dimensiones por producto para mejorar la precisión de cotizaciones y creación de guías en Skydropx.

## Feature A: Empaque en Admin Pedido
- Selector de perfil de empaque (ENVELOPE/BOX_S/BOX_M o personalizado)
- Guarda en `metadata.shipping_package`
- Integrado con `/requote` y `/create-label`

## Feature B: Dimensiones en Admin Producto
- UI para editar peso y dimensiones por producto
- Guarda en columnas nuevas: `shipping_weight_g`, `shipping_length_cm`, etc.
- Migración SQL incluida

## Cambios
- Nuevos archivos: `packageProfiles.ts`, endpoints y componentes
- Migración SQL: `ops/sql/2025-01-XX_add_shipping_fields_to_products.sql`
- Actualizados: `/requote`, `/create-label`, tipos de productos

## Cómo probar
1. Ejecutar migración SQL en Supabase
2. Admin → Pedidos → [Orden] → Seleccionar empaque
3. Recotizar y crear guía usando el empaque guardado
4. Admin → Productos → [Producto] → Editar dimensiones de envío
