### PR TITLE
fix(shipping): prevent rate_used nulls by persisting only normalized metadata

### DIFF
--- a/src/test/lib/normalizeShippingMetadata.test.ts
+++ b/src/test/lib/normalizeShippingMetadata.test.ts
@@ -2,7 +2,40 @@ import { describe, expect, it } from "vitest";
 
 import { normalizeShippingMetadata } from "@/lib/shipping/normalizeShippingMetadata";
 
+/** Fixture que reproduce el bug de producción: pricing con números, rate_used nulls, _last_write apply-rate */
+const PRODUCTION_FIXTURE = {
+  shipping_pricing: {
+    carrier_cents: 14964,
+    packaging_cents: 2000,
+    margin_cents: 3671,
+    total_cents: 21635,
+  },
+  shipping: {
+    rate_used: {
+      external_rate_id: "rate_xyz",
+      provider: "skydropx",
+      service: "express",
+      carrier_cents: null,
+      price_cents: null,
+      customer_total_cents: null,
+    },
+    _last_write: { route: "apply-rate", at: "2025-01-22T00:00:00.000Z", sha: "abc1234" },
+  },
+} as const;
+
 describe("normalizeShippingMetadata", () => {
+  it("reproducción prod: pricing con números + rate_used nulls → normalizar rellena rate_used", () => {
+    const metadata = { ...PRODUCTION_FIXTURE };
+    const result = normalizeShippingMetadata(metadata, { source: "admin", orderId: "test" });
+    const rateUsed = result.shippingMeta.rate_used as Record<string, unknown>;
+    expect(rateUsed.price_cents).toBe(21635);
+    expect(rateUsed.carrier_cents).toBe(14964);
+    expect(rateUsed.customer_total_cents).toBe(21635);
+    expect(rateUsed.price_cents).not.toBeNull();
+    expect(rateUsed.carrier_cents).not.toBeNull();
+    expect(rateUsed.customer_total_cents).not.toBeNull();
+  });
+
   it("backfill desde shipping_pricing aunque rate_used venga con nulls", () => {
     const metadata = {
       shipping_pricing: {
@@ -120,6 +153,56 @@ describe("normalizeShippingMetadata", () => {
     expect(rateUsed.carrier_cents).not.toBeNull();
     expect(rateUsed.price_cents).not.toBeNull();
     expect(rateUsed.customer_total_cents).not.toBeNull();
+  });
+
+  it("Test B: con shipping_pricing y rate_used nulls → rate_used.price_cents === total_cents, rate_used.carrier_cents === carrier_cents", () => {
+    const metadata = {
+      shipping_pricing: { carrier_cents: 14964, packaging_cents: 2000, margin_cents: 3306, total_cents: 20270 },
+      shipping: {
+        rate_used: {
+          external_rate_id: "r",
+          provider: "skydropx",
+          service: "s",
+          carrier_cents: null,
+          price_cents: null,
+          customer_total_cents: null,
+        },
+      },
+    };
+    const result = normalizeShippingMetadata(metadata, { source: "admin" });
+    const rateUsed = result.shippingMeta.rate_used as Record<string, unknown>;
+    expect(rateUsed.price_cents).toBe(metadata.shipping_pricing.total_cents);
+    expect(rateUsed.carrier_cents).toBe(metadata.shipping_pricing.carrier_cents);
+    expect(rateUsed.customer_total_cents).toBe(metadata.shipping_pricing.total_cents);
+  });
+
+  it("merge bug: pricing ok pero rate_used null → overwrite forzado rellena sin nulls", () => {
+    const metadata = {
+      shipping_pricing: { carrier_cents: 14964, total_cents: 20270 },
+      shipping: {
+        rate_used: { provider: "skydropx", service: "s", carrier_cents: null, price_cents: null, customer_total_cents: null },
+        _last_write: { route: "apply-rate" },
+      },
+    };
+    const result = normalizeShippingMetadata(metadata, { source: "admin" });
+    const rateUsed = result.shippingMeta.rate_used as Record<string, unknown>;
+    expect(rateUsed.carrier_cents).toBe(14964);
+    expect(rateUsed.price_cents).toBe(20270);
+    expect(rateUsed.carrier_cents).not.toBeNull();
+    expect(rateUsed.price_cents).not.toBeNull();
+  });
+
+  it("string numbers (JSON/DB): shipping_pricing total_cents/carrier_cents como string → rellena rate_used", () => {
+    const metadata = {
+      shipping_pricing: { carrier_cents: "14964" as unknown, total_cents: "21635" as unknown },
+      shipping: { rate_used: { provider: "skydropx", service: "s", carrier_cents: null, price_cents: null } },
+    };
+    const result = normalizeShippingMetadata(metadata, { source: "admin" });
+    const rateUsed = result.shippingMeta.rate_used as Record<string, unknown>;
+    expect(rateUsed.carrier_cents).toBe(14964);
+    expect(rateUsed.price_cents).toBe(21635);
+    expect(rateUsed.carrier_cents).not.toBeNull();
+    expect(rateUsed.price_cents).not.toBeNull();
   });
 
   it("fallback: si falta shipping_pricing pero existe shipping.pricing, también rellena rate_used", () => {


### PR DESCRIPTION
Root cause: con pricing presente, rate_used quedaba en null porque (1) overwrite usaba normalizedPricing "corregido" en vez de canonical raw, (2) resolveCanonicalPricing fallaba con typeof number (JSON/DB devuelve strings). apply-rate ya persistía solo normalizado.

Fix: overwrite incondicional desde canonical pricing (raw) con toNum(); coerce strings. apply-rate sin cambios (shipping al final, solo normalizado).

How to verify en prod: Admin Recotizar + Apply-rate, revisar metadata: rate_used.price_cents === shipping_pricing.total_cents, rate_used.carrier_cents === shipping_pricing.carrier_cents, _last_write.route === "apply-rate".
