### PR TITLE
fix(shipping): use package_final for label weight (avoid 1kg fallback)

### DIFF
--- a/src/app/api/admin/shipping/skydropx/create-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/create-label/route.ts
@@ -567,36 +567,28 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    type PackageData = {
+      weight_g?: number;
+      length_cm?: number;
+      width_cm?: number;
+      height_cm?: number;
+      mode?: string;
+      updated_at?: string;
+    };
+
     // Obtener shipping_package_final (paquete real capturado por admin)
-    const shippingPackageFinal = packageMetadata.shipping_package_final as
-      | {
-          weight_g?: number;
-          length_cm?: number;
-          width_cm?: number;
-          height_cm?: number;
-          mode?: string;
-          updated_at?: string;
-        }
-      | undefined;
+    // Prioridad: root -> shipping.package_final -> shipping.shipping_package_final
+    const shippingPackageFinal =
+      (packageMetadata.shipping_package_final as PackageData | undefined) ||
+      (packageShippingMeta.package_final as PackageData | undefined) ||
+      (packageShippingMeta.shipping_package_final as PackageData | undefined);
 
     // Obtener paquete estimado (checkout) como fallback
+    // Prioridad: root -> shipping.estimated_package -> shipping.shipping_package_estimated
     const shippingPackageEstimated =
-      (packageMetadata.shipping_package_estimated as
-        | {
-            weight_g?: number;
-            length_cm?: number;
-            width_cm?: number;
-            height_cm?: number;
-          }
-        | undefined) ||
-      ((packageShippingMeta.estimated_package as
-        | {
-            weight_g?: number;
-            length_cm?: number;
-            width_cm?: number;
-            height_cm?: number;
-          }
-        | undefined) ?? undefined);
+      (packageMetadata.shipping_package_estimated as PackageData | undefined) ||
+      (packageShippingMeta.estimated_package as PackageData | undefined) ||
+      (packageShippingMeta.shipping_package_estimated as PackageData | undefined);
 
     const DEFAULT_PACKAGE = {
       weight_g: 1200,
@@ -656,6 +648,7 @@ export async function POST(req: NextRequest) {
         hasPackageType: !!packageType,
         package: {
           source: packageSource,
+          weightG,
           weightKg,
           lengthCm,
           widthCm,


### PR DESCRIPTION
## Root cause
- create-label no leía metadata.shipping_package_final ni variantes en metadata.shipping, y caía en estimado/default (1kg).

## Fix
- Selección de paquete con prioridad final → estimated → default, soportando keys duplicadas en root y en metadata.shipping.
- Conversión g → kg preservada (Skydropx espera kg).
- Logging no-prod con source y dimensiones.

## How to verify
1) En orden con metadata.shipping_package_final.weight_g=2220
2) Admin → guardar paquete real 2220g (40x30x20)
3) Crear guía → abrir PDF
4) Ver peso ≈ 2.22kg (o 2220g si la API mostrara g)

## Validaciones
- pnpm lint (warnings existentes)
- pnpm typecheck
- pnpm build

**Files**
- src/app/api/admin/shipping/skydropx/create-label/route.ts