### PR TITLE
fix(shipping): unify shipping_pricing as canonical, mirror legacy pricing, and persist complete rate_used without nulls

### DIFF
--- a/src/app/api/checkout/create-order/route.ts
+++ b/src/app/api/checkout/create-order/route.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { toMxE164, toMxWhatsAppDigits, isValidMx10 } from "@/lib/phone/mx";
 import { estimatePackageWeight } from "@/lib/shipping/estimatePackageWeight";
 import { normalizeShippingPricing } from "@/lib/shipping/normalizeShippingPricing";
+import { normalizeShippingMetadata } from "@/lib/shipping/normalizeShippingMetadata";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -314,14 +315,6 @@ export async function POST(req: NextRequest) {
         const normalizedPricing = normalizeShippingPricing(pricingInput);
         if (normalizedPricing) {
           metadata.shipping_pricing = normalizedPricing;
-          if (metadata.shipping && typeof metadata.shipping === "object") {
-            const shippingMeta = metadata.shipping as Record<string, unknown>;
-            metadata.shipping = {
-              ...shippingMeta,
-              pricing: normalizedPricing,
-              price_cents: normalizedPricing.total_cents,
-            };
-          }
         }
       }
       if (orderData.shipping.rate) {
@@ -341,11 +334,19 @@ export async function POST(req: NextRequest) {
             eta_min_days: orderData.shipping.rate.eta_min_days ?? null,
             eta_max_days: orderData.shipping.rate.eta_max_days ?? null,
             carrier_cents: carrierCents,
+            price_cents: carrierCents,
             selected_at: new Date().toISOString(),
             selection_source: "checkout",
           },
         };
       }
+      const normalizedMeta = normalizeShippingMetadata(metadata, {
+        source: "checkout",
+      });
+      if (normalizedMeta.shippingPricing) {
+        metadata.shipping_pricing = normalizedMeta.shippingPricing;
+      }
+      metadata.shipping = normalizedMeta.shippingMeta;
       if (orderData.shipping.package_used) {
         const shippingMetaWithPackage = (metadata.shipping as Record<string, unknown>) || {};
         metadata.shipping = {

--- a/src/lib/shipping/normalizeShippingMetadata.ts
+++ b/src/lib/shipping/normalizeShippingMetadata.ts
@@ -1,0 +1,92 @@
+import {
+  normalizeShippingPricing,
+  type NormalizedShippingPricing,
+} from "@/lib/shipping/normalizeShippingPricing";
+
+type NormalizeContext = {
+  source: "checkout" | "admin" | "create-label" | "apply-rate";
+  orderId?: string;
+};
+
+type ShippingRateUsed = {
+  external_rate_id?: string | null;
+  rate_id?: string | null;
+  provider?: string | null;
+  service?: string | null;
+  eta_min_days?: number | null;
+  eta_max_days?: number | null;
+  carrier_cents?: number | null;
+  price_cents?: number | null;
+  selection_source?: "checkout" | "admin";
+  eta_policy?: string | null;
+  eta_changed?: boolean | null;
+};
+
+type NormalizeResult = {
+  shippingPricing: NormalizedShippingPricing | null;
+  shippingMeta: Record<string, unknown>;
+  mismatchDetected: boolean;
+};
+
+export function normalizeShippingMetadata(
+  metadata: Record<string, unknown>,
+  context: NormalizeContext,
+): NormalizeResult {
+  const shippingMeta = (metadata.shipping as Record<string, unknown>) || {};
+  const rootPricing = (metadata.shipping_pricing as Record<string, unknown>) || null;
+  const nestedPricing = (shippingMeta.pricing as Record<string, unknown>) || null;
+
+  const basePricing = rootPricing ?? nestedPricing;
+  const normalizedPricing = normalizeShippingPricing(basePricing || undefined);
+
+  const mismatchDetected =
+    Boolean(rootPricing && nestedPricing) &&
+    JSON.stringify(rootPricing) !== JSON.stringify(nestedPricing);
+
+  const nextShippingMeta: Record<string, unknown> = {
+    ...shippingMeta,
+  };
+
+  if (normalizedPricing) {
+    nextShippingMeta.pricing = normalizedPricing;
+    nextShippingMeta.price_cents = normalizedPricing.total_cents;
+  }
+
+  const rateUsed = (shippingMeta.rate_used as ShippingRateUsed) || null;
+  if (rateUsed) {
+    const carrier =
+      typeof rateUsed.carrier_cents === "number"
+        ? rateUsed.carrier_cents
+        : typeof rateUsed.price_cents === "number"
+          ? rateUsed.price_cents
+          : null;
+    const price = typeof rateUsed.price_cents === "number" ? rateUsed.price_cents : carrier;
+    nextShippingMeta.rate_used = {
+      ...rateUsed,
+      carrier_cents: carrier,
+      price_cents: price,
+      external_rate_id:
+        rateUsed.external_rate_id || rateUsed.rate_id || (shippingMeta.rate_id as string) || null,
+    };
+  }
+
+  if (context.source !== "checkout" && process.env.NODE_ENV !== "production") {
+    console.log("[shipping-metadata] normalize:", {
+      orderId: context.orderId || null,
+      source: context.source,
+      has_root_shipping_pricing: Boolean(rootPricing),
+      has_nested_shipping_pricing: Boolean(nestedPricing),
+      mismatch_detected: mismatchDetected,
+      total_cents: normalizedPricing?.total_cents ?? null,
+      carrier_cents: normalizedPricing?.carrier_cents ?? null,
+      packaging_cents: normalizedPricing?.packaging_cents ?? null,
+      margin_cents: normalizedPricing?.margin_cents ?? null,
+    });
+  }
+
+  return {
+    shippingPricing: normalizedPricing,
+    shippingMeta: nextShippingMeta,
+    mismatchDetected,
+  };
+}


### PR DESCRIPTION
## Root cause
- Existían dos breakdowns divergentes (`shipping_pricing` raíz vs `shipping.pricing`), y `rate_used` quedaba incompleto o con option_code desfasado.

## Fix
- Helper canónico `normalizeShippingMetadata` que sincroniza pricing raíz/anidado y completa `rate_used`.
- Checkout/admin guardan `shipping_pricing` como fuente de verdad y reflejan `shipping.pricing` idéntico.
- `rate_used` ahora incluye carrier_cents/price_cents y mantiene option_code coherente.

## How to verify
1) Checkout: `shipping_pricing.total = carrier + packaging + margin` y `shipping.pricing` espejo exacto.
2) Admin apply-rate: `rate_used` completo y `option_code` actualizado al rate aplicado.
3) Create-label: no altera total cliente y mantiene rate_used coherente.
4) pnpm lint, pnpm typecheck, pnpm build.
