### PR TITLE
fix(shipping): prevent rate_used nulls by persisting only normalized metadata

### DIFF
--- a/src/app/api/admin/shipping/skydropx/requote/route.ts
+++ b/src/app/api/admin/shipping/skydropx/requote/route.ts
@@ -6,7 +6,7 @@ import { getSkydropxRates } from "@/lib/shipping/skydropx.server";
 import { normalizeSkydropxRates } from "@/lib/shipping/normalizeSkydropxRates";
 import type { SkydropxRate } from "@/lib/shipping/skydropx.server";
 import { getOrderShippingAddress } from "@/lib/shipping/getOrderShippingAddress";
-import { normalizeShippingMetadata } from "@/lib/shipping/normalizeShippingMetadata";
+import { normalizeShippingMetadata, addShippingMetadataDebug } from "@/lib/shipping/normalizeShippingMetadata";
 import { createClient } from "@supabase/supabase-js";
 
 export const dynamic = "force-dynamic";
@@ -488,9 +488,11 @@ export async function POST(req: NextRequest) {
           source: "admin",
           orderId,
         });
+        
+        // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
         const finalMetadata: Record<string, unknown> = {
           ...updatedMetadata,
-          shipping: normalizedMeta.shippingMeta,
+          shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "requote"),
           ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
         };
         await supabase

--- a/src/app/api/admin/shipping/skydropx/sync-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/sync-label/route.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { createClient } from "@supabase/supabase-js";
 import { checkAdminAccess } from "@/lib/admin/access";
 import { getShipment, type SkydropxShipmentResponse } from "@/lib/skydropx/client";
-import { normalizeShippingMetadata } from "@/lib/shipping/normalizeShippingMetadata";
+import { normalizeShippingMetadata, addShippingMetadataDebug } from "@/lib/shipping/normalizeShippingMetadata";
 import { isValidShippingStatus } from "@/lib/orders/statuses";
 
 export const dynamic = "force-dynamic";
@@ -478,9 +478,11 @@ export async function POST(req: NextRequest) {
       source: "admin",
       orderId,
     });
+    
+    // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
     updateData.metadata = {
       ...updatedMetadata,
-      shipping: normalizedMeta.shippingMeta,
+      shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "sync-label"),
       ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
     };
 

--- a/src/app/api/shipping/skydropx/webhook/route.ts
+++ b/src/app/api/shipping/skydropx/webhook/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { normalizeShippingStatus, isValidShippingStatus } from "@/lib/orders/statuses";
-import { normalizeShippingMetadata } from "@/lib/shipping/normalizeShippingMetadata";
+import { normalizeShippingMetadata, addShippingMetadataDebug } from "@/lib/shipping/normalizeShippingMetadata";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -564,9 +564,11 @@ export async function POST(req: NextRequest) {
             source: "admin",
             orderId: order.id,
           });
+          
+          // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
           updateData.metadata = {
             ...updatedMetadata,
-            shipping: normalizedMeta.shippingMeta,
+            shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "webhook-skydropx"),
             ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
           };
         }

--- a/src/lib/shipping/normalizeShippingMetadata.ts
+++ b/src/lib/shipping/normalizeShippingMetadata.ts
@@ -215,3 +215,25 @@ export function normalizeShippingMetadata(
     correctionReason,
   };
 }
+
+/**
+ * Agrega debug metadata para rastrear quién escribió metadata.shipping (solo server-side admin)
+ */
+export function addShippingMetadataDebug(
+  shippingMeta: Record<string, unknown>,
+  route: string,
+): Record<string, unknown> {
+  // Solo agregar debug en server-side (no en cliente)
+  if (typeof process !== "undefined" && process.env) {
+    return {
+      ...shippingMeta,
+      _last_write: {
+        route,
+        at: new Date().toISOString(),
+        // SHA del commit actual si está disponible (opcional, no crítico)
+        sha: process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 7) || "unknown",
+      },
+    };
+  }
+  return shippingMeta;
+}


### PR DESCRIPTION
Root cause: algunos endpoints persistían updatedMetadata crudo después de normalizar, reintroduciendo rate_used.price_cents/carrier_cents en null.

Fix: todos los writers ahora persisten únicamente el output de normalizeShippingMetadata; debug _last_write agregado.

How to verify: recotizar/apply-rate/create-label/sync-label y confirmar que rate_used.* no queda null si hay shipping_pricing.