### PR TITLE
feat(admin): delete single order API + UI danger zone

### DIFF
--- a/src/app/admin/pedidos/[id]/DeleteOrderClient.tsx
+++ b/src/app/admin/pedidos/[id]/DeleteOrderClient.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  orderId: string;
+};
+
+const CONFIRM_PREFIX = "BORRAR ";
+
+export default function DeleteOrderClient({ orderId }: Props) {
+  const router = useRouter();
+  const [understood, setUnderstood] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [force, setForce] = useState(false);
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const expectedConfirm = CONFIRM_PREFIX + orderId;
+  const confirmValid = confirmText.trim() === expectedConfirm;
+  const reasonValid = !force || reason.trim().length >= 5;
+  const canDelete = understood && confirmValid && reasonValid;
+
+  const handleDelete = async () => {
+    if (!canDelete) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/orders/${orderId}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          force,
+          reason: force ? reason.trim() : undefined,
+        }),
+      });
+      const data = await res.json();
+
+      if (!data.ok) {
+        if (data.code === "protected-order") {
+          if (data.reason === "paid") {
+            setError("Esta orden está pagada. Activa \"Forzar\" y escribe una razón para borrarla.");
+          } else {
+            setError("Esta orden tiene guía creada. Activa \"Forzar\" y escribe una razón para borrarla.");
+          }
+        } else {
+          setError(data.message || "Error al eliminar la orden");
+        }
+        return;
+      }
+
+      router.push("/admin/pedidos");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error de red");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="px-6 py-6 border-t border-red-200 bg-red-50/50">
+      <h2 className="text-lg font-semibold text-red-800 mb-2">Eliminar pedido</h2>
+      <p className="text-sm text-gray-700 mb-4">
+        Esta acción borra la orden y sus items de forma permanente. No se puede deshacer.
+      </p>
+
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm font-medium text-gray-700 mb-1">ID de la orden</p>
+          <p className="font-mono text-sm text-gray-900 break-all bg-white px-2 py-1 rounded border border-gray-200">
+            {orderId}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            id="delete-understood"
+            type="checkbox"
+            checked={understood}
+            onChange={(e) => setUnderstood(e.target.checked)}
+            className="rounded border-gray-300 text-red-600 focus:ring-red-500"
+          />
+          <label htmlFor="delete-understood" className="text-sm text-gray-700">
+            Entiendo que esto borra el pedido permanentemente
+          </label>
+        </div>
+
+        <div>
+          <label htmlFor="delete-confirm" className="block text-sm font-medium text-gray-700 mb-1">
+            Escribe <strong>{CONFIRM_PREFIX.trim()}</strong> seguido del ID para confirmar
+          </label>
+          <input
+            id="delete-confirm"
+            type="text"
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            placeholder={`${CONFIRM_PREFIX}${orderId.slice(0, 8)}…`}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500 font-mono text-sm"
+            aria-label="Confirmación: BORRAR seguido del ID"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            id="delete-force"
+            type="checkbox"
+            checked={force}
+            onChange={(e) => setForce(e.target.checked)}
+            className="rounded border-gray-300 text-red-600 focus:ring-red-500"
+          />
+          <label htmlFor="delete-force" className="text-sm text-gray-700">
+            Forzar (permitir borrar pagadas / con guía)
+          </label>
+        </div>
+
+        {force && (
+          <div>
+            <label htmlFor="delete-reason" className="block text-sm font-medium text-gray-700 mb-1">
+              Razón del borrado forzado (mínimo 5 caracteres)
+            </label>
+            <input
+              id="delete-reason"
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Ej: orden de prueba, duplicado, etc."
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 text-sm"
+              minLength={5}
+            />
+          </div>
+        )}
+
+        {error && (
+          <div className="p-3 bg-red-100 border border-red-200 rounded-lg text-sm text-red-800">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={!canDelete || loading}
+          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {loading ? "Eliminando…" : "Eliminar pedido"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -23,6 +23,7 @@ import NotifyShippingClient from "./NotifyShippingClient";
 import { normalizePhoneToE164Mx } from "@/lib/utils/phone";
 import EditShippingOverrideClient from "./EditShippingOverrideClient";
 import ShippingTrackingDisplay from "./ShippingTrackingDisplay";
+import DeleteOrderClient from "./DeleteOrderClient";
 import { getOrderShippingAddress } from "@/lib/shipping/getOrderShippingAddress";
 
 export const dynamic = "force-dynamic";
@@ -879,6 +880,9 @@ export default async function AdminPedidoDetailPage({
               </div>
             </div>
           )}
+
+        {/* Eliminar pedido (danger zone) */}
+        <DeleteOrderClient orderId={order.id} />
       </div>
     </div>
   );

--- a/src/app/api/admin/orders/[id]/route.ts
+++ b/src/app/api/admin/orders/[id]/route.ts
@@ -1,0 +1,249 @@
+/**
+ * DELETE /api/admin/orders/[id]
+ * Borrado de una orden específica (solo admin).
+ * Por defecto no borra si payment_status='paid' o si tiene shipping_shipment_id.
+ * Con force=true exige reason (min 5 chars) y permite borrar igual.
+ */
+
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { sanitizeForLog } from "@/lib/utils/sanitizeForLog";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const DeleteBodySchema = z.object({
+  force: z.boolean().optional().default(false),
+  reason: z.string().optional(),
+});
+
+type DeleteSuccessResponse = {
+  ok: true;
+  deletedOrder: true;
+  deletedItems: number;
+};
+
+type DeleteErrorResponse = {
+  ok: false;
+  code: "unauthorized" | "invalid_id" | "order_not_found" | "protected-order" | "config_error" | "db_error" | "force_requires_reason" | "unknown_error";
+  reason?: "paid" | "has_shipment";
+  message?: string;
+};
+
+export type DeleteOrderResponse = DeleteSuccessResponse | DeleteErrorResponse;
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isValidUUID(id: string): boolean {
+  return UUID_REGEX.test(id);
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+): Promise<NextResponse<DeleteOrderResponse>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unauthorized",
+          message: "Acceso denegado",
+        } satisfies DeleteErrorResponse,
+        { status: 403 },
+      );
+    }
+
+    const { id } = await context.params;
+    if (!id || !isValidUUID(id)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "invalid_id",
+          message: "ID de orden inválido (debe ser UUID)",
+        } satisfies DeleteErrorResponse,
+        { status: 400 },
+      );
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const parsed = DeleteBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "unknown_error",
+          message: parsed.error.errors[0]?.message ?? "Parámetros inválidos",
+        } satisfies DeleteErrorResponse,
+        { status: 400 },
+      );
+    }
+
+    const { force, reason } = parsed.data;
+
+    if (force) {
+      const trimmedReason = (reason ?? "").trim();
+      if (trimmedReason.length < 5) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "force_requires_reason",
+            message: "Con force=true se requiere reason de al menos 5 caracteres",
+          } satisfies DeleteErrorResponse,
+          { status: 400 },
+        );
+      }
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) {
+      console.error("[orders/delete] Configuración de Supabase incompleta");
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "config_error",
+          message: "Configuración incompleta",
+        } satisfies DeleteErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: order, error: fetchError } = await supabase
+      .from("orders")
+      .select("id, payment_status, shipping_shipment_id")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error("[orders/delete] Error al obtener orden:", sanitizeForLog(fetchError.message));
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "db_error",
+          message: "Error al consultar orden",
+        } satisfies DeleteErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    if (!order) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "order_not_found",
+          message: "Orden no encontrada",
+        } satisfies DeleteErrorResponse,
+        { status: 404 },
+      );
+    }
+
+    if (!force) {
+      if (order.payment_status === "paid") {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "protected-order",
+            reason: "paid",
+            message: "No se puede borrar una orden pagada sin forzar",
+          } satisfies DeleteErrorResponse,
+          { status: 409 },
+        );
+      }
+      if (order.shipping_shipment_id != null && String(order.shipping_shipment_id).trim() !== "") {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: "protected-order",
+            reason: "has_shipment",
+            message: "No se puede borrar una orden con guía creada sin forzar",
+          } satisfies DeleteErrorResponse,
+          { status: 409 },
+        );
+      }
+    }
+
+    const { data: itemsData, error: itemsError } = await supabase
+      .from("order_items")
+      .select("id")
+      .eq("order_id", id);
+
+    if (itemsError) {
+      console.error("[orders/delete] Error al listar items:", sanitizeForLog(itemsError.message));
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "db_error",
+          message: "Error al consultar items",
+        } satisfies DeleteErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    const deletedItemsCount = (itemsData ?? []).length;
+
+    const { error: deleteItemsError } = await supabase
+      .from("order_items")
+      .delete()
+      .eq("order_id", id);
+
+    if (deleteItemsError) {
+      console.error("[orders/delete] Error al borrar order_items:", sanitizeForLog(deleteItemsError.message));
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "db_error",
+          message: "Error al borrar items de la orden",
+        } satisfies DeleteErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    const { error: deleteOrderError } = await supabase.from("orders").delete().eq("id", id);
+
+    if (deleteOrderError) {
+      console.error("[orders/delete] Error al borrar orden:", sanitizeForLog(deleteOrderError.message));
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "db_error",
+          message: "Error al borrar orden",
+        } satisfies DeleteErrorResponse,
+        { status: 500 },
+      );
+    }
+
+    console.log("[orders/delete] Resumen", {
+      orderId: sanitizeForLog(id),
+      force,
+      reason: force ? sanitizeForLog(reason) : undefined,
+      adminEmail: sanitizeForLog(access.userEmail),
+      deletedItemsCount,
+      deletedOrderCount: 1,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      deletedOrder: true,
+      deletedItems: deletedItemsCount,
+    } satisfies DeleteSuccessResponse);
+  } catch (err) {
+    console.error("[orders/delete] Error inesperado:", err);
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "unknown_error",
+        message: "Error inesperado",
+      } satisfies DeleteErrorResponse,
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Objetivo
Borrado seguro de una orden específica desde Admin (sin usar SQL).

