### PR TITLE
fix(shipping): verify skydropx shipment weight and clarify label printed weight

### DIFF
--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -402,6 +402,23 @@ export default async function AdminPedidoDetailPage({
                     >
                       Ver etiqueta PDF
                     </Link>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Nota: la etiqueta puede mostrar 1.0 KG aunque el peso declarado sea mayor.
+                    </p>
+                    {(() => {
+                      const metadata = (order.metadata as Record<string, unknown>) || {};
+                      const shippingMeta = (metadata.shipping as Record<string, unknown>) || {};
+                      const shipmentDebug = shippingMeta.shipment_debug as
+                        | { weight?: number | string | null; weight_unit?: string | null }
+                        | undefined;
+                      if (!shipmentDebug?.weight) return null;
+                      return (
+                        <p className="mt-1 text-xs text-gray-600">
+                          Peso declarado (shipment): {shipmentDebug.weight}
+                          {shipmentDebug.weight_unit ? ` ${shipmentDebug.weight_unit}` : ""}
+                        </p>
+                      );
+                    })()}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Root cause
- El PDF puede seguir mostrando 1.0 KG aunque el shipment tenga otro peso; no había verificación/registro del peso real en Skydropx.

## Fix
- Después de crear shipment, se consulta Skydropx por id y se guarda metadata.shipping.shipment_debug (peso/unidad/dims).
- Se muestra nota y peso real en admin junto a la etiqueta PDF.

## How to verify
1) Orden con metadata.shipping_package_final.weight_g=2200
2) Crear guía y descargar etiqueta (PDF sigue en 1.0 KG)
3) Confirmar en admin que shipment_debug.weight ≈ 2.2 y shipment_id cambió
4) Ver nota junto a “Ver etiqueta PDF”

## Validaciones
- pnpm lint (warnings existentes)
- pnpm typecheck
- pnpm build

**Files**
- src/app/api/admin/shipping/skydropx/create-label/route.ts
- src/app/admin/pedidos/[id]/page.tsx