### PR TITLE
fix(skydropx): cancel shipment in Skydropx when admin cancels label

### DIFF
--- a/src/app/api/admin/shipping/skydropx/cancel-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/cancel-label/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
 import { checkAdminAccess } from "@/lib/admin/access";
-import { skydropxFetch } from "@/lib/skydropx/client";
+import { skydropxFetch, getSkydropxConfig } from "@/lib/skydropx/client";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -109,10 +109,10 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    // Cargar la orden
+    // Cargar la orden (incluir shipping_shipment_id y metadata)
     const { data: order, error: orderError } = await supabase
       .from("orders")
-      .select("*")
+      .select("id, shipping_shipment_id, shipping_tracking_number, shipping_label_url, shipping_status, shipping_provider, metadata")
       .eq("id", orderId)
       .single();
 
@@ -130,10 +130,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Obtener shipment_id de metadata para verificar evidencia de guía creada
+    // Obtener shipment_id con prioridad: columna shipping_shipment_id, luego metadata (legacy)
+    const shipmentIdColumn = (order.shipping_shipment_id as string) || null;
     const currentMetadata = (order.metadata as Record<string, unknown>) || {};
     const shippingMeta = (currentMetadata.shipping as Record<string, unknown>) || {};
-    const shipmentId = (shippingMeta.shipment_id as string) || null;
+    const shipmentIdFromMeta = (shippingMeta.shipment_id as string) || null;
+    const shipmentId = shipmentIdColumn || shipmentIdFromMeta;
 
     // Construir diagnóstico sin PII
     const diagnostic = {
@@ -227,86 +229,171 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    let cancelRequestId: string | null = null;
-    let cancelStatus: string | null = null;
+    // Cancelar realmente en Skydropx usando el endpoint correcto
+    if (!shipmentId) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "missing_shipment_id",
+          message: "La orden no tiene shipment_id. No se puede cancelar el envío en Skydropx.",
+          diagnostic,
+        } satisfies CancelLabelResponse,
+        { status: 400 },
+      );
+    }
 
-    // Intentar crear cancel request en Skydropx si tenemos shipment_id
-    if (shipmentId) {
-      try {
-        // Skydropx API: POST /v1/cancel_label_requests (modelo cancel request)
-        const cancelPayload = {
-          shipment_id: shipmentId,
-          reason: "Cliente solicitó cancelación",
-        };
+    // Obtener configuración de Skydropx para usar la base URL correcta
+    const skydropxConfig = getSkydropxConfig();
+    if (!skydropxConfig) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "config_error",
+          message: "Skydropx no está configurado",
+        } satisfies CancelLabelResponse,
+        { status: 500 },
+      );
+    }
 
