### PR TITLE
fix(admin): charge shipping, correct label weight, persist address override

### DIFF
--- a/src/app/checkout/pago/PagoClient.tsx
+++ b/src/app/checkout/pago/PagoClient.tsx
@@ -509,6 +509,9 @@ export default function PagoClient() {
         phone: datos.phone || null, // Teléfono para metadata
         shippingMethod: displayShippingMethod,
         shippingCostCents,
+        discountCents: discount && discountScope ? Math.round(discount * 100) : 0,
+        discountScope: discountScope || undefined,
+        couponCode: couponCode || undefined,
         paymentMethod: "bank_transfer",
         paymentStatus: "pending",
         // Dirección de envío (solo si no es pickup)
@@ -796,6 +799,9 @@ export default function PagoClient() {
         whatsappConfirmed: datos.whatsappConfirmed || false, // Confirmación de WhatsApp
         shippingMethod: displayShippingMethod, // Método de envío (solo lectura)
         shippingCostCents, // Costo de envío en centavos
+        discountCents: discount && discountScope ? Math.round(discount * 100) : 0,
+        discountScope: discountScope || undefined,
+        couponCode: couponCode || undefined,
         paymentMethod: selectedPaymentMethodValue, // Método de pago seleccionado
         paymentStatus: selectedPaymentStatusValue, // Estado de pago (pending para métodos manuales)
         // Dirección de envío (solo si no es pickup)


### PR DESCRIPTION
## Root cause
- create-order calculaba total_cents solo con items, omitiendo envío/descuentos; transferencia y fallback de Stripe quedaban sin shipping.
- create-label no priorizaba shipping_address_override y solo aceptaba paquete final; si faltaba, terminaba usando defaults (1kg) en PDF.
- metadata de paquete estimado no incluía base de empaque ni dimensiones, y no estaba disponible como shipping.estimated_package.

## Fix
- total_cents = subtotal + shipping - descuentos/loyalty; se persisten discount_* y coupon_code; PagoClient envía discountScope/discountCents/couponCode.
- create-payment-intent usa orders.total_cents y suma shipping_price_cents al recomputar.
- create-label prioriza override de dirección y paquete final > estimado > default con logging del paquete.
- create-order/save-order guardan estimated_package con base 1200g + pesos de items y dims default.

## How to verify
### Checkout (prod/preview)
1) https://ddnshop.mx/tienda (o preview) → agrega producto
2) Envío != pickup → confirmar costo de envío
3) Pagar con Stripe o transferencia
4) Orden/DB: shipping_price_cents > 0 cuando aplica; total_cents incluye envío
5) Stripe PaymentIntent: amount_total incluye shipping
6) Transferencia: Total a pagar incluye shipping

### Admin (prod/preview)
1) Abrir orden pagada
2) Guardar override de dirección → recargar → campos precargados
3) Guardar Paquete real (ej. 2200g) → crear guía
4) Ver etiqueta PDF → peso refleja 2.2kg
5) Si no hay paquete real, guía usa estimated_package

### Notes
- Sticky header/flags sin cambios
- No se tocaron endpoints de Stripe/Supabase fuera de cálculo

**Files**
- src/app/api/checkout/create-order/route.ts
- src/app/api/checkout/save-order/route.ts
- src/app/api/stripe/create-payment-intent/route.ts
- src/app/api/admin/shipping/skydropx/create-label/route.ts
- src/app/checkout/pago/PagoClient.tsx