### PR TITLE
fix(skydropx): implement polling for quotations + align base URLs

### DIFF
--- a/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
+++ b/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
@@ -80,6 +80,13 @@ export default function RequoteSkydropxRatesClient({
       const data = await res.json();
 
       if (!data.ok) {
+        // Manejar quotation_pending de forma especial
+        if (data.code === "quotation_pending") {
+          setError("La cotización está en progreso. Por favor, reintenta en unos momentos.");
+          setDiagnostic(data.diagnostic || null);
+          return;
+        }
+        
         // Si es precondition failed, mostrar reason y missingFields
         const errorMessage =
           data.code === "unauthorized"


### PR DESCRIPTION
## Problema
Skydropx quotations devuelve `rates: []` prematuramente cuando en UI de Skydropx sí existen tarifas para los mismos CPs.

**Root cause identificado:**
- Skydropx docs indican que las cotizaciones se completan progresivamente
- POST `/api/v1/quotations` devuelve `quotation_id` e `is_completed=false`
- Se debe hacer polling con GET `/api/v1/quotations/{id}` hasta que `is_completed=true`
- Estábamos tomando el response del POST como "final" (rates puede venir vacío mientras `is_completed=false`)
- Estábamos marcando `emptyReason=skydropx_no_rates` demasiado pronto

## Solución
Implementar polling en `createQuotation` y actualizar base URLs según docs de Skydropx.

### Cambios

#### `src/lib/skydropx/client.ts`
- **Polling implementado**: POST devuelve `quotation_id` → GET hasta `is_completed=true`
  - Poll cada 500ms (respetando rate limit de 2 req/s)
  - Máximo 12 intentos (~8 segundos timeout)
  - Backoff automático entre intentos
- **Base URLs actualizadas**: Usar `pro.skydropx.com` por default (según docs)
  - `SKYDROPX_API_BASE_URL` como base común
  - `SKYDROPX_QUOTATIONS_BASE_URL` y `SKYDROPX_SHIPMENTS_BASE_URL` opcionales
- **Tipos actualizados**: `SkydropxQuotationResponse` incluye `id`, `is_completed`
- **Resultado mejorado**: `SkydropxQuotationResult` incluye `quotationId`, `isCompleted`, `pollingInfo`

#### `src/lib/shipping/skydropx.server.ts`
- **Manejo de quotation_pending**: Lanza error especial cuando timeout
- **Diagnóstico mejorado**: Incluye información de quotation:
  - `quotation_id`, `is_completed`, `polling_attempts`, `polling_elapsed_ms`
  - `rates_count_raw`, `rates_count_filtered`, `rates_by_status`
- **Logging mejorado**: Solo marca `skydropx_no_rates` cuando `is_completed === true`
- **Filtros actualizados**: Acepta más status válidos (price_found_*, approved, coverage_checked, pending)
  - Excluye: no_coverage, not_applicable, tariff_price_not_found, unavailable

#### `src/app/api/admin/shipping/skydropx/requote/route.ts`
- **Manejo de quotation_pending**: Captura error y devuelve `ok:false` con `code="quotation_pending"`
- **emptyReason condicional**: Solo devuelve `emptyReason="skydropx_no_rates"` cuando:
  - `is_completed === true` Y `rates.length === 0`
- **Diagnóstico mejorado**: Incluye información de quotation en respuesta
- **Tipo actualizado**: `RequoteResponse` incluye caso `quotation_pending`

#### `src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx`
- **UI para quotation_pending**: Muestra mensaje "La cotización está en progreso. Por favor, reintenta en unos momentos."

#### `CONFIGURACION.md`
- **Documentación actualizada**: Explica polling y nuevas env vars
- **Base URLs**: Documenta `SKYDROPX_API_BASE_URL`, `SKYDROPX_QUOTATIONS_BASE_URL`, `SKYDROPX_SHIPMENTS_BASE_URL`

## Validaciones
- ✅ typecheck: OK
- ✅ lint: OK (solo warnings existentes)
- ✅ build: OK

## Criterios de aceptación
- ✅ Cuando Skydropx tarda, el admin NO muestra "skydropx_no_rates" inmediatamente; espera/pollea
- ✅ Cuando `is_completed=true` y hay rates, el endpoint devuelve rates
- ✅ Cuando sigue pendiente (timeout), devuelve `quotation_pending` con diagnostic útil
- ✅ Base URL para quotations alineada a `pro.skydropx.com` por default
- ✅ Diagnóstico incluye información de quotation (id, is_completed, attempts, elapsed_ms, rates counts)

## Evidencia (Skydropx docs)
- Skydropx docs indican que las cotizaciones se completan progresivamente
- POST devuelve `quotation_id` e `is_completed=false`
- GET `/api/v1/quotations/{id}` hasta que `is_completed=true`
- Base URL recomendada: `pro.skydropx.com` para OAuth/quotations/shipments

## Testing
- Probar con orden real que antes devolvía `rates: []` prematuramente
- Verificar que ahora espera/pollea hasta que `is_completed=true`
- Verificar que si timeout, devuelve `quotation_pending` con mensaje claro
- Verificar que diagnostic incluye información de quotation
