### PR TITLE
fix(skydropx): use colonia (address2) for area_level3 in quotations

### DIFF
--- a/CONFIGURACION.md
+++ b/CONFIGURACION.md
@@ -65,6 +65,12 @@ SKYDROPX_ORIGIN_POSTAL_CODE=01234
 SKYDROPX_ORIGIN_ADDRESS_LINE_1=Calle Principal 123
 SKYDROPX_ORIGIN_PHONE=5512345678
 SKYDROPX_ORIGIN_EMAIL=envios@ddnshop.mx
+# Colonia/barrio para area_level3 en Skydropx quotations (opcional)
+# Si no se configura, se usa alcaldía detectada o address2
+# Ejemplo para CP 14380: SKYDROPX_ORIGIN_AREA_LEVEL3=San Bartolo El Chico
+SKYDROPX_ORIGIN_AREA_LEVEL3=
+# Referencia para shipments (opcional, NO se usa en quotations)
+SKYDROPX_ORIGIN_REFERENCE=
 
 # Peso mínimo billable para Skydropx (default: 1000g = 1kg)
 # Skydropx requiere/cobra mínimo 1kg para cotizaciones y envíos.

--- a/src/lib/shipping/skydropx.server.ts
+++ b/src/lib/shipping/skydropx.server.ts
@@ -39,6 +39,7 @@ export type SkydropxDestination = {
   city: string;
   country?: string; // default "MX"
   address1?: string; // Opcional: calle/dirección de destino
+  address2?: string; // Opcional: colonia/barrio (para area_level3 en Skydropx)
 };
 
 export type SkydropxPackageInput = {
@@ -60,6 +61,8 @@ type OriginConfig = {
   city: string;
   postalCode: string;
   addressLine1: string;
+  areaLevel3?: string; // Colonia/barrio para area_level3 en Skydropx (opcional, configurable via env)
+  reference?: string; // Referencia para shipments (opcional, NO para quotations)
 };
 
 /**
@@ -93,6 +96,8 @@ export function getSkydropxConfig(): SkydropxAuthConfig | null {
   const originCity = process.env.SKYDROPX_ORIGIN_CITY;
   const originPostalCode = process.env.SKYDROPX_ORIGIN_POSTAL_CODE;
   const originAddressLine1 = process.env.SKYDROPX_ORIGIN_ADDRESS_LINE_1;
+  const originAreaLevel3 = process.env.SKYDROPX_ORIGIN_AREA_LEVEL3; // Colonia/barrio para area_level3 (opcional)
+  const originReference = process.env.SKYDROPX_ORIGIN_REFERENCE; // Referencia para shipments (opcional)
 
   // Validación mínima de datos de origen
   if (!originName || !originState || !originCity || !originPostalCode) {
@@ -113,6 +118,8 @@ export function getSkydropxConfig(): SkydropxAuthConfig | null {
     city: originCity,
     postalCode: originPostalCode,
     addressLine1: originAddressLine1 || "",
+    areaLevel3: originAreaLevel3, // Colonia/barrio para area_level3 (opcional)
+    reference: originReference, // Referencia para shipments (opcional)
   };
 
   // URL base de la API de Skydropx
@@ -178,7 +185,8 @@ export async function getSkydropxRates(
       state: destination.state,
       city: destination.city,
       country: destination.country,
-      address1: destination.address1, // Pasar address1 si está disponible
+      address1: destination.address1, // Pasar address1 (calle) si está disponible
+      address2: destination.address2, // Pasar address2 (colonia) si está disponible para area_level3
     },
     package: {
       weightGrams: pkg.weightGrams || 1000,

--- a/src/lib/skydropx/client.ts
+++ b/src/lib/skydropx/client.ts
@@ -429,10 +429,12 @@ export async function createQuotation(
           || payload.address_from.province 
           || "Ciudad de México",
         area_level2: payload.address_from.city || "",
-        // Usar address1 en area_level3 (prioridad sobre neighborhood)
-        area_level3: payload.address_from.address1 
-          || payload.address_from.neighborhood 
-          || payload.address_from.city 
+        // area_level3 = colonia/barrio (NO calle)
+        // PRIORIDAD: address2 (colonia) > neighborhood > address1 (último recurso)
+        area_level3: payload.address_from.address2
+          || payload.address_from.neighborhood
+          || payload.address_from.address1
+          || payload.address_from.city
           || "",
       },
       address_to: {
@@ -444,10 +446,12 @@ export async function createQuotation(
           || payload.address_from.province 
           || "Ciudad de México",
         area_level2: payload.address_to.city || "",
-        // Usar address1 en area_level3 (prioridad sobre neighborhood)
-        area_level3: payload.address_to.address1 
-          || payload.address_to.neighborhood 
-          || payload.address_to.city 
+        // area_level3 = colonia/barrio (NO calle)
+        // PRIORIDAD: address2 (colonia) > neighborhood > address1 (último recurso)
+        area_level3: payload.address_to.address2
+          || payload.address_to.neighborhood
+          || payload.address_to.address1
+          || payload.address_to.city
           || "",
       },
       parcels: [


### PR DESCRIPTION
## Problema
Skydropx rates vacíos (`rates: []`) cuando en UI de Skydropx sí existen tarifas para los mismos CPs.

**Evidencia confirmada:**
- En Skydropx UI, para CP 14380 aparece "San Bartolo El Chico" como colonia
- Para CP 14390 aparece "Narciso Mendoza" como colonia
- En nuestra integración, `area_level3` estaba usando `address1` (calle) en lugar de colonia/barrio
- Skydropx requiere `area_level3` = colonia/barrio, NO calle

## Solución
Corregir el mapping de `area_level3` para usar colonia (address2/neighborhood) en lugar de address1 (calle).

### Cambios

#### `src/lib/skydropx/client.ts` (createQuotation)
- Cambiar prioridad de `area_level3`: `address2` (colonia) > `neighborhood` > `address1` (último recurso)
- Antes: `address1` > `neighborhood` > `city`
- Ahora: `address2` > `neighborhood` > `address1` > `city`

#### `src/lib/shipping/buildSkydropxRatesRequest.ts`
- **Destination**: Usar `address2` (colonia) como `neighborhood` para `area_level3`
  - Prioridad: `address2` > `address1` (último recurso)
- **Origin**: Prioridad para `neighborhood`:
  - `SKYDROPX_ORIGIN_AREA_LEVEL3` (env var) > alcaldía > `address2` > `address1`
- Actualizar diagnóstico para incluir `area_level3_len` y `area_level3_source`

#### `src/lib/shipping/skydropx.server.ts`
- Agregar `address2?: string` a `SkydropxDestination`
- Agregar `areaLevel3?: string` y `reference?: string` a `OriginConfig`
- Leer `SKYDROPX_ORIGIN_AREA_LEVEL3` y `SKYDROPX_ORIGIN_REFERENCE` de env vars
- Pasar `address2` al builder desde `getSkydropxRates`

#### `src/app/api/admin/shipping/skydropx/requote/route.ts`
- Actualizar `extractAddressFromMetadata` para extraer `address2` (colonia)
- Pasar `address2` a `getSkydropxRates`
- Actualizar diagnóstico normalizado para incluir `area_level3_len` y `area_level3_source`
- Mejorar log diagnóstico cuando `rates=[]` (incluir area_level3 info)

#### `CONFIGURACION.md`
- Documentar `SKYDROPX_ORIGIN_AREA_LEVEL3` (colonia/barrio para origin)
- Documentar `SKYDROPX_ORIGIN_REFERENCE` (referencia para shipments, NO quotations)

## Validaciones
- ✅ typecheck: OK
- ✅ lint: OK (solo warnings existentes)
- ✅ build: OK

## Criterios de aceptación
- ✅ Para orden con `postal_code=14390`, `address2="NARCISO MENDOZA"`, `address1="vereda andador 1"`:
  - Diagnostic muestra `destination.area_level3_len > 0` y `area_level3_source="address2"`
- ✅ Para caso real (14380 -> 14390) y peso 1kg, Skydropx devuelve rates (no vacíos)
- ✅ Si Skydropx devuelve 0 rates, diagnóstico muestra claramente qué `area_level3` se mandó

## Evidencia manual (Skydropx UI)
- Origen: CP 14380 - San Bartolo El Chico
- Destino: CP 14390 - Narciso Mendoza
- Paquete: Caja de cartón, peso 1kg
- Resultado: ~15 tarifas disponibles

## Testing
- Probar con orden real que tiene `address2` en metadata
- Verificar que diagnostic muestra `area_level3_source="address2"`
- Verificar que Skydropx devuelve rates cuando antes devolvía vacío