## D) Borrado de una orden específica (admin)

### API
- **DELETE /api/admin/orders/[id]** (`src/app/api/admin/orders/[id]/route.ts`)
- Auth: solo admin (`checkAdminAccess()`), 403 si no
- Validación: `id` como UUID (Zod/regex)
- Body JSON: `{ force?: boolean, reason?: string }`

### Comportamiento
- **Por defecto (force=false)**:
  - No borrar si `payment_status='paid'`
  - No borrar si `shipping_shipment_id` no es null
  - Respuesta 409: `{ ok: false, code: 'protected-order', reason: 'paid' | 'has_shipment' }`
- **Con force=true**:
  - Permite borrar pagadas o con guía (para pruebas)
  - Exige `reason` no vacío (mínimo 5 caracteres)
- Borrado: primero `order_items` donde `order_id=id`, luego `orders` donde `id=id`
- Logging con `sanitizeForLog`: orderId, force, reason, adminEmail, deletedItemsCount, deletedOrderCount
- Respuesta éxito: `{ ok: true, deletedOrder: true, deletedItems: n }`

### UI
- Bloque "Eliminar pedido" (danger zone) al final de `/admin/pedidos/[id]`
- Muestra ID completo de la orden
- Checkbox "Entiendo que esto borra el pedido permanentemente"
- Input de confirmación: usuario debe escribir **BORRAR \<ID\>** (exacto)
- Botón "Eliminar" deshabilitado hasta que la confirmación sea válida
- Toggle "Forzar (permitir borrar pagadas / con guía)" + input `reason` obligatorio (min 5 chars) si force activo
- Al ejecutar: DELETE con body `{ force, reason }`; mensaje de error si 409; si ok => redirección a `/admin/pedidos` + refresh

## Validaciones
- `pnpm typecheck` OK
- `pnpm build` OK

## Prueba manual
1. Orden no pagada y sin guía: marcar checkbox, escribir "BORRAR \<uuid\>", Eliminar → debe borrar y redirigir a lista.
2. Orden pagada: intentar Eliminar sin forzar → debe mostrar 409 / mensaje "orden pagada"; activar Forzar + razón (≥5 chars) → debe permitir borrar.
3. Orden con guía: sin forzar → 409; con forzar + razón → debe permitir borrar.
