### PR TITLE
feat(admin): add reset quote action for skydropx

### DIFF
--- a/src/app/admin/pedidos/[id]/ResetQuoteClient.tsx
+++ b/src/app/admin/pedidos/[id]/ResetQuoteClient.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  orderId: string;
+};
+
+const CONFIRM_PREFIX = "RESET COTIZACION ";
+
+export default function ResetQuoteClient({ orderId }: Props) {
+  const router = useRouter();
+  const [confirmText, setConfirmText] = useState("");
+  const [force, setForce] = useState(false);
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const expectedConfirm = CONFIRM_PREFIX + orderId;
+  const confirmValid = confirmText.trim() === expectedConfirm;
+  const reasonValid = !force || reason.trim().length >= 5;
+  const canSubmit = confirmValid && reasonValid;
+
+  const handleReset = async () => {
+    if (!canSubmit) return;
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const res = await fetch(`/api/admin/orders/${orderId}/shipping/reset-quote`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          confirm: confirmText.trim(),
+          force: force || undefined,
+          reason: force ? reason.trim() : undefined,
+        }),
+      });
+      const data = await res.json();
+
+      if (!data.ok) {
+        if (data.code === "confirm_mismatch") {
+          setError("La confirmación no coincide. Escribe exactamente: RESET COTIZACION seguido del ID.");
+        } else if (data.code === "has_shipment") {
+          setError("No se puede resetear porque ya tiene guía. Activa FORZAR y escribe una razón.");
+        } else if (data.code === "force_requires_reason") {
+          setError("Si activas FORZAR, debes indicar una razón (mínimo 5 caracteres).");
+        } else {
+          setError(data.message || "Error al resetear cotización");
+        }
+        return;
+      }
+
+      setSuccess("Cotización reseteada. Puedes recotizar con la política actual (standard_box 25×20×15).");
+      setConfirmText("");
+      setReason("");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error de red");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="px-6 py-6 border-t border-amber-200 bg-amber-50/50">
+      <h2 className="text-lg font-semibold text-amber-900 mb-2">Reset cotización (Skydropx)</h2>
+      <p className="text-sm text-gray-700 mb-4">
+        Esto eliminará la cotización guardada para forzar recotización. No cancela guías ni borra tracking.
+      </p>
+
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm font-medium text-gray-700 mb-1">ID de la orden</p>
+          <p className="font-mono text-sm text-gray-900 break-all bg-white px-2 py-1 rounded border border-gray-200">
+            {orderId}
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="reset-quote-confirm" className="block text-sm font-medium text-gray-700 mb-1">
+            Escribe <strong>RESET COTIZACION</strong> seguido del ID para confirmar
+          </label>
+          <input
+            id="reset-quote-confirm"
+            type="text"
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            placeholder={`${CONFIRM_PREFIX}${orderId.slice(0, 8)}…`}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500 font-mono text-sm"
+            aria-label="Confirmación: RESET COTIZACION seguido del ID"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            id="reset-quote-force"
+            type="checkbox"
+            checked={force}
+            onChange={(e) => setForce(e.target.checked)}
+            className="rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+          />
+          <label htmlFor="reset-quote-force" className="text-sm text-gray-700">
+            FORZAR (aunque tenga guía)
+          </label>
+        </div>
+
+        {force && (
+          <div>
+            <label htmlFor="reset-quote-reason" className="block text-sm font-medium text-gray-700 mb-1">
+              Razón (obligatorio si FORZAR, mínimo 5 caracteres)
+            </label>
+            <input
+              id="reset-quote-reason"
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Ej: recotizar con dims actuales"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 text-sm"
+              minLength={5}
+            />
+          </div>
+        )}
+
+        {error && (
+          <div className="p-3 bg-red-100 border border-red-200 rounded-lg text-sm text-red-800">
+            {error}
+          </div>
+        )}
+
+        {success && (
+          <div className="p-3 bg-green-100 border border-green-200 rounded-lg text-sm text-green-800">
+            {success}
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={!canSubmit || loading}
+          className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {loading ? "Reseteando…" : "Reset cotización (Skydropx)"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -24,6 +24,7 @@ import { normalizePhoneToE164Mx } from "@/lib/utils/phone";
 import EditShippingOverrideClient from "./EditShippingOverrideClient";
 import ShippingTrackingDisplay from "./ShippingTrackingDisplay";
 import DeleteOrderClient from "./DeleteOrderClient";
+import ResetQuoteClient from "./ResetQuoteClient";
 import { getOrderShippingAddress } from "@/lib/shipping/getOrderShippingAddress";
 
 export const dynamic = "force-dynamic";
@@ -881,6 +882,9 @@ export default async function AdminPedidoDetailPage({
               </div>
             </div>
           )}
+
+        {/* Reset cotización Skydropx (forzar recotización con política actual) */}
+        <ResetQuoteClient orderId={order.id} />
 
         {/* Eliminar pedido (danger zone) */}
         <DeleteOrderClient orderId={order.id} />

--- a/src/app/api/admin/orders/[id]/shipping/reset-quote/route.ts
+++ b/src/app/api/admin/orders/[id]/shipping/reset-quote/route.ts
@@ -1,0 +1,275 @@
+/**
+ * POST /api/admin/orders/[id]/shipping/reset-quote
+ * Resetea cotización Skydropx de una orden: elimina quotation_id, rate_id, quoted_package, etc.
+ * para forzar recotización con política actual (standard_box 25×20×15 salvo override).
+ * No borra la orden ni tracking/label salvo que force=true (y se registra reason).
+ */
+
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { logPreWrite, logPostWrite } from "@/lib/shipping/metadataWriterLogger";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const EXPECTED_CONFIRM_PREFIX = "RESET COTIZACION ";
+
+type ResetQuoteBody = {
+  confirm?: string;
+  force?: boolean;
+  reason?: string;
+};
+
+type SuccessResponse = {
+  ok: true;
+  orderId: string;
+  reset: {
+    removed: {
+      quotation_id: boolean;
+      rate_id: boolean;
+      rate_used: boolean;
+      shipping_pricing: boolean;
+      quoted_package: boolean;
+    };
+    force: boolean;
+  };
+};
+
+type ErrorResponse = {
+  ok: false;
+  code: string;
+  message: string;
+};
+
+function isValidUUID(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+): Promise<NextResponse<SuccessResponse | ErrorResponse>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json(
+        { ok: false, code: "unauthorized", message: "Acceso denegado" },
+        { status: 403 },
+      );
+    }
+
+    const { id: orderId } = await context.params;
+    if (!orderId || !isValidUUID(orderId)) {
+      return NextResponse.json(
+        { ok: false, code: "invalid_id", message: "ID de orden inválido (debe ser UUID)" },
+        { status: 400 },
+      );
+    }
+
+    const body = (await req.json().catch(() => null)) as ResetQuoteBody | null;
+    if (!body || typeof body.confirm !== "string") {
+      return NextResponse.json(
+        { ok: false, code: "invalid_request", message: "confirm es requerido" },
+        { status: 400 },
+      );
+    }
+
+    const expectedConfirm = EXPECTED_CONFIRM_PREFIX + orderId;
+    if (body.confirm.trim() !== expectedConfirm) {
+      return NextResponse.json(
+        { ok: false, code: "confirm_mismatch", message: "La confirmación no coincide. Escribe exactamente: RESET COTIZACION seguido del ID de la orden." },
+        { status: 400 },
+      );
+    }
+
+    const force = Boolean(body.force);
+    const reason = typeof body.reason === "string" ? body.reason.trim() : undefined;
+    if (force && (!reason || reason.length < 5)) {
+      return NextResponse.json(
+        { ok: false, code: "force_requires_reason", message: "Si activas FORZAR, debes indicar una razón (mínimo 5 caracteres)." },
+        { status: 400 },
+      );
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceRoleKey) {
+      return NextResponse.json(
+        { ok: false, code: "config_error", message: "Configuración incompleta" },
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: order, error: fetchError } = await supabase
+      .from("orders")
+      .select("id, metadata, shipping_shipment_id, shipping_label_url, shipping_tracking_number, shipping_rate_ext_id, shipping_provider, shipping_service_name, shipping_price_cents")
+      .eq("id", orderId)
+      .single();
+
+    if (fetchError || !order) {
+      return NextResponse.json(
+        { ok: false, code: "order_not_found", message: "Orden no encontrada" },
+        { status: 404 },
+      );
+    }
+
+    const hasShipment =
+      Boolean((order as { shipping_shipment_id?: string | null }).shipping_shipment_id) ||
+      Boolean((order as { shipping_label_url?: string | null }).shipping_label_url) ||
+      Boolean((order as { shipping_tracking_number?: string | null }).shipping_tracking_number);
+
+    if (hasShipment && !force) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: "has_shipment",
+          message: "No se puede resetear porque ya tiene guía. Usa FORZAR con razón para permitir.",
+        },
+        { status: 409 },
+      );
+    }
+
+    const currentMetadata = ((order as { metadata?: Record<string, unknown> }).metadata as Record<string, unknown>) || {};
+    const currentShipping = (currentMetadata.shipping as Record<string, unknown>) || {};
+
+    const prevQuotationId = typeof currentShipping.quotation_id === "string" ? currentShipping.quotation_id : null;
+    const prevRateId =
+      typeof (currentShipping.rate as Record<string, unknown>)?.external_id === "string"
+        ? (currentShipping.rate as { external_id: string }).external_id
+        : typeof currentShipping.selected_rate_id === "string"
+          ? currentShipping.selected_rate_id
+          : null;
+    const hadRateUsed = currentShipping.rate_used != null && typeof currentShipping.rate_used === "object";
+    const hadShippingPricing = currentMetadata.shipping_pricing != null && typeof currentMetadata.shipping_pricing === "object";
+    const hadQuotedPackage = currentShipping.quoted_package != null && typeof currentShipping.quoted_package === "object";
+
+    const { data: freshOrder } = await supabase
+      .from("orders")
+      .select("metadata, updated_at")
+      .eq("id", orderId)
+      .single();
+
+    const freshMetadata = ((freshOrder as { metadata?: Record<string, unknown> } | null)?.metadata as Record<string, unknown>) || {};
+    const freshUpdatedAt = (freshOrder as { updated_at?: string } | null)?.updated_at;
+    const freshShipping = (freshMetadata.shipping as Record<string, unknown>) || {};
+
+    const quoteResetAudit = {
+      at: new Date().toISOString(),
+      by: "admin" as const,
+      reason: force ? reason ?? null : null,
+      force,
+      prev: {
+        quotation_id: prevQuotationId,
+        rate_id: prevRateId,
+        had_rate_used: hadRateUsed,
+        had_shipping_pricing: hadShippingPricing,
+      },
+    };
+
+    const newShipping: Record<string, unknown> = {
+      ...freshShipping,
+      quote_reset: quoteResetAudit,
+      quote_state: "reset",
+    };
+    delete newShipping.quotation_id;
+    delete newShipping.quotation_host_used;
+    delete newShipping.selected_rate_id;
+    delete newShipping.rate_id;
+    delete newShipping.rate;
+    delete newShipping.rate_used;
+    delete newShipping.quoted_package;
+    delete newShipping.last_quote_at;
+
+    const finalMetadata: Record<string, unknown> = {
+      ...freshMetadata,
+      shipping: newShipping,
+    };
+    const hadFreshShippingPricing = finalMetadata.shipping_pricing != null && typeof finalMetadata.shipping_pricing === "object";
+    if (hadFreshShippingPricing) {
+      delete finalMetadata.shipping_pricing;
+    }
+
+    const updatePayload: {
+      metadata: Record<string, unknown>;
+      updated_at: string;
+      shipping_rate_ext_id?: null;
+    } = {
+      metadata: finalMetadata,
+      updated_at: new Date().toISOString(),
+    };
+    if (prevRateId != null) {
+      updatePayload.shipping_rate_ext_id = null;
+    }
+
+    const sha = process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 7) || "unknown";
+
+    console.log("[admin/reset-quote] PRE-WRITE:", JSON.stringify({
+      routeName: "reset-quote",
+      orderId,
+      sha,
+      route: "POST /api/admin/orders/[id]/shipping/reset-quote",
+      force,
+      hasShipment,
+      prev: { quotation_id: !!prevQuotationId, rate_id: !!prevRateId, had_rate_used: hadRateUsed, had_shipping_pricing: hadShippingPricing, had_quoted_package: hadQuotedPackage },
+    }));
+
+    logPreWrite("reset-quote", orderId, freshMetadata, freshUpdatedAt, finalMetadata as Record<string, unknown>);
+
+    const { data: updated, error: updateError } = await supabase
+      .from("orders")
+      .update(updatePayload)
+      .eq("id", orderId)
+      .select("id, metadata, updated_at")
+      .single();
+
+    if (updateError) {
+      return NextResponse.json(
+        { ok: false, code: "update_failed", message: updateError.message },
+        { status: 500 },
+      );
+    }
+
+    const postMeta = ((updated as { metadata?: Record<string, unknown> }).metadata as Record<string, unknown>) || {};
+    const postUpdatedAt = (updated as { updated_at?: string }).updated_at;
+    logPostWrite("reset-quote", orderId, postMeta, postUpdatedAt);
+
+    console.log("[admin/reset-quote] POST-WRITE:", JSON.stringify({
+      routeName: "reset-quote",
+      orderId,
+      sha,
+      route: "POST /api/admin/orders/[id]/shipping/reset-quote",
+      force,
+      hasShipment,
+    }));
+
+    return NextResponse.json({
+      ok: true,
+      orderId,
+      reset: {
+        removed: {
+          quotation_id: !!prevQuotationId,
+          rate_id: !!prevRateId,
+          rate_used: hadRateUsed,
+          shipping_pricing: hadShippingPricing,
+          quoted_package: hadQuotedPackage,
+        },
+        force,
+      },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "unknown_error",
+        message: err instanceof Error ? err.message : "Error desconocido",
+      },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Qué se resetea y qué NO

**Se resetea (para forzar recotización con política actual):**
- `metadata.shipping`: `quotation_id`, `quotation_host_used`, `selected_rate_id`, `rate_id`, `rate`, `rate_used`, `quoted_package`, `last_quote_at`
- `metadata.shipping_pricing` (se elimina para forzar re-selección limpia)
- Columna `shipping_rate_ext_id` (se pone a null si existía rate)

**NO se borra:**
- `metadata.shipping.package_final` / override manual
- `metadata.shipping.manual_override`
- `shipping_shipment_id`, `shipping_label_url`, `shipping_tracking_number` (por defecto no se tocan; con FORZAR solo se permite la acción, no se limpian guías)

## Confirmación y FORZAR

- **Confirm:** El admin debe escribir exactamente `RESET COTIZACION <orderId>`. Si no coincide → 400.
- **FORZAR:** Si la orden ya tiene guía (shipment_id / label_url / tracking), sin FORZAR → 409. Con FORZAR + razón (mín. 5 caracteres) se permite el reset y se registra `reason` en `metadata.shipping.quote_reset`.

## Por qué evita reuse de cotizaciones viejas

Tras el reset, la orden queda sin `quotation_id` y sin `rate_id`. En el siguiente flujo (requote o create-label) no se reutilizará cotización antigua; se generará una nueva con la política actual (standard_box 25×20×15 salvo override). El guard rail en create-label ya evita reusar cuando `quoted_package` tiene dims distintas a 25×20×15; este reset permite “limpiar” la cotización guardada para que requote/create-label siempre partan de estado limpio.

## Audit trail

- `metadata.shipping.quote_reset`: `{ at, by: "admin", reason, force, prev: { quotation_id, rate_id, had_rate_used, had_shipping_pricing } }`
- `metadata.shipping.quote_state`: `"reset"`

## Archivos

- `POST /api/admin/orders/[id]/shipping/reset-quote`: endpoint con validación confirm/force, merge profundo, PRE/POST log
- `ResetQuoteClient.tsx`: UI en /admin/pedidos/[id] (antes de danger zone)
- `page.tsx`: import y uso de ResetQuoteClient
