### PR TITLE
fix(skydropx): clamp min billable weight to 1kg for rates/shipments

### DIFF
--- a/CONFIGURACION.md
+++ b/CONFIGURACION.md
@@ -66,6 +66,11 @@ SKYDROPX_ORIGIN_ADDRESS_LINE_1=Calle Principal 123
 SKYDROPX_ORIGIN_PHONE=5512345678
 SKYDROPX_ORIGIN_EMAIL=envios@ddnshop.mx
 
+# Peso mínimo billable para Skydropx (default: 1000g = 1kg)
+# Skydropx requiere/cobra mínimo 1kg para cotizaciones y envíos.
+# Si el paquete pesa menos de 1kg, se ajustará automáticamente a 1kg para la cotización/creación de guía.
+SKYDROPX_MIN_BILLABLE_WEIGHT_G=1000
+
 # App URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```
@@ -240,6 +245,7 @@ Para obtener cotizaciones precisas de Skydropx, es importante seleccionar el emp
 - El empaque guardado se usa automáticamente en `/requote` y `/create-label`
 - Si no hay empaque guardado, el sistema usa BOX_S por defecto y muestra un warning
 - No se puede cambiar el empaque si ya se creó la guía (tiene `shipping_tracking_number` o `shipping_label_url`)
+- **Peso mínimo**: Skydropx requiere/cobra mínimo 1kg (1000g) para cotizaciones y envíos. Si el paquete pesa menos de 1kg, se ajustará automáticamente a 1kg (ver `SKYDROPX_MIN_BILLABLE_WEIGHT_G`)
 
 **Estructura de `metadata.shipping_package`:**
 ```typescript

--- a/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
+++ b/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
@@ -34,6 +34,8 @@ export default function RequoteSkydropxRatesClient({
   const [diagnostic, setDiagnostic] = useState<any>(null);
   const [emptyReason, setEmptyReason] = useState<string | null>(null);
   const [showDiagnostic, setShowDiagnostic] = useState(false);
+  const [weightClamped, setWeightClamped] = useState(false);
+  const [warning, setWarning] = useState<string | null>(null);
 
   // Verificar si la tarifa está expirada o próxima a expirar
   const isExpiredOrExpiring = (): boolean => {
@@ -63,6 +65,8 @@ export default function RequoteSkydropxRatesClient({
     setDiagnostic(null);
     setEmptyReason(null);
     setShowDiagnostic(false);
+    setWeightClamped(false);
+    setWarning(null);
 
     try {
       const res = await fetch("/api/admin/shipping/skydropx/requote", {
@@ -93,11 +97,8 @@ export default function RequoteSkydropxRatesClient({
       setRates(data.rates || []);
       setDiagnostic(data.diagnostic || null);
       setEmptyReason(data.emptyReason || null);
-      
-      // Mostrar warning si viene del backend
-      if (data.warning) {
-        setError(data.warning);
-      }
+      setWeightClamped(data.weightClamped || false);
+      setWarning(data.warning || null);
       
       // Si rates está vacío y hay diagnóstico, mostrar panel por defecto
       if (((data.rates?.length ?? 0) === 0) && data.diagnostic) {
@@ -231,6 +232,23 @@ export default function RequoteSkydropxRatesClient({
       {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 p-4">
           <p className="text-sm text-red-800">{error}</p>
+        </div>
+      )}
+
+      {/* Warning si el peso fue clampado (informativo, no error) */}
+      {weightClamped && diagnostic?.pkg && (
+        <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4">
+          <p className="text-sm text-yellow-800">
+            <strong>Nota:</strong> Skydropx requiere/cobra mínimo {diagnostic.pkg.min_billable_weight_g}g (1kg). 
+            Se cotizó con {diagnostic.pkg.min_billable_weight_g}g ({diagnostic.pkg.min_billable_weight_g / 1000}kg).
+          </p>
+        </div>
+      )}
+
+      {/* Warning general (para empaque, etc.) */}
+      {warning && !weightClamped && (
+        <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4">
+          <p className="text-sm text-yellow-800">{warning}</p>
         </div>
       )}
 

--- a/src/lib/shipping/skydropx.server.ts
+++ b/src/lib/shipping/skydropx.server.ts
@@ -9,6 +9,16 @@ import {
 import { normalizeMxAddress } from "./normalizeAddress";
 
 /**
+ * Peso mínimo billable para Skydropx (1kg)
+ * Skydropx requiere/cobra mínimo 1kg para cotizaciones y envíos
+ * Configurable vía env var: SKYDROPX_MIN_BILLABLE_WEIGHT_G (default: 1000)
+ */
+const MIN_BILLABLE_WEIGHT_G = parseInt(
+  process.env.SKYDROPX_MIN_BILLABLE_WEIGHT_G || "1000",
+  10,
+);
+
+/**
  * Tipos para la integración con Skydropx
  * (Mantener compatibilidad con código existente)
  */
@@ -625,7 +635,9 @@ export async function createSkydropxShipment(input: {
     console.log("[createSkydropxShipment] Usando autenticación: OAuth");
   }
 
-  const weightGrams = input.pkg.weightGrams || 1000;
+  // Skydropx requiere/cobra mínimo 1kg (1000g) para cotizaciones y envíos
+  const rawWeightGrams = input.pkg.weightGrams || 1000;
+  const weightGrams = Math.max(rawWeightGrams, MIN_BILLABLE_WEIGHT_G);
   const weightKg = weightGrams / 1000; // Convertir gramos a kilogramos
   const lengthCm = input.pkg.lengthCm || 20;
   const widthCm = input.pkg.widthCm || 20;


### PR DESCRIPTION
## Problema
Admin/Checkout devuelven `rates: []` cuando el paquete pesa < 1kg. Skydropx requiere/cobra mínimo 1kg para cotizaciones y envíos. Con 0.1kg (100g) falla y con 1kg sí devuelve tarifas.

## Solución
- Aplicar "billable weight" mínimo 1kg para Skydropx rates y shipments
- Mantener diagnóstico sin PII pero mostrando el peso final usado y si fue clampado
- Documentar claramente que Skydropx cobra mínimo 1kg

## Cambios

### `src/lib/shipping/buildSkydropxRatesRequest.ts`
- Agregar constante `MIN_BILLABLE_WEIGHT_G` (default 1000g, configurable via env)
- Cambiar clamp de 50g a 1000g (1kg)
- Actualizar diagnóstico para incluir `was_clamped` y `min_billable_weight_g`

### `src/lib/shipping/skydropx.server.ts`
- Aplicar mismo clamp mínimo 1kg en `createSkydropxShipment`
- Asegurar consistencia entre rates y shipments

### `src/app/api/admin/shipping/skydropx/requote/route.ts`
- Actualizar clamp mínimo a 1000g (1kg) en requote
- Incluir `was_clamped` y `min_billable_weight_g` en diagnóstico
- Mostrar warning si el peso fue clampado

### `src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx`
- Mostrar aviso informativo si el peso fue clampado al mínimo
- Separar warnings de peso vs empaque

### `CONFIGURACION.md`
- Documentar `SKYDROPX_MIN_BILLABLE_WEIGHT_G=1000`
- Explicar que Skydropx requiere/cobra mínimo 1kg

## Validaciones
- ✅ typecheck: OK
- ✅ lint: OK (solo warnings existentes)
- ✅ build: OK

## Criterios de aceptación
- ✅ Para un paquete con `weight_g=100`, se cotiza con `weight_g=1000` (1kg)
- ✅ El diagnóstico muestra `was_clamped: true` y `min_billable_weight_g: 1000`
- ✅ Admin muestra aviso: "Skydropx requiere/cobra mínimo 1kg. Se cotizó con 1kg."
- ✅ Checkout rates también aplica clamp mínimo 1kg
- ✅ Create-label/shipments también aplica clamp mínimo 1kg (consistencia)
