### PR TITLE
fix: status-check constraint + cleanup unpaid_any_age + input bug

### DIFF
--- a/ops/sql/2026-01-31_orders_status_check_add_processing_completed.sql
+++ b/ops/sql/2026-01-31_orders_status_check_add_processing_completed.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- Fix: orders_status_check constraint
+-- ============================================================================
+-- Contexto: En public.orders existe un constraint orders_status_check con
+-- definición que solo permite: pending, paid, failed, canceled
+-- Esto rompe el admin cuando intenta setear status='processing' (error 23514).
+--
+-- Este script debe aplicarse manualmente en Supabase SQL Editor.
+-- Es idempotente: puede ejecutarse varias veces sin efectos adversos.
+-- ============================================================================
+
+-- Drop del constraint existente (si existe)
+ALTER TABLE public.orders
+  DROP CONSTRAINT IF EXISTS orders_status_check;
+
+-- Recrear con valores expandidos
+-- Valores existentes: pending, paid, failed, canceled
+-- Valores nuevos: processing, completed (para flujo admin), cancelled (alias UK)
+ALTER TABLE public.orders
+  ADD CONSTRAINT orders_status_check CHECK (
+    status = ANY (ARRAY[
+      'pending'::text,
+      'paid'::text,
+      'failed'::text,
+      'canceled'::text,
+      'cancelled'::text,
+      'processing'::text,
+      'completed'::text
+    ])
+  );
+
+-- Comentario para documentar
+COMMENT ON CONSTRAINT orders_status_check ON public.orders IS
+  'Valores permitidos: pending, paid, failed, canceled, cancelled, processing, completed';

--- a/src/app/api/admin/orders/cleanup/route.ts
+++ b/src/app/api/admin/orders/cleanup/route.ts
@@ -16,7 +16,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 const CleanupRequestSchema = z.object({
-  mode: z.enum(["cancelled", "abandoned", "both"]),
+  mode: z.enum(["cancelled", "abandoned", "both", "unpaid_any_age"]),
   olderThanDays: z.number().int().min(1).max(365).default(14),
   dryRun: z.boolean().default(true),
   excludeWithShipmentId: z.boolean().default(true),


### PR DESCRIPTION
## Objetivo
Fix crítico del constraint orders_status_check (error 23514 al setear processing) + mejoras en cleanup y UI.

## A) Fix constraint orders_status_check
- **Problema**: El constraint actual solo permite pending, paid, failed, canceled. El admin falla (23514) al setear status='processing'.
- **Solución**: Script SQL idempotente `ops/sql/2026-01-31_orders_status_check_add_processing_completed.sql`
  - Drop y recreate del constraint con: pending, paid, failed, canceled, cancelled, processing, completed
  - **Aplicar manualmente** en Supabase SQL Editor antes de mergear/deployar

## B) Cleanup: modo unpaid_any_age
- Nuevo modo `unpaid_any_age`: borra no pagadas sin importar fecha
- Solo órdenes con status in ('pending','cancelled','canceled')
- Nunca borra payment_status='paid'
- excludeWithShipmentId sigue aplicando

## C) UI panel de limpieza
- **Bug fix**: Input días ahora usa string state; permite escribir "7", "17", etc. sin clavarse en "1"
- Validación 1-365 solo en blur
- Opción "No pagadas (cualquier edad)" para unpaid_any_age
- Campo días se oculta cuando modo = unpaid_any_age
- Modal confirmación sigue exigiendo teclear BORRAR

## Validaciones
- pnpm lint OK
- pnpm typecheck OK
- pnpm build OK

## Prueba manual
1. **SQL**: Ejecutar script en Supabase SQL Editor. Admin debe poder marcar pagado => status processing sin error 23514.
2. **Input**: En /admin/pedidos, panel Limpieza, cambiar días: escribir 7, 70, 365. Verificar que no se clava.
3. **unpaid_any_age**: Modo "No pagadas (cualquier edad)", dry run, verificar conteos. Ejecutar requiere BORRAR.
