### PR TITLE
fix(skydropx): allow shipments base URL override + safe diagnostics when sync-label finds nothing

### DIFF
--- a/CONFIGURACION.md
+++ b/CONFIGURACION.md
@@ -49,6 +49,13 @@ SKYDROPX_QUOTATIONS_BASE_URL=https://api-pro.skydropx.com
 #   2. ${SKYDROPX_BASE_URL}/v1/shipments (fallback si 404)
 SKYDROPX_BASE_URL=https://api-pro.skydropx.com
 
+# Shipments: URL base específica para obtener tracking/label (default: usa SKYDROPX_BASE_URL)
+# IMPORTANTE: Según documentación oficial de Skydropx (app.skydropx.com/es-MX/api-docs),
+# para obtener tracking_number y label_url desde shipments, usar app.skydropx.com.
+# OAuth token URL puede seguir siendo api-pro.skydropx.com, pero shipments debe ser app.skydropx.com
+# para que la respuesta incluya included[].attributes.tracking_number y included[].attributes.label_url.
+SKYDROPX_SHIPMENTS_BASE_URL=https://app.skydropx.com
+
 # Carta Porte (SAT) - REQUERIDO para crear shipments/labels en Skydropx PRO
 # consignment_note = código Carta Porte (SAT) del producto/servicio
 # package_type = código de tipo de empaque (SAT)


### PR DESCRIPTION
## Descripción

Permite configurar `SKYDROPX_SHIPMENTS_BASE_URL` para forzar que `getShipment()` use `app.skydropx.com` en lugar de `api-pro.skydropx.com`, y agrega logs seguros (sin PII) cuando `sync-label` no encuentra tracking/label (`strategyUsed === "none"`).

## Problema

En producción, `sync-label` devuelve `{trackingNumber:null, labelUrl:null}` con `strategyUsed:'none'` aunque Skydropx ya tiene tracking disponible. La documentación oficial indica que para obtener `included[].attributes.tracking_number` y `included[].attributes.label_url`, se debe usar `app.skydropx.com` en lugar de `api-pro.skydropx.com`.

## Cambios

### 1. Configuración de `SKYDROPX_SHIPMENTS_BASE_URL` (`src/lib/skydropx/client.ts`)
- ✅ `getSkydropxConfig()` ya prioriza `SKYDROPX_SHIPMENTS_BASE_URL` con fallback a otros env vars
- ✅ Agregado log de configuración que muestra qué env var se está usando (solo en non-production o si está explícitamente configurado)

### 2. Logs de diagnóstico en `getShipment()` (`src/lib/skydropx/client.ts`)
- ✅ Cuando la respuesta es OK pero no tiene estructura esperada para tracking/label, se loguea:
  - `baseUrl` usado
  - `status` code
  - `includedCount`
  - `sampleIncludedKeys` (solo keys, filtradas: excluye keys que contengan "address", "phone", "email", "name")
  - `dataAttributesKeys` (solo keys)
  - `includedTypesSample` (tipos de included items)
  - Flags: `hasData`, `hasDataAttributes`, `hasIncludedAttributes`, `hasDataAttributesTracking`

### 3. Logs mejorados en `sync-label` (`src/app/api/admin/shipping/skydropx/sync-label/route.ts`)
- ✅ Si `strategyUsed === 'none'` y hay datos en la respuesta, se incluyen logs de diagnóstico adicionales:
  - `sampleIncludedKeys` (filtrado para evitar PII)
  - `dataAttributesKeys`
  - `includedFirstItemType`
  - `includedFirstItemHasAttributes`
- ✅ Estos logs aparecen en producción cuando `strategyUsed === 'none'` para debugging

### 4. Documentación actualizada (`CONFIGURACION.md`)
- ✅ Agregada sección para `SKYDROPX_SHIPMENTS_BASE_URL`:
  - Valor recomendado: `https://app.skydropx.com`
  - Nota: OAuth token URL puede seguir siendo `api-pro.skydropx.com`, pero shipments debe ser `app.skydropx.com` para obtener `included[].attributes.tracking_number` y `included[].attributes.label_url`

## Seguridad

- ✅ **NO se loguean valores sensibles**: Solo keys, flags y counts
- ✅ **Filtrado de PII**: Se excluyen keys que contengan "address", "phone", "email", "name"
- ✅ **ShipmentId truncado**: Solo primeros 8 caracteres en logs

## Configuración requerida

Para habilitar en producción, agregar en `.env.local` o variables de entorno:

```env
SKYDROPX_SHIPMENTS_BASE_URL=https://app.skydropx.com
```

## Test manual

1. Configurar `SKYDROPX_SHIPMENTS_BASE_URL=https://app.skydropx.com`
2. Probar con `shipmentId: 01362d7d-eb4b-4298-9cbf-f8fcacab4314`
3. POST a `/api/admin/shipping/skydropx/sync-label`
4. Verificar logs en Vercel/consola:
   - `baseUrl` usado (debe ser `app.skydropx.com`)
   - Estructura de respuesta si `strategyUsed === 'none'`
   - Keys disponibles en `included[0]` y `data.attributes`

## Validaciones

- ✅ `pnpm lint` - Pasó
- ✅ `pnpm typecheck` - Pasó
- ✅ `pnpm build` - Pasó exitosamente
