### PR TITLE
fix(shipping): close skydropx pricing consistency + idempotent label creation

### DIFF
--- a/src/app/admin/pedidos/[id]/CreateSkydropxLabelClient.tsx
+++ b/src/app/admin/pedidos/[id]/CreateSkydropxLabelClient.tsx
@@ -90,6 +90,8 @@ export default function CreateSkydropxLabelClient({
                   : data.code === "missing_address_data" ||
                       data.code === "missing_shipping_address"
                     ? "Falta dirección en la orden."
+            : data.code === "label_creation_in_progress"
+              ? "La creación de la guía está en progreso. Intenta de nuevo en unos momentos."
                     : data.code === "missing_final_package"
                       ? "Captura peso y medidas reales de la caja antes de crear guía. Ve a la sección 'Paquete real para guía'."
                     : data.code === "skydropx_no_rates" || data.statusCode === 502
@@ -323,7 +325,7 @@ export default function CreateSkydropxLabelClient({
                     className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
                   >
                     <Download className="w-4 h-4" />
-                    Descargar etiqueta (PDF)
+                    Reimprimir etiqueta
                   </a>
                   {needsSync && (
                     <button


### PR DESCRIPTION
## Root cause
- Admin podía sobrescribir el total del cliente con el carrier y crear guías duplicadas por doble click/retry.

## Fix
- `shipping_pricing` canónico: preserva total del cliente y recalcula margen si cambia el carrier.
- `shipping_price_cents` y `metadata.shipping.price_cents` reflejan total del cliente.
- Idempotencia: `label_creation` en metadata, `already_created` si hay guía, y `in_progress` si hay intento activo.
- UI: botón de reimpresión cuando existe `label_url`.

## How to verify
1) Checkout: total = carrier + 2000 + margin.
2) Admin apply-rate: total del cliente no cambia; carrier sí.
3) Admin create-label doble click: segunda respuesta `label_creation_in_progress` o `already_created`.
4) Si hay `label_url`, botón “Reimprimir etiqueta” abre el PDF.
5) pnpm lint, pnpm typecheck, pnpm build.