+    // Tipo para respuesta de cancelación de Skydropx
+    type CancelResponse = {
+      id?: string;
+      data?: { id?: string; attributes?: { id?: string; status?: string } };
+      attributes?: { id?: string; status?: string };
+    };
+
+    // Skydropx API: POST /api/v1/shipments/{shipment_id}/cancellations
+    const cancelPath = `/api/v1/shipments/${shipmentId}/cancellations`;
+    const cancelPayload = {
+      reason: "Cancelado desde admin DDN",
+      shipment_id: shipmentId,
+    };
+
+    // Log seguro (sin PII)
+    if (process.env.NODE_ENV !== "production") {
+      console.log("[cancel-label] Cancelando shipment en Skydropx:", {
+        shipmentId: shipmentId.substring(0, 8) + "...", // Solo primeros 8 chars
+        path: cancelPath,
+        baseUrl: skydropxConfig.restBaseUrl,
+      });
+    }
+
+    let cancelResponseData: CancelResponse | null = null;
+    let skydropxCancelSuccess = false;
+
+    try {
+      const response = await skydropxFetch(cancelPath, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(cancelPayload),
+      });
+
+      if (response.ok) {
+        skydropxCancelSuccess = true;
+        cancelResponseData = (await response.json()) as CancelResponse;
+
+        // Log seguro
         if (process.env.NODE_ENV !== "production") {
-          console.log("[cancel-label] Creando cancel request en Skydropx:", {
-            shipmentId,
-            url: "/v1/cancel_label_requests",
+          console.log("[cancel-label] Shipment cancelado exitosamente en Skydropx:", {
+            shipmentId: shipmentId.substring(0, 8) + "...",
+            status: response.status,
+            cancelId: cancelResponseData?.id || cancelResponseData?.data?.id || cancelResponseData?.data?.attributes?.id || null,
           });
         }
+      } else {
+        // Si Skydropx responde error, NO marcar como cancelado localmente
+        const errorText = await response.text();
+        let errorBody: unknown = null;
+        try {
+          errorBody = JSON.parse(errorText);
+        } catch {
+          errorBody = errorText.substring(0, 200);
+        }
 
-        const response = await skydropxFetch("/v1/cancel_label_requests", {
-          method: "POST",
-          body: JSON.stringify(cancelPayload),
+        // Log seguro del error
+        console.warn("[cancel-label] Error cancelando shipment en Skydropx:", {
+          shipmentId: shipmentId.substring(0, 8) + "...",
+          status: response.status,
+          statusText: response.statusText,
+          baseUrl: skydropxConfig.restBaseUrl,
+          path: cancelPath,
+          errorSnippet: typeof errorBody === "string" ? errorBody : JSON.stringify(errorBody).substring(0, 200),
         });
 
-        if (response.ok) {
-          const cancelResponse = (await response.json()) as {
-            id?: string;
-            data?: { id?: string };
-            attributes?: { status?: string; id?: string };
-          };
+        // Determinar código de error según status (todos los errores de Skydropx usan "skydropx_error")
+        const errorCode: Extract<CancelLabelResponse, { ok: false }>["code"] = "skydropx_error";
 
-          // Extraer cancel_request_id
-          cancelRequestId =
-            cancelResponse.id ||
-            cancelResponse.data?.id ||
-            cancelResponse.attributes?.id ||
-            null;
+        const errorMessage =
+          response.status === 404
+            ? "El shipment no existe en Skydropx o ya fue cancelado"
+            : response.status === 422
+              ? "El shipment no se puede cancelar (puede estar en tránsito o ya entregado)"
+              : `Error al cancelar en Skydropx: ${response.statusText || `HTTP ${response.status}`}`;
 
-          // Extraer status inicial (puede ser "reviewing", "pending", etc.)
-          cancelStatus = cancelResponse.attributes?.status || "reviewing";
-
-          if (process.env.NODE_ENV !== "production") {
-            console.log("[cancel-label] Cancel request creado en Skydropx:", {
-              cancelRequestId,
-              cancelStatus,
-            });
-          }
-        } else {
-          // Si falla, puede ser que ya existe o que el shipment no se puede cancelar
-          const errorText = await response.text();
-          if (process.env.NODE_ENV !== "production") {
-            console.warn("[cancel-label] Error creando cancel request en Skydropx:", {
-              shipmentId,
-              status: response.status,
-              error: errorText,
-            });
-          }
-          // Continuar con actualización local aunque falle en Skydropx
-        }
-      } catch (skydropxError) {
-        // Si falla la cancelación en Skydropx, continuar con la actualización local
-        if (process.env.NODE_ENV !== "production") {
-          console.warn("[cancel-label] Error al crear cancel request en Skydropx (continuando localmente):", {
-            shipmentId,
-            error: skydropxError instanceof Error ? skydropxError.message : String(skydropxError),
-          });
-        }
+        return NextResponse.json(
+          {
+            ok: false,
+            code: errorCode,
+            message: errorMessage,
+            diagnostic,
+          } satisfies CancelLabelResponse,
+          { status: response.status >= 400 && response.status < 500 ? response.status : 500 },
+        );
       }
-    } else {
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("[cancel-label] No se encontró shipment_id en metadata, solo actualizando localmente");
-      }
+    } catch (skydropxError) {
+      // Si falla la llamada a Skydropx, NO marcar como cancelado localmente
+      const errorMessage = skydropxError instanceof Error ? skydropxError.message : String(skydropxError);
+
+      console.error("[cancel-label] Error inesperado al cancelar shipment en Skydropx:", {
+        shipmentId: shipmentId.substring(0, 8) + "...",
+        baseUrl: skydropxConfig.restBaseUrl,
+        path: cancelPath,
+        error: errorMessage,
+      });
+
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "skydropx_error",
+          message: `Error al cancelar en Skydropx: ${errorMessage}`,
+          diagnostic,
+        } satisfies CancelLabelResponse,
+        { status: 500 },
+      );
     }
