### PR TITLE
fix(shipping): require selected rate before create-label; persist customer ETA; harden label in-progress handling

### DIFF
--- a/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
+++ b/src/app/admin/pedidos/[id]/RequoteSkydropxRatesClient.tsx
@@ -174,11 +174,6 @@ export default function RequoteSkydropxRatesClient({
     }
   };
 
-  const getPriceDifference = (newPriceCents: number): number => {
-    if (!currentRatePriceCents) return newPriceCents;
-    return newPriceCents - currentRatePriceCents;
-  };
-
   const formatETA = (min: number | null, max: number | null): string => {
     if (min === null && max === null) return "No disponible";
     if (min === null) return `${max} días`;
@@ -272,7 +267,6 @@ export default function RequoteSkydropxRatesClient({
           <h4 className="text-sm font-semibold text-gray-900">Tarifas disponibles:</h4>
           {rates.map((rate) => {
             const carrierCents = rate.carrier_cents ?? rate.price_cents;
-            const priceDiff = getPriceDifference(carrierCents);
             return (
               <div
                 key={rate.external_id}
@@ -284,16 +278,6 @@ export default function RequoteSkydropxRatesClient({
                       <span className="text-sm font-medium text-gray-900">
                         {rate.provider} - {rate.service}
                       </span>
-                      {priceDiff > 0 && (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">
-                          +{formatMXNFromCents(priceDiff)}
-                        </span>
-                      )}
-                      {priceDiff < 0 && (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
-                          {formatMXNFromCents(priceDiff)}
-                        </span>
-                      )}
                     </div>
                     <div className="mt-1 text-sm text-gray-600">
                       <span className="font-semibold text-gray-900">

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -148,6 +148,14 @@ export default async function AdminPedidoDetailPage({
   const isSkydropx = order.shipping_provider === "skydropx" || order.shipping_provider === "Skydropx";
   const isNotPickup = (order.metadata as Record<string, unknown> | null)?.shipping_method !== "pickup";
   const shouldShowPackageFinal: boolean = isSkydropx && isNotPickup;
+  const shippingMeta = ((order.metadata as Record<string, unknown>)?.shipping as Record<string, unknown>) || {};
+  const rateUsed = (shippingMeta.rate_used as Record<string, unknown>) || {};
+  const hasSelectedRate =
+    typeof rateUsed.external_rate_id === "string"
+      ? rateUsed.external_rate_id.trim().length > 0
+      : typeof rateUsed.rate_id === "string"
+        ? rateUsed.rate_id.trim().length > 0
+        : false;
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -541,6 +549,7 @@ export default async function AdminPedidoDetailPage({
                       currentTrackingNumber={order.shipping_tracking_number}
                       currentLabelUrl={order.shipping_label_url}
                       hasShipmentId={hasShipmentId}
+                      hasSelectedRate={hasSelectedRate}
                     />
 
                     {/* Botón para cancelar envío si es Skydropx y tiene label creada */}


### PR DESCRIPTION
## Root cause
- Admin permitía crear guía sin tarifa aplicada y el lock podía quedar activo sin TTL, generando errores intermitentes.
- ETAs y pricing del cliente se guardaban sin trazabilidad clara entre checkout y admin.

## Fix
- Requiere `metadata.shipping.rate_used.external_rate_id` para crear guía; si falta responde `missing_selected_rate`.
- Persiste `rate_used` con ETA/costo del carrier y `selection_source` (checkout/admin).
- Normaliza `shipping_pricing` con total consistente y conserva `customer_eta_*`.
- Lock de creación con TTL (5 min), estado `created/failed`, y UI con cooldown en 409.
- UI recotizar sin badge $0.00 y botón crear guía bloqueado si no hay rate.

## How to verify
1) Admin sin aplicar rate: botón deshabilitado y API 400 `missing_selected_rate`.
2) Checkout: `shipping_pricing.customer_eta_*` presente; total = carrier + packaging + margin.
3) Admin apply-rate: actualiza `rate_used` y mantiene total del cliente.
4) Doble click en crear guía: responde `label_creation_in_progress` y luego `already_created`.
5) pnpm lint, pnpm typecheck, pnpm build.
