### PR TITLE
fix(shipping): make create-label auto-quote/select rate + persist shipment ids + standard box default

### DIFF
--- a/src/app/admin/pedidos/[id]/CreateSkydropxLabelClient.tsx
+++ b/src/app/admin/pedidos/[id]/CreateSkydropxLabelClient.tsx
@@ -7,7 +7,6 @@ type Props = {
   orderId: string;
   paymentStatus: string | null;
   shippingProvider: string | null;
-  shippingRateExtId: string | null;
   shippingStatus: string | null;
   currentTrackingNumber: string | null;
   currentLabelUrl: string | null;
@@ -19,7 +18,6 @@ export default function CreateSkydropxLabelClient({
   orderId,
   paymentStatus,
   shippingProvider,
-  shippingRateExtId,
   shippingStatus,
   currentTrackingNumber,
   currentLabelUrl,
@@ -52,8 +50,7 @@ export default function CreateSkydropxLabelClient({
   const canCreateLabel =
     !hasLabelEvidence &&
     paymentStatus === "paid" &&
-    (shippingProvider === "skydropx" || shippingProvider === "Skydropx") &&
-    shippingRateExtId;
+    (shippingProvider === "skydropx" || shippingProvider === "Skydropx");
 
   const handleCreateLabel = async () => {
     setIsLoading(true);
@@ -89,11 +86,13 @@ export default function CreateSkydropxLabelClient({
                 : data.code === "unsupported_provider"
                   ? "El proveedor de envío no es compatible."
                   : data.code === "missing_shipping_rate"
-                    ? "La orden no tiene un rate_id de Skydropx guardado."
+                    ? "No hay tarifa guardada. Intenta crear la guía de nuevo."
                   : data.code === "missing_address_data"
                     ? "No se encontraron datos de dirección en la orden."
                     : data.code === "missing_final_package"
                       ? "Captura peso y medidas reales de la caja antes de crear guía. Ve a la sección 'Paquete real para guía'."
+                    : data.code === "skydropx_no_rates"
+                      ? "Skydropx no devolvió tarifas para la cotización. Intenta de nuevo en unos segundos."
                       : data.code === "invalid_shipping_payload"
                         ? (() => {
                             const missing = Array.isArray(data.details?.missingFields) ? data.details.missingFields as string[] : [];

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -459,8 +459,23 @@ export default async function AdminPedidoDetailPage({
 
               {shouldShowPackageFinal ? (
                 <div className="mb-4 pb-4 border-b border-gray-200">
-                  <h3 className="text-md font-semibold mb-2">Paquete real para guía</h3>
-                  <ShippingPackageFinalClient orderId={order.id} currentPackageFinal={currentPackageFinal} />
+                  <div className="mb-3">
+                    <h3 className="text-md font-semibold">Caja estándar</h3>
+                    <p className="text-sm text-gray-600">
+                      25 × 20 × 15 cm (se usa por defecto si no hay override).
+                    </p>
+                  </div>
+                  <details className="bg-gray-50 rounded-lg border border-gray-200 px-4 py-3">
+                    <summary className="cursor-pointer text-sm font-semibold text-gray-900">
+                      Editar paquete real (override)
+                    </summary>
+                    <div className="mt-3">
+                      <ShippingPackageFinalClient
+                        orderId={order.id}
+                        currentPackageFinal={currentPackageFinal}
+                      />
+                    </div>
+                  </details>
                 </div>
               ) : null}
 
@@ -524,7 +539,6 @@ export default async function AdminPedidoDetailPage({
                       orderId={order.id}
                       paymentStatus={order.payment_status}
                       shippingProvider={order.shipping_provider}
-                      shippingRateExtId={order.shipping_rate_ext_id}
                       shippingStatus={order.shipping_status}
                       currentTrackingNumber={order.shipping_tracking_number}
                       currentLabelUrl={order.shipping_label_url}


### PR DESCRIPTION
## Root cause
- Create-label dependía de un rate guardado; al crear una nueva cotización los rate_id cambian y el match fallaba.
- Se podía crear shipment en Skydropx pero fallaba antes de persistir, dejando la orden sin shipment_id en DB.

## Fix
- Create-label auto‑cotiza y selecciona rate con prioridad id → provider/service → fallback más barato.
- Persistencia temprana de shipment_id, quotation_id, rate_id y rate_used antes de pasos extra.
- Default de caja estándar 25×20×15 cm, con override opcional.
- Webhook busca por shipping_shipment_id y metadata.shipping.shipment_id/tracking_number.

## How to verify
1) Crear orden sin rate guardado.
2) En admin, guardar package_final (opcional) y click “Crear guía en Skydropx”.
3) Ver que no falla el mapeo y se crea shipment/label.
4) Confirmar en metadata: shipping.rate_used, shipping.rate.external_id actualizado si hubo fallback.
5) Ver shipping_shipment_id guardado antes de tracking.
6) Revisar logs (quotation_id, rate_id, shipment_id, criterio).

## QA
- `pnpm lint` (warnings preexistentes)
- `pnpm typecheck`
- `pnpm build`