+
+    // Solo actualizar localmente si Skydropx respondió OK
+    if (!skydropxCancelSuccess) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "skydropx_error",
+          message: "No se pudo cancelar el shipment en Skydropx",
+          diagnostic,
+        } satisfies CancelLabelResponse,
+        { status: 500 },
+      );
+    }
+
+    // Extraer información de la respuesta de cancelación
+    const cancelId =
+      cancelResponseData?.id ||
+      cancelResponseData?.data?.id ||
+      cancelResponseData?.data?.attributes?.id ||
+      cancelResponseData?.attributes?.id ||
+      null;
+    const cancelStatus = cancelResponseData?.data?.attributes?.status || cancelResponseData?.attributes?.status || "cancelled";
 
     // Merge seguro de metadata (NO sobreescribir completo)
     const updatedShippingMeta = {
       ...shippingMeta, // Preservar datos existentes
-      ...(shipmentId && { shipment_id: shipmentId }), // Asegurar shipment_id
-      ...(cancelRequestId && { cancel_request_id: cancelRequestId }), // Agregar cancel_request_id si existe
-      ...(cancelStatus && { cancel_status: cancelStatus }), // Agregar cancel_status si existe
+      shipment_id: shipmentId, // Asegurar shipment_id
+      cancel_reason: "Cancelado desde admin DDN",
+      canceled_at: new Date().toISOString(),
+      ...(cancelId && { cancel_response_id: cancelId }), // Agregar cancel_response_id si existe
+      cancel_status: cancelStatus,
     };
 
     const updatedMetadata = {
@@ -314,17 +401,20 @@ export async function POST(req: NextRequest) {
       shipping: updatedShippingMeta,
     };
 
-    // Actualizar la orden localmente: estado = "cancelled" (marcar como cancelado)
+    // Actualizar la orden localmente: estado = "cancelled" (solo si Skydropx respondió OK)
     // Conservar tracking/label para referencia histórica, pero marcar como cancelado
-    const { error: updateError } = await supabase
-      .from("orders")
-      .update({
-        shipping_status: "cancelled", // Marcar como cancelado
-        metadata: updatedMetadata, // Merge seguro de metadata (incluye cancel_request_id, cancel_status)
-        updated_at: new Date().toISOString(),
-        // NO limpiar tracking/label: conservar para referencia histórica
-      })
-      .eq("id", orderId);
+    const updateData: Record<string, unknown> = {
+      shipping_status: "cancelled", // Marcar como cancelado
+      metadata: updatedMetadata, // Merge seguro de metadata (incluye cancel_response_id, cancel_status)
+      updated_at: new Date().toISOString(),
+    };
+
+    // Asegurar que shipping_shipment_id esté guardado en la columna si no estaba
+    if (shipmentId && !shipmentIdColumn) {
+      updateData.shipping_shipment_id = shipmentId;
+    }
+
+    const { error: updateError } = await supabase.from("orders").update(updateData).eq("id", orderId);
 
     if (updateError) {
       if (process.env.NODE_ENV !== "production") {
@@ -340,18 +430,74 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Insertar evento en shipping_events (idempotente)
+    if (shipmentId) {
+      const eventTimestamp = new Date().toISOString();
+      const providerEventId = `cancel-${shipmentId}-${Date.now()}`;
+
+      // Verificar si el evento ya existe (idempotencia)
+      const { data: existingEvent } = await supabase
+        .from("shipping_events")
+        .select("id")
+        .eq("provider", "skydropx")
+        .eq("provider_event_id", providerEventId)
+        .maybeSingle();
+
+      // Solo insertar si no existe
+      if (!existingEvent) {
+        const { error: eventInsertError } = await supabase.from("shipping_events").insert({
+          order_id: orderId,
+          provider: "skydropx",
+          provider_event_id: providerEventId,
+          raw_status: "cancelled",
+          mapped_status: "cancelled",
+          tracking_number: order.shipping_tracking_number,
+          label_url: order.shipping_label_url,
+          payload: {
+            source: "cancel-label-endpoint",
+            shipment_id: shipmentId,
+            cancel_id: cancelId,
+            cancel_status: cancelStatus,
+            canceled_at: eventTimestamp,
+          },
+          occurred_at: eventTimestamp,
+        });
+
+        if (eventInsertError) {
+          // Si es unique constraint, ignorar (idempotencia)
+          if (eventInsertError.code !== "23505" && !eventInsertError.message.includes("duplicate")) {
+            console.error("[cancel-label] Error al insertar evento de cancelación:", {
+              orderId,
+              providerEventId,
+              errorCode: eventInsertError.code,
+              errorMessage: eventInsertError.message,
+            });
+          }
+        } else {
+          if (process.env.NODE_ENV !== "production") {
+            console.log("[cancel-label] Evento de cancelación insertado:", {
+              orderId,
+              providerEventId,
+            });
+          }
+        }
+      }
+    }
+
+    // Log seguro de éxito
     if (process.env.NODE_ENV !== "production") {
       console.log("[cancel-label] Envío cancelado exitosamente:", {
         orderId,
-        shipmentId,
-        cancelRequestId,
+        shipmentId: shipmentId.substring(0, 8) + "...",
+        cancelId,
+        cancelStatus,
         diagnostic,
       });
     }
 
     return NextResponse.json({
       ok: true,
-      message: "Envío cancelado exitosamente",
+      message: "Envío cancelado exitosamente en Skydropx",
       diagnostic,
     } satisfies CancelLabelResponse);
   } catch (error) {

--- a/src/lib/skydropx/client.ts
+++ b/src/lib/skydropx/client.ts
@@ -24,7 +24,7 @@ let tokenCache: CachedToken | null = null;
  * Obtiene la configuración de Skydropx desde env vars
  * Usa OAuth exclusivamente
  */
-function getSkydropxConfig() {
+export function getSkydropxConfig() {
   const clientId = process.env.SKYDROPX_CLIENT_ID;
   const clientSecret = process.env.SKYDROPX_CLIENT_SECRET;
   


### PR DESCRIPTION
## Descripción

Arregla \
Cancelar
envío\ para que realmente cancele la guía en Skydropx vía API, no solo cambie el estado localmente en la DB.

## Problema

En admin, al presionar \Cancelar
envío\, el estado cambiaba a \Envío
cancelado\ en UI/DB, pero en Skydropx la guía seguía activa. El endpoint cancel-label estaba usando un endpoint incorrecto (/v1/cancel_label_requests) o no estaba llamando correctamente a la API de cancelación de Skydropx.

## Cambios

### 1. Endpoint correcto de Skydropx
- ✅ Cambiado de /v1/cancel_label_requests a /api/v1/shipments/{shipment_id}/cancellations`n- ✅ Usa SKYDROPX_SHIPMENTS_BASE_URL (recomendado: https://app.skydropx.com)
- ✅ Payload correcto: { \reason\: \Cancelado
desde
admin
DDN\, \shipment_id\: \<shipmentId>\ }`n
### 2. Obtención de shipmentId con prioridad
- ✅ Prioridad 1: orders.shipping_shipment_id (columna dedicada)
- ✅ Prioridad 2: orders.metadata.shipping.shipment_id (legacy fallback)

### 3. Manejo de respuesta mejorado
- ✅ **Solo marca como cancelado si Skydropx responde 2xx**: NO continúa con actualización local si falla
- ✅ Si Skydropx responde error (400/401/403/404/422): NO marca como cancelado localmente, devuelve error descriptivo
- ✅ Si Skydropx responde OK: actualiza estado, guarda metadata, inserta evento en shipping_events

### 4. Logs seguros (sin PII)
- ✅ shipmentId truncado, solo keys/flags, NO direcciones/teléfonos/emails/nombres

### 5. Exportación de getSkydropxConfig()`n- ✅ Exportada para poder usarla en otros endpoints

## Validaciones

- ✅ pnpm lint - Pasó
- ✅ pnpm typecheck - Pasó
- ✅ pnpm build - Pasó exitosamente
