### PR TITLE
fix(shipping): use 25x20x15 + base 1200g and add packaging fee to rates; keep create-label consistent

### DIFF
--- a/src/app/api/admin/shipping/skydropx/create-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/create-label/route.ts
@@ -315,6 +315,9 @@ export async function POST(req: NextRequest) {
         normalizePackageCandidate(metadata.shipping_package_final) ||
         normalizePackageCandidate(shippingMeta.package_final) ||
         normalizePackageCandidate(shippingMeta.shipping_package_final);
+      const packageUsed =
+        normalizePackageCandidate(shippingMeta.package_used) ||
+        normalizePackageCandidate((shippingMeta as { package_used?: unknown }).package_used);
 
       const estimatedPackage =
         normalizePackageCandidate(metadata.shipping_package_estimated) ||
@@ -330,6 +333,9 @@ export async function POST(req: NextRequest) {
 
       if (finalPackage) {
         return { source: "final" as const, ...finalPackage };
+      }
+      if (packageUsed) {
+        return { source: "package_used" as const, ...packageUsed };
       }
       if (estimatedPackage) {
         return { source: "estimated" as const, ...estimatedPackage };

--- a/src/app/checkout/datos/ClientPage.tsx
+++ b/src/app/checkout/datos/ClientPage.tsx
@@ -450,6 +450,11 @@ function DatosPageContent() {
         etaMaxDays: opt.etaMaxDays,
         externalRateId: opt.externalRateId,
         originalPriceCents: opt.originalPriceCents,
+        carrierCents: opt.carrierCents,
+        packagingCents: opt.packagingCents,
+        totalCents: opt.totalCents,
+        includesPackagingFee: opt.includesPackagingFee,
+        packageUsed: opt.packageUsed,
       }));
 
       if (!isOk || primary.length === 0) {

--- a/src/app/checkout/pago/PagoClient.tsx
+++ b/src/app/checkout/pago/PagoClient.tsx
@@ -537,6 +537,12 @@ export default function PagoClient() {
                       provider: "skydropx",
                       option_code: selectedShippingOption.code,
                       price_cents: selectedShippingOption.priceCents,
+                      pricing: {
+                        carrier_cents: selectedShippingOption.carrierCents ?? selectedShippingOption.priceCents,
+                        packaging_cents: selectedShippingOption.packagingCents ?? 2000,
+                        total_cents: selectedShippingOption.totalCents ?? selectedShippingOption.priceCents,
+                      },
+                      package_used: selectedShippingOption.packageUsed ?? undefined,
                       rate: {
                         external_id: selectedShippingOption.externalRateId,
                         provider: selectedShippingOption.provider,
@@ -827,6 +833,12 @@ export default function PagoClient() {
                       provider: "skydropx",
                       option_code: selectedShippingOption.code,
                       price_cents: selectedShippingOption.priceCents,
+                      pricing: {
+                        carrier_cents: selectedShippingOption.carrierCents ?? selectedShippingOption.priceCents,
+                        packaging_cents: selectedShippingOption.packagingCents ?? 2000,
+                        total_cents: selectedShippingOption.totalCents ?? selectedShippingOption.priceCents,
+                      },
+                      package_used: selectedShippingOption.packageUsed ?? undefined,
                       rate: {
                         external_id: selectedShippingOption.externalRateId,
                         provider: selectedShippingOption.provider,

--- a/src/lib/shipping/buildSkydropxRatesRequest.ts
+++ b/src/lib/shipping/buildSkydropxRatesRequest.ts
@@ -193,10 +193,10 @@ export function buildSkydropxRatesRequest(
     input.destination.city;
 
   // PAQUETE: Valores por defecto si no se proporcionan, con hardening (valores mínimos razonables)
-  const rawWeightGrams = input.package.weightGrams || 1000;
-  const rawLengthCm = input.package.lengthCm || 20;
+  const rawWeightGrams = input.package.weightGrams || 1200;
+  const rawLengthCm = input.package.lengthCm || 25;
   const rawWidthCm = input.package.widthCm || 20;
-  const rawHeightCm = input.package.heightCm || 10;
+  const rawHeightCm = input.package.heightCm || 15;
 
   // Hardening: valores mínimos razonables para evitar payloads inválidos
   // Skydropx requiere/cobra mínimo 1kg (1000g) para cotizaciones y envíos

--- a/src/lib/store/checkoutStore.ts
+++ b/src/lib/store/checkoutStore.ts
@@ -52,6 +52,17 @@ export type UiShippingOption = {
   etaMaxDays: number | null;
   externalRateId: string;
   originalPriceCents?: number; // Precio original antes de aplicar promo (para mostrar "antes $XXX")
+  carrierCents?: number;
+  packagingCents?: number;
+  totalCents?: number;
+  includesPackagingFee?: boolean;
+  packageUsed?: {
+    weight_g: number;
+    length_cm: number;
+    width_cm: number;
+    height_cm: number;
+    source: "default" | "calculated";
+  };
 };
 
 type CheckoutPersisted = {


### PR DESCRIPTION
## Root cause
- Cotización usaba caja 20×20×10 y peso sin empaque, y no aplicaba el costo fijo de empaque en los rates.

## Fix
- Checkout cotiza con caja 25×20×15 y peso base 1200g + peso de productos.
- Se suma packaging fee (+2000 cents) a todas las opciones; se expone breakdown (carrier/packaging/total) e incluye `includes_packaging_fee`.
- Persistencia: `shipping_pricing` y `package_used` se guardan en orden; create-label prioriza `package_used`.

## How to verify
1) Checkout con productos: rates usan 25×20×15 y peso >= 1200g + productos.
2) Cada opción incluye `packaging_cents=2000` y `total_cents`.
3) Al seleccionar envío, order guarda `shipping_pricing` y `package_used`.
4) create-label usa `package_used` si no hay `shipping_package_final`.
