### PR TITLE
feat: admin cleanup + shipping override

### DIFF
--- a/src/app/admin/pedidos/AdminPedidosClient.tsx
+++ b/src/app/admin/pedidos/AdminPedidosClient.tsx
@@ -8,6 +8,7 @@ import type { OrderSummary } from "@/lib/supabase/orders.server";
 import { getShippingStatusLabel, getShippingStatusVariant } from "@/lib/orders/shippingStatus";
 import { getPaymentMethodLabel, getPaymentStatusLabel, getPaymentStatusVariant } from "@/lib/orders/paymentStatus";
 import { PAYMENT_STATUSES, PAYMENT_STATUS_LABELS } from "@/lib/orders/statuses";
+import OrderCleanupPanel from "./OrderCleanupPanel";
 
 type Props = {
   orders: OrderSummary[];
@@ -66,6 +67,8 @@ export default function AdminPedidosClient({
     const statusMap: Record<string, string> = {
       pending: "Pendiente",
       paid: "Pagado",
+      processing: "En proceso",
+      completed: "Completado",
       failed: "Fallido",
       canceled: "Cancelado",
       requires_payment: "Requiere pago",
@@ -115,8 +118,11 @@ export default function AdminPedidosClient({
   };
 
   const getOrderStatusBadgeClasses = (status: string) => {
-    if (status === "paid") {
+    if (status === "completed") {
       return "bg-green-100 text-green-700";
+    }
+    if (status === "paid" || status === "processing") {
+      return "bg-blue-100 text-blue-700";
     }
     if (status === "pending") {
       return "bg-yellow-100 text-yellow-700";
@@ -188,6 +194,8 @@ export default function AdminPedidosClient({
           </Link>
         </div>
       </header>
+
+      <OrderCleanupPanel />
 
       {/* Filtros rápidos de transferencia */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-4">

--- a/src/app/admin/pedidos/OrderCleanupPanel.tsx
+++ b/src/app/admin/pedidos/OrderCleanupPanel.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type CleanupMode = "cancelled" | "abandoned" | "both";
+
+type DryRunResult = {
+  ok: true;
+  dryRun: true;
+  ordersToDelete: number;
+  orderItemsToDelete: number;
+  sampleOrderIds: string[];
+};
+
+type ExecuteResult = {
+  ok: true;
+  dryRun: false;
+  ordersDeleted: number;
+  orderItemsDeleted: number;
+};
+
+type ErrorResult = {
+  ok: false;
+  code: string;
+  message: string;
+};
+
+type CleanupResponse = DryRunResult | ExecuteResult | ErrorResult;
+
+export default function OrderCleanupPanel() {
+  const router = useRouter();
+  const [mode, setMode] = useState<CleanupMode>("abandoned");
+  const [olderThanDays, setOlderThanDays] = useState(14);
+  const [dryRun, setDryRun] = useState(true);
+  const [excludeWithShipmentId, setExcludeWithShipmentId] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<CleanupResponse | null>(null);
+  const [showExecuteModal, setShowExecuteModal] = useState(false);
+  const [executeConfirm, setExecuteConfirm] = useState("");
+
+  const runCleanup = async (actuallyExecute: boolean) => {
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await fetch("/api/admin/orders/cleanup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          mode,
+          olderThanDays: Number(olderThanDays) || 14,
+          dryRun: !actuallyExecute,
+          excludeWithShipmentId,
+        }),
+      });
+      const data: CleanupResponse = await res.json();
+      setResult(data);
+      if (data.ok && !data.dryRun) {
+        setShowExecuteModal(false);
+        setExecuteConfirm("");
+        router.refresh();
+      }
+    } catch (err) {
+      setResult({
+        ok: false,
+        code: "unknown_error",
+        message: err instanceof Error ? err.message : "Error de red",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDryRun = () => runCleanup(false);
+
+  const handleOpenExecuteModal = () => {
+    if (dryRun) return;
+    setResult(null);
+    setExecuteConfirm("");
+    setShowExecuteModal(true);
+  };
+
+  const handleExecute = () => {
+    if (executeConfirm !== "BORRAR") return;
+    runCleanup(true);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-2">
+        Limpieza de órdenes (basura)
+      </h2>
+      <p className="text-sm text-gray-600 mb-4">
+        Borrar órdenes canceladas o abandonadas (nunca se borran órdenes pagadas).
+        Por defecto es simulación (dry run).
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <div>
+          <label
+            htmlFor="cleanup-mode"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Modo
+          </label>
+          <select
+            id="cleanup-mode"
+            value={mode}
+            onChange={(e) => setMode(e.target.value as CleanupMode)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="cancelled">Solo canceladas</option>
+            <option value="abandoned">Solo abandonadas (&gt; N días)</option>
+            <option value="both">Ambas</option>
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="cleanup-days"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Más antiguas que (días)
+          </label>
+          <input
+            id="cleanup-days"
+            type="number"
+            min={1}
+            max={365}
+            value={olderThanDays}
+            onChange={(e) => setOlderThanDays(Number(e.target.value) || 14)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            id="cleanup-dryrun"
+            type="checkbox"
+            checked={dryRun}
+            onChange={(e) => setDryRun(e.target.checked)}
+            className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          <label htmlFor="cleanup-dryrun" className="text-sm text-gray-700">
+            Simulación (dry run) — no borra nada
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            id="cleanup-exclude-shipment"
+            type="checkbox"
+            checked={excludeWithShipmentId}
+            onChange={(e) => setExcludeWithShipmentId(e.target.checked)}
+            className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          <label htmlFor="cleanup-exclude-shipment" className="text-sm text-gray-700">
+            Excluir órdenes con guía creada (shipping_shipment_id)
+          </label>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleDryRun}
+          disabled={loading}
+          className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-800 disabled:opacity-50 transition-colors"
+        >
+          {loading ? "Consultando…" : "Vista previa (dry run)"}
+        </button>
+        {!dryRun && (
+          <button
+            type="button"
+            onClick={handleOpenExecuteModal}
+            disabled={loading}
+            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+          >
+            Ejecutar borrado
+          </button>
+        )}
+      </div>
+
+      {/* Resultado */}
+      {result && (
+        <div
+          className={`mt-4 p-4 rounded-lg border ${
+            result.ok
+              ? result.dryRun
+                ? "bg-blue-50 border-blue-200 text-blue-900"
+                : "bg-green-50 border-green-200 text-green-900"
+              : "bg-red-50 border-red-200 text-red-900"
+          }`}
+        >
+          {result.ok ? (
+            result.dryRun ? (
+              <>
+                <p className="font-medium">
+                  Vista previa: {result.ordersToDelete} órdenes,{" "}
+                  {result.orderItemsToDelete} items a borrar.
+                </p>
+                {result.sampleOrderIds.length > 0 && (
+                  <p className="text-sm mt-1 font-mono truncate">
+                    Ejemplo IDs: {result.sampleOrderIds.slice(0, 5).join(", ")}
+                    {result.sampleOrderIds.length > 5 && " …"}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="font-medium">
+                Hecho: {result.ordersDeleted} órdenes y {result.orderItemsDeleted}{" "}
+                items borrados.
+              </p>
+            )
+          ) : (
+            <p className="font-medium">
+              Error: {result.message} ({result.code})
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Modal de confirmación para ejecutar */}
+      {showExecuteModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="execute-modal-title"
+        >
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+            <h3 id="execute-modal-title" className="text-lg font-semibold text-gray-900 mb-2">
+              Confirmar borrado
+            </h3>
+            <p className="text-sm text-gray-600 mb-4">
+              Esto borrará órdenes y sus items de forma permanente. Escribe{" "}
+              <strong>BORRAR</strong> para confirmar.
+            </p>
+            <input
+              type="text"
+              value={executeConfirm}
+              onChange={(e) => setExecuteConfirm(e.target.value)}
+              placeholder="BORRAR"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 mb-4"
+              aria-label="Escribe BORRAR para confirmar"
+            />
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowExecuteModal(false);
+                  setExecuteConfirm("");
+                }}
+                className="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={handleExecute}
+                disabled={executeConfirm !== "BORRAR" || loading}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                {loading ? "Borrando…" : "Borrar"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/pedidos/[id]/UpdateShippingStatusClient.tsx
+++ b/src/app/admin/pedidos/[id]/UpdateShippingStatusClient.tsx
@@ -19,13 +19,16 @@ export default function UpdateShippingStatusClient({
   const router = useRouter();
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showReasonInput, setShowReasonInput] = useState(false);
+  const [pendingStatus, setPendingStatus] = useState<ShippingStatus | null>(null);
+  const [overrideReason, setOverrideReason] = useState("");
 
-  const handleUpdateStatus = async (newStatus: ShippingStatus) => {
+  const handleUpdateStatus = async (newStatus: ShippingStatus, reason?: string) => {
     setIsUpdating(true);
     setError(null);
 
     try {
-      const result = await updateShippingStatusAdmin(orderId, newStatus);
+      const result = await updateShippingStatusAdmin(orderId, newStatus, reason);
 
       if (!result.ok) {
         // Mapear códigos de error a mensajes
@@ -43,12 +46,32 @@ export default function UpdateShippingStatusClient({
       }
 
       // Refrescar la página para mostrar el nuevo estado
+      setShowReasonInput(false);
+      setPendingStatus(null);
+      setOverrideReason("");
       router.refresh();
     } catch (err) {
       console.error("[UpdateShippingStatusClient] Error:", err);
       setError("Error inesperado al actualizar el estado");
     } finally {
       setIsUpdating(false);
+    }
+  };
+
+  const handleStatusClick = (newStatus: ShippingStatus) => {
+    // Si es Skydropx, mostrar input para reason opcional
+    if (shippingProvider === "skydropx" || shippingProvider === "Skydropx") {
+      setPendingStatus(newStatus);
+      setShowReasonInput(true);
+    } else {
+      // Para otros proveedores, actualizar directamente sin reason
+      handleUpdateStatus(newStatus);
+    }
+  };
+
+  const handleConfirmWithReason = () => {
+    if (pendingStatus) {
+      handleUpdateStatus(pendingStatus, overrideReason.trim() || undefined);
     }
   };
 
@@ -61,27 +84,72 @@ export default function UpdateShippingStatusClient({
       <div>
         <p className="text-sm font-medium text-gray-700 mb-2">
           Cambiar estado de envío
+          {(shippingProvider === "skydropx" || shippingProvider === "Skydropx") && (
+            <span className="text-xs text-gray-500 ml-2">
+              (Override manual - webhooks no cambiarán este estado)
+            </span>
+          )}
         </p>
         {error && (
           <div className="mb-3 p-2 bg-red-50 border border-red-200 rounded text-sm text-red-700">
             {error}
           </div>
         )}
+        
+        {/* Input para reason cuando se muestra */}
+        {showReasonInput && pendingStatus && (
+          <div className="mb-3 p-3 bg-blue-50 border border-blue-200 rounded">
+            <label htmlFor="override-reason" className="block text-sm font-medium text-gray-700 mb-1">
+              Razón del cambio manual (opcional)
+            </label>
+            <input
+              id="override-reason"
+              type="text"
+              value={overrideReason}
+              onChange={(e) => setOverrideReason(e.target.value)}
+              placeholder="Ej: Cliente reportó entrega, corrección manual, etc."
+              className="w-full px-3 py-2 border border-gray-300 rounded text-sm mb-2"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleConfirmWithReason}
+                disabled={isUpdating}
+                className="px-3 py-1.5 text-sm bg-primary-600 text-white rounded hover:bg-primary-700 disabled:opacity-50"
+              >
+                {isUpdating ? "Actualizando..." : "Confirmar"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowReasonInput(false);
+                  setPendingStatus(null);
+                  setOverrideReason("");
+                }}
+                disabled={isUpdating}
+                className="px-3 py-1.5 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300 disabled:opacity-50"
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        )}
+        
         <div className="flex flex-wrap gap-2">
           {isPickup && (
             <>
               <button
                 type="button"
-                onClick={() => handleUpdateStatus("ready_for_pickup")}
-                disabled={isUpdating || currentStatus === "ready_for_pickup"}
+                onClick={() => handleStatusClick("ready_for_pickup")}
+                disabled={isUpdating || currentStatus === "ready_for_pickup" || showReasonInput}
                 className="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {isUpdating ? "Actualizando..." : "Marcar como listo para recoger"}
               </button>
               <button
                 type="button"
-                onClick={() => handleUpdateStatus("delivered")}
-                disabled={isUpdating || currentStatus === "delivered"}
+                onClick={() => handleStatusClick("delivered")}
+                disabled={isUpdating || currentStatus === "delivered" || showReasonInput}
                 className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {isUpdating ? "Actualizando..." : "Marcar como entregado"}
@@ -92,16 +160,16 @@ export default function UpdateShippingStatusClient({
             <>
               <button
                 type="button"
-                onClick={() => handleUpdateStatus("in_transit")}
-                disabled={isUpdating || currentStatus === "in_transit"}
+                onClick={() => handleStatusClick("in_transit")}
+                disabled={isUpdating || currentStatus === "in_transit" || showReasonInput}
                 className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {isUpdating ? "Actualizando..." : "Marcar como en tránsito"}
               </button>
               <button
                 type="button"
-                onClick={() => handleUpdateStatus("delivered")}
-                disabled={isUpdating || currentStatus === "delivered"}
+                onClick={() => handleStatusClick("delivered")}
+                disabled={isUpdating || currentStatus === "delivered" || showReasonInput}
                 className="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {isUpdating ? "Actualizando..." : "Marcar como entregado"}
@@ -111,8 +179,8 @@ export default function UpdateShippingStatusClient({
           {(isPickup || isPaqueteria) && (
             <button
               type="button"
-              onClick={() => handleUpdateStatus("cancelled")}
-              disabled={isUpdating || currentStatus === "cancelled"}
+              onClick={() => handleStatusClick("cancelled")}
+              disabled={isUpdating || currentStatus === "cancelled" || showReasonInput}
               className="px-3 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {isUpdating ? "Actualizando..." : "Cancelar envío"}

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -102,6 +102,8 @@ export default async function AdminPedidoDetailPage({
     const statusMap: Record<string, string> = {
       pending: "Pendiente",
       paid: "Pagado",
+      processing: "En proceso",
+      completed: "Completado",
       failed: "Fallido",
       canceled: "Cancelado",
       requires_payment: "Requiere pago",
@@ -249,7 +251,8 @@ export default async function AdminPedidoDetailPage({
               <p className="text-sm text-gray-600">Estado</p>
               <span
                 className={`inline-flex px-2 py-1 text-xs font-medium rounded-full mt-1 ${(() => {
-                  if (order.status === "paid") return "bg-green-100 text-green-700";
+                  if (order.status === "completed") return "bg-green-100 text-green-700";
+                  if (order.status === "paid" || order.status === "processing") return "bg-blue-100 text-blue-700";
                   if (order.status === "pending") return "bg-yellow-100 text-yellow-700";
                   if (order.status === "failed") return "bg-red-100 text-red-700";
                   return "bg-gray-100 text-gray-700";

--- a/src/app/api/admin/orders/cleanup/route.ts
+++ b/src/app/api/admin/orders/cleanup/route.ts
@@ -1,0 +1,308 @@
+/**
+ * Endpoint admin para limpieza de órdenes "basura":
+ * - Canceladas (status=cancelled, no pagadas)
+ * - Abandonadas (no pagadas, creadas hace más de N días)
+ * Nunca borra órdenes con payment_status='paid'.
+ */
+
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { sanitizeForLog } from "@/lib/utils/sanitizeForLog";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const CleanupRequestSchema = z.object({
+  mode: z.enum(["cancelled", "abandoned", "both"]),
+  olderThanDays: z.number().int().min(1).max(365).default(14),
+  dryRun: z.boolean().default(true),
+  excludeWithShipmentId: z.boolean().default(true),
+});
+
+type CleanupDryRunResponse = {
+  ok: true;
+  dryRun: true;
+  ordersToDelete: number;
+  orderItemsToDelete: number;
+  sampleOrderIds: string[];
+};
+
+type CleanupExecuteResponse = {
+  ok: true;
+  dryRun: false;
+  ordersDeleted: number;
+  orderItemsDeleted: number;
+};
+
+type CleanupErrorResponse = {
+  ok: false;
+  code: "unauthorized" | "invalid_params" | "config_error" | "db_error" | "unknown_error";
+  message: string;
+};
+
+export type CleanupResponse =
+  | CleanupDryRunResponse
+  | CleanupExecuteResponse
+  | CleanupErrorResponse;
+
+export async function POST(req: NextRequest): Promise<NextResponse<CleanupResponse>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unauthorized",
+          message: "Acceso denegado",
+        } satisfies CleanupErrorResponse,
+        { status: 403 },
+      );
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const parsed = CleanupRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_params",
+          message: parsed.error.errors[0]?.message ?? "Parámetros inválidos",
+        } satisfies CleanupErrorResponse,
+        { status: 400 },
+      );
+    }
+
+    const { mode, olderThanDays, dryRun, excludeWithShipmentId } = parsed.data;
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) {
+      console.error("[orders/cleanup] Configuración de Supabase incompleta");
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "config_error",
+          message: "Configuración incompleta",
+        } satisfies CleanupErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - olderThanDays);
+    const cutoffIso = cutoff.toISOString();
+
+    let orderIds: string[] = [];
+
+    if (mode === "both") {
+      let cancelledQuery = supabase
+        .from("orders")
+        .select("id")
+        .neq("payment_status", "paid")
+        .in("status", ["cancelled", "canceled"]);
+      if (excludeWithShipmentId) {
+        cancelledQuery = cancelledQuery.is("shipping_shipment_id", null);
+      }
+      let abandonedQuery = supabase
+        .from("orders")
+        .select("id")
+        .neq("payment_status", "paid")
+        .lt("created_at", cutoffIso);
+      if (excludeWithShipmentId) {
+        abandonedQuery = abandonedQuery.is("shipping_shipment_id", null);
+      }
+      const [cancelledRes, abandonedRes] = await Promise.all([
+        cancelledQuery,
+        abandonedQuery,
+      ]);
+      if (cancelledRes.error) {
+        console.error(
+          "[orders/cleanup] Error al listar canceladas:",
+          sanitizeForLog(cancelledRes.error.message),
+        );
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "db_error",
+            message: "Error al consultar órdenes",
+          } satisfies CleanupErrorResponse,
+          { status: 500 },
+        );
+      }
+      if (abandonedRes.error) {
+        console.error(
+          "[orders/cleanup] Error al listar abandonadas:",
+          sanitizeForLog(abandonedRes.error.message),
+        );
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "db_error",
+            message: "Error al consultar órdenes",
+          } satisfies CleanupErrorResponse,
+          { status: 500 },
+        );
+      }
+      const cancelledIds = (cancelledRes.data ?? []).map((r: { id: string }) => r.id);
+      const abandonedIds = (abandonedRes.data ?? []).map((r: { id: string }) => r.id);
+      orderIds = [...new Set([...cancelledIds, ...abandonedIds])];
+    } else {
+      let query = supabase
+        .from("orders")
+        .select("id")
+        .neq("payment_status", "paid");
+      if (excludeWithShipmentId) {
+        query = query.is("shipping_shipment_id", null);
+      }
+      if (mode === "cancelled") {
+        query = query.in("status", ["cancelled", "canceled"]);
+      } else {
+        query = query.lt("created_at", cutoffIso);
+      }
+      const { data: orderRows, error: listError } = await query;
+      if (listError) {
+        console.error(
+          "[orders/cleanup] Error al listar órdenes:",
+          sanitizeForLog(listError.message),
+        );
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "db_error",
+            message: "Error al consultar órdenes",
+          } satisfies CleanupErrorResponse,
+          { status: 500 },
+        );
+      }
+      orderIds = (orderRows ?? []).map((r: { id: string }) => r.id);
+    }
+
+    const ordersToDelete = orderIds.length;
+
+    if (ordersToDelete === 0) {
+      const dryPayload: CleanupDryRunResponse = {
+        ok: true,
+        dryRun: true,
+        ordersToDelete: 0,
+        orderItemsToDelete: 0,
+        sampleOrderIds: [],
+      };
+      if (dryRun) {
+        console.log("[orders/cleanup] Resumen", {
+          mode: sanitizeForLog(mode),
+          olderThanDays,
+          dryRun: true,
+          admin: sanitizeForLog(access.userEmail),
+          ordersToDelete: 0,
+          orderItemsToDelete: 0,
+        });
+        return NextResponse.json(dryPayload);
+      }
+      return NextResponse.json({
+        ok: true,
+        dryRun: false,
+        ordersDeleted: 0,
+        orderItemsDeleted: 0,
+      } satisfies CleanupExecuteResponse);
+    }
+
+    // Contar order_items para estos order_ids
+    const { count: itemsCount, error: countError } = await supabase
+      .from("order_items")
+      .select("id", { count: "exact", head: true })
+      .in("order_id", orderIds);
+
+    const orderItemsToDelete = countError ? 0 : (itemsCount ?? 0);
+    const sampleOrderIds = orderIds.slice(0, 10);
+
+    if (dryRun) {
+      console.log("[orders/cleanup] Resumen (dry run)", {
+        mode: sanitizeForLog(mode),
+        olderThanDays,
+        dryRun: true,
+        admin: sanitizeForLog(access.userEmail),
+        ordersToDelete,
+        orderItemsToDelete,
+        sampleOrderIds: sampleOrderIds.map(sanitizeForLog),
+      });
+      return NextResponse.json({
+        ok: true,
+        dryRun: true,
+        ordersToDelete,
+        orderItemsToDelete,
+        sampleOrderIds,
+      } satisfies CleanupDryRunResponse);
+    }
+
+    // Ejecutar: borrar primero order_items, luego orders
+    const { error: deleteItemsError } = await supabase
+      .from("order_items")
+      .delete()
+      .in("order_id", orderIds);
+
+    if (deleteItemsError) {
+      console.error(
+        "[orders/cleanup] Error al borrar order_items:",
+        sanitizeForLog(deleteItemsError.message),
+      );
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "db_error",
+          message: "Error al borrar items de órdenes",
+        } satisfies CleanupErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    const { error: deleteOrdersError } = await supabase.from("orders").delete().in("id", orderIds);
+
+    if (deleteOrdersError) {
+      console.error(
+        "[orders/cleanup] Error al borrar órdenes:",
+        sanitizeForLog(deleteOrdersError.message),
+      );
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "db_error",
+          message: "Error al borrar órdenes",
+        } satisfies CleanupErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    console.log("[orders/cleanup] Resumen (ejecutado)", {
+      mode: sanitizeForLog(mode),
+      olderThanDays,
+      dryRun: false,
+      admin: sanitizeForLog(access.userEmail),
+      ordersDeleted: orderIds.length,
+      orderItemsDeleted: orderItemsToDelete,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      dryRun: false,
+      ordersDeleted: orderIds.length,
+      orderItemsDeleted: orderItemsToDelete,
+    } satisfies CleanupExecuteResponse);
+  } catch (err) {
+    console.error("[orders/cleanup] Error inesperado:", err);
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "unknown_error",
+        message: "Error inesperado",
+      } satisfies CleanupErrorResponse,
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Objetivo
Implementa tres entregables para Admin: consistencia de estado, limpieza de órdenes basura y override manual de shipping.

## A) Estado general cuando admin marca pago
- Cuando `payment_status` cambia a `paid` => `status` pasa automáticamente a `processing` (evitar Pagado + Pendiente)
- Cuando `shipping_status` cambia a `delivered` => `status` pasa a `completed`
- UI: badges para `processing` (En proceso) y `completed` (Completado)

## B) Limpieza de órdenes
- **POST /api/admin/orders/cleanup** (solo admin)
  - body: `mode` (cancelled|abandoned|both), `olderThanDays`, `dryRun=true`, `excludeWithShipmentId=true`
  - Nunca borra órdenes con `payment_status='paid'`
  - Borra primero `order_items`, luego `orders`
- **UI** en `/admin/pedidos`: panel con preview (dry run) + confirmación escribiendo BORRAR para ejecutar

## C) Override manual shipping
- Admin setea `shipping_status` => `metadata.shipping.manual_override=true` + `override_reason?` + `override_set_at`
- Webhook Skydropx respeta `manual_override`: no pisa `shipping_status` pero sí actualiza `tracking_number`/`label_url` (columnas + metadata)
- UI: input reason opcional + aviso "Override manual - webhooks no cambiarán este estado"

## Validación
- `pnpm typecheck` OK
- `pnpm build` OK
- `pnpm lint` OK (0 errors)

## Cómo probar
1. **A**: Marcar pago como Pagado en transferencia => verificar que Estado pasa a "En proceso"
2. **B**: En /admin/pedidos, usar panel Limpieza. Vista previa (dry run) muestra conteos. Ejecutar requiere escribir BORRAR
3. **C**: En orden Skydropx, usar "Marcar como en tránsito/entregado". Verificar metadata.override y que webhooks no pisen el estado
