### PR TITLE
fix(shipping): unify rate normalization; sort checkout by customer total and admin by carrier cost

### DIFF
--- a/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
+++ b/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
@@ -17,6 +17,8 @@ type Rate = {
   eta_min_days: number | null;
   eta_max_days: number | null;
   price_cents: number;
+  carrier_cents?: number;
+  customer_total_cents?: number | null;
 };
 
 /**
@@ -134,10 +136,11 @@ export default function RequoteSkydropxRatesClient({
           rateExternalId: rate.external_id,
           service: rate.service,
           provider: rate.provider,
-          priceCents: rate.price_cents,
+          priceCents: rate.carrier_cents ?? rate.price_cents,
           etaMin: rate.eta_min_days,
           etaMax: rate.eta_max_days,
           optionCode: rate.option_code,
+          customerTotalCents: rate.customer_total_cents ?? null,
         }),
       });
 
@@ -264,7 +267,8 @@ export default function RequoteSkydropxRatesClient({
         <div className="space-y-3">
           <h4 className="text-sm font-semibold text-gray-900">Tarifas disponibles:</h4>
           {rates.map((rate) => {
-            const priceDiff = getPriceDifference(rate.price_cents);
+            const carrierCents = rate.carrier_cents ?? rate.price_cents;
+            const priceDiff = getPriceDifference(carrierCents);
             return (
               <div
                 key={rate.external_id}
@@ -289,10 +293,15 @@ export default function RequoteSkydropxRatesClient({
                     </div>
                     <div className="mt-1 text-sm text-gray-600">
                       <span className="font-semibold text-gray-900">
-                        {formatMXNFromCents(rate.price_cents)}
+                        {formatMXNFromCents(carrierCents)}
                       </span>
                       {" • "}
                       <span>ETA: {formatETA(rate.eta_min_days, rate.eta_max_days)}</span>
+                      {rate.customer_total_cents ? (
+                        <span className="ml-2 text-xs text-gray-500">
+                          Cliente pagó: {formatMXNFromCents(rate.customer_total_cents)}
+                        </span>
+                      ) : null}
                     </div>
                   </div>
                 </div>

--- a/src/app/api/admin/shipping/skydropx/apply-rate/route.ts
+++ b/src/app/api/admin/shipping/skydropx/apply-rate/route.ts
@@ -47,6 +47,7 @@ export async function POST(req: NextRequest) {
       etaMin,
       etaMax,
       optionCode,
+      customerTotalCents,
     } = body;
 
     // Validaciones básicas
@@ -149,10 +150,17 @@ export async function POST(req: NextRequest) {
     };
 
     // Merge seguro de metadata
-    const updatedMetadata = {
+    const updatedMetadata: Record<string, unknown> = {
       ...currentMetadata,
       shipping: updatedShippingMeta,
     };
+    if (typeof customerTotalCents === "number") {
+      updatedMetadata.shipping_pricing = {
+        carrier_cents: priceCents,
+        packaging_cents: Math.max(0, customerTotalCents - priceCents),
+        total_cents: customerTotalCents,
+      };
+    }
 
     // Actualizar order
     const { error: updateError } = await supabase

--- a/src/lib/shipping/normalizeSkydropxRates.ts
+++ b/src/lib/shipping/normalizeSkydropxRates.ts
@@ -1,0 +1,82 @@
+import type { SkydropxRate } from "@/lib/shipping/skydropx.server";
+
+type NormalizedRate = {
+  external_id: string;
+  provider: string;
+  service: string;
+  option_code?: string;
+  carrier_cents: number;
+  packaging_cents?: number;
+  total_cents?: number;
+  customer_total_cents?: number;
+  eta_min_days: number | null;
+  eta_max_days: number | null;
+};
+
+type NormalizeMode = "checkout" | "admin";
+
+type NormalizeOptions = {
+  packagingCents?: number;
+  mode: NormalizeMode;
+};
+
+const normalizeEta = (rate: SkydropxRate) => {
+  const etaMin = typeof rate.etaMinDays === "number" ? rate.etaMinDays : null;
+  const etaMax = typeof rate.etaMaxDays === "number" ? rate.etaMaxDays : null;
+  return {
+    eta_min_days: etaMin,
+    eta_max_days: etaMax,
+  };
+};
+
+export function normalizeSkydropxRates(
+  rawRates: SkydropxRate[],
+  options: NormalizeOptions,
+): NormalizedRate[] {
+  const packagingCents = options.packagingCents ?? 0;
+  const normalized = rawRates.map((rate) => {
+    const carrierCents = rate.totalPriceCents;
+    const { eta_min_days, eta_max_days } = normalizeEta(rate);
+    const base: NormalizedRate = {
+      external_id: rate.externalRateId,
+      provider: rate.provider,
+      service: rate.service,
+      option_code: undefined,
+      carrier_cents: carrierCents,
+      eta_min_days,
+      eta_max_days,
+    };
+
+    if (options.mode === "checkout") {
+      const total = carrierCents + packagingCents;
+      return {
+        ...base,
+        packaging_cents: packagingCents,
+        total_cents: total,
+      };
+    }
+
+    return {
+      ...base,
+      packaging_cents: packagingCents || undefined,
+      customer_total_cents: packagingCents ? carrierCents + packagingCents : undefined,
+    };
+  });
+
+  const etaForSort = (rate: NormalizedRate) =>
+    rate.eta_min_days ?? rate.eta_max_days ?? Number.MAX_SAFE_INTEGER;
+
+  if (options.mode === "checkout") {
+    return normalized.sort((a, b) => {
+      const totalA = a.total_cents ?? a.carrier_cents;
+      const totalB = b.total_cents ?? b.carrier_cents;
+      if (totalA !== totalB) return totalA - totalB;
+      return etaForSort(a) - etaForSort(b);
+    });
+  }
+
+  return normalized.sort((a, b) => {
+    if (a.carrier_cents !== b.carrier_cents) return a.carrier_cents - b.carrier_cents;
+    return etaForSort(a) - etaForSort(b);
+  });
+}


### PR DESCRIPTION
## Root cause
- Checkout y Admin normalizaban/ordenaban rates con reglas distintas, mezclando costo real del carrier con cargo de empaque.

## Fix
- Helper compartido `normalizeSkydropxRates` con sorting por modo: checkout (total_cents) y admin (carrier_cents).
- ETA consistente; rates admin muestran carrier y customer_total_cents para referencia.
- apply-rate guarda pricing para auditoría sin afectar selección por carrier.

## How to verify
1) Checkout: ordenado por total (incluye empaque) + ETA.
2) Admin recotizar: ordenado por carrier y muestra “Cliente pagó” si aplica.
3) apply-rate usa carrier_cents para selección.
