### PR TITLE
fix(shipping): ensure rate_used always filled from canonical pricing in apply-rate

### DIFF
--- a/src/app/api/admin/shipping/skydropx/cancel-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/cancel-label/route.ts
@@ -407,10 +407,13 @@ export async function POST(req: NextRequest) {
     });
     
     // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
-    const finalMetadata: Record<string, unknown> = {
+    const metadataWithPricing: Record<string, unknown> = {
       ...updatedMetadata,
-      shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "cancel-label"),
       ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
+    };
+    const finalMetadata: Record<string, unknown> = {
+      ...metadataWithPricing,
+      shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "cancel-label", metadataWithPricing),
     };
 
     // Actualizar la orden localmente: estado = "cancelled" (solo si Skydropx respondió OK)

--- a/src/app/api/admin/shipping/skydropx/create-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/create-label/route.ts
@@ -1998,10 +1998,13 @@ export async function POST(req: NextRequest) {
     });
     
     // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
-    const normalizedFinalMetadata: Record<string, unknown> = {
+    const metadataWithPricing: Record<string, unknown> = {
       ...updatedMetadata,
-      shipping: addShippingMetadataDebug(finalNormalizedMeta.shippingMeta, "create-label"),
       ...(finalNormalizedMeta.shippingPricing ? { shipping_pricing: finalNormalizedMeta.shippingPricing } : {}),
+    };
+    const normalizedFinalMetadata: Record<string, unknown> = {
+      ...metadataWithPricing,
+      shipping: addShippingMetadataDebug(finalNormalizedMeta.shippingMeta, "create-label", metadataWithPricing),
     };
     
     // Actualizar la orden con tracking y label (si están disponibles)

--- a/src/app/api/admin/shipping/skydropx/requote/route.ts
+++ b/src/app/api/admin/shipping/skydropx/requote/route.ts
@@ -490,10 +490,13 @@ export async function POST(req: NextRequest) {
         });
         
         // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
-        const finalMetadata: Record<string, unknown> = {
+        const metadataWithPricing: Record<string, unknown> = {
           ...updatedMetadata,
-          shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "requote"),
           ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
+        };
+        const finalMetadata: Record<string, unknown> = {
+          ...metadataWithPricing,
+          shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "requote", metadataWithPricing),
         };
         await supabase
           .from("orders")

--- a/src/app/api/admin/shipping/skydropx/sync-label/route.ts
+++ b/src/app/api/admin/shipping/skydropx/sync-label/route.ts
@@ -480,10 +480,13 @@ export async function POST(req: NextRequest) {
     });
     
     // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
-    updateData.metadata = {
+    const metadataWithPricing: Record<string, unknown> = {
       ...updatedMetadata,
-      shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "sync-label"),
       ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
+    };
+    updateData.metadata = {
+      ...metadataWithPricing,
+      shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "sync-label", metadataWithPricing),
     };
 
     // Detectar si metadata difiere de columnas (necesita sync)

--- a/src/app/api/shipping/skydropx/webhook/route.ts
+++ b/src/app/api/shipping/skydropx/webhook/route.ts
@@ -566,10 +566,13 @@ export async function POST(req: NextRequest) {
           });
           
           // Usar SOLO el resultado normalizado (nunca mezclar con updatedMetadata)
-          updateData.metadata = {
+          const metadataWithPricing: Record<string, unknown> = {
             ...updatedMetadata,
-            shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "webhook-skydropx"),
             ...(normalizedMeta.shippingPricing ? { shipping_pricing: normalizedMeta.shippingPricing } : {}),
+          };
+          updateData.metadata = {
+            ...metadataWithPricing,
+            shipping: addShippingMetadataDebug(normalizedMeta.shippingMeta, "webhook-skydropx", metadataWithPricing),
           };
         }
       }


### PR DESCRIPTION
## Root Cause

After \pply-rate\, \metadata.shipping.rate_used.price_cents\ and \carrier_cents\ remained \
ull\ despite \metadata.shipping_pricing\ having valid numbers. The overwrite logic in \
ormalizeShippingMetadata\ was executing inside \shouldDeriveRate\ block, but wasn't guaranteed to run as the final step, allowing merges/spreads to reintroduce nulls.

## Fix

1. **Added final overwrite step** at the end of \
ormalizeShippingMetadata\ (just before return) to guarantee \ate_used\ is always populated from canonical raw pricing when it exists.
2. **Added validation in apply-rate** to detect and log/throw error if canonical pricing exists but \ate_used\ has nulls (dev/staging throws, prod logs).
3. **Enhanced \ddShippingMetadataDebug\** to include \canonical_detected\ and \ate_used_overwritten\ booleans for debugging.
4. **Added \customer_total_cents\** to \ShippingRateUsed\ type.

## Invariants Enforced

If canonical pricing exists (\shipping_pricing\ or \shipping.pricing\) with numbers (including numeric strings), then:
- \ate_used.price_cents\ = \canonical.total_cents\
- \ate_used.carrier_cents\ = \canonical.carrier_cents\
- \ate_used.customer_total_cents\ = \canonical.customer_total_cents ?? canonical.total_cents\

**Never null** when canonical pricing exists.

## Tests

- Added test for final overwrite step simulating apply-rate flow.
- All existing tests pass (9/9).

## How to Verify in Supabase

1. Create order and go to **Admin → Recotizar → Apply-rate**
2. Check metadata in Supabase:
   - \metadata.shipping_pricing.total_cents\ and \carrier_cents\ should have numbers
   - \metadata.shipping.rate_used.price_cents\ should equal \	otal_cents\ (not null)
   - \metadata.shipping.rate_used.carrier_cents\ should equal \carrier_cents\ (not null)
   - \metadata.shipping._last_write.route\ should be \'apply-rate'\
   - \metadata.shipping._last_write.canonical_detected\ should be \	rue\
   - \metadata.shipping._last_write.rate_used_overwritten\ should be \	rue\

## Validations

- ✅ pnpm typecheck: OK
- ✅ pnpm build: OK
- ✅ pnpm test -t normalizeShippingMetadata: 9/9 passed
- ✅ pnpm lint: OK (only pre-existing warnings)