### PR TITLE
fix(mobile): mobile-p0-fixes (overflow, zoom, tap targets, tienda)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,11 +108,12 @@ body {
   overscroll-behavior: contain;
 }
 
-/* Inputs: evitar zoom iOS elevando tipografía */
+/* Inputs: evitar zoom iOS elevando tipografía (>=16px evita zoom automático en iOS) */
 input,
 select,
 textarea {
   font-size: 16px;
+  max-width: 100%;
 }
 
 /* Utilidad para padding inferior respetando notch */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -280,7 +280,7 @@ export default function RootLayout({
             </nav>
           </HeaderWithScrollEffect>
 
-        <main className="max-w-6xl mx-auto p-4 flex-1 w-full pb-24 md:pb-safe overflow-x-hidden">
+        <main className="max-w-6xl mx-auto p-4 flex-1 w-full max-w-full pb-24 md:pb-safe overflow-x-clip box-border">
           {children}
           <FinalThanks />
         </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,7 +122,7 @@ export default async function HomePage() {
   const items = await getFeaturedItems();
 
   return (
-    <main className="min-h-screen overflow-x-hidden">
+    <div className="min-h-screen overflow-x-clip max-w-full">
       {/* Hero Section - Premium 2025 */}
       <section className="relative bg-gradient-to-br from-primary-600 via-primary-700 to-primary-800 text-white py-16 sm:py-24 md:py-32 px-4 overflow-hidden w-full -mx-4 md:mx-0">
         {/* Background decoration - más sutil y moderno */}
@@ -282,6 +282,6 @@ export default async function HomePage() {
       <div className="max-w-6xl mx-auto px-4 py-8 sm:py-12">
         <HelpWidget context="home" />
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -107,7 +107,7 @@ async function FeaturedItemsSection() {
 export default async function TiendaPage() {
 
   return (
-    <div className="bg-gray-50">
+    <div className="bg-gray-50 overflow-x-clip max-w-full">
       {/* Mini-hero con beneficios */}
       <div className="bg-gradient-to-br from-primary-600 via-primary-700 to-primary-800 text-white">
         <div className="max-w-7xl mx-auto px-4 pt-20 sm:pt-24 pb-10 sm:pb-16">

--- a/src/components/FeaturedCarousel.tsx
+++ b/src/components/FeaturedCarousel.tsx
@@ -7,8 +7,8 @@ export default function FeaturedCarousel({ items }: { items: FeaturedItem[] }) {
   if (!items?.length) return null;
 
   return (
-    <div className="w-full overflow-x-auto no-scrollbar py-3">
-      <div className="flex gap-4 min-w-max">
+    <div className="w-full max-w-full overflow-x-auto overflow-y-hidden no-scrollbar py-3">
+      <div className="flex gap-4 min-w-max max-w-max">
         {items.map((item, index) => (
           <div key={item.product_id} className="flex-shrink-0 w-64">
             <FeaturedCard

--- a/src/components/SearchInput.client.tsx
+++ b/src/components/SearchInput.client.tsx
@@ -71,7 +71,7 @@ export default function SearchInput({ sticky = false }: SearchInputProps) {
   };
 
   return (
-    <div className={sticky ? "sticky top-0 z-10 bg-white pb-2 pt-2 -mx-4 px-4 sm:static sm:pb-0 sm:pt-0 sm:mx-0 sm:px-0" : ""}>
+    <div className={sticky ? "sticky top-0 z-10 bg-white pb-2 pt-2 -mx-4 px-4 max-w-full overflow-x-hidden sm:static sm:pb-0 sm:pt-0 sm:mx-0 sm:px-0" : ""}>
       <form
         action="/buscar"
         method="GET"

--- a/src/components/catalog/SectionExplorer.tsx
+++ b/src/components/catalog/SectionExplorer.tsx
@@ -93,8 +93,8 @@ export default async function SectionExplorer({
       </div>
 
       {/* Mobile: carrusel horizontal con snap */}
-      <div className="lg:hidden">
-        <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 snap-x snap-mandatory no-scrollbar">
+      <div className="lg:hidden w-full max-w-full overflow-x-clip">
+        <div className="flex gap-4 overflow-x-auto overflow-y-hidden pb-4 -mx-4 px-4 snap-x snap-mandatory no-scrollbar">
           {displaySections.map((section) => {
             const Icon = getSectionIcon(section.slug);
             return (

--- a/src/components/marketing/TrustBanners.tsx
+++ b/src/components/marketing/TrustBanners.tsx
@@ -55,7 +55,7 @@ export function TrustBanners() {
       </div>
 
       {/* Mobile: Horizontal scroll */}
-      <div className="md:hidden overflow-x-auto snap-x snap-mandatory no-scrollbar -mx-4 px-4">
+      <div className="md:hidden w-full max-w-full overflow-x-auto overflow-y-hidden snap-x snap-mandatory no-scrollbar -mx-4 px-4">
         <div className="flex gap-4 w-max">
           {banners.map((banner) => {
             const Icon = banner.icon;

--- a/src/components/pdp/ProductGallery.client.tsx
+++ b/src/components/pdp/ProductGallery.client.tsx
@@ -143,7 +143,7 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
         {/* Thumbnails horizontales */}
         {displayImages.length > 1 && (
           <div className="w-full">
-            <div className="flex gap-2 overflow-x-auto pb-2 -mx-2 px-2 no-scrollbar">
+            <div className="w-full max-w-full flex gap-2 overflow-x-auto overflow-y-hidden pb-2 -mx-2 px-2 no-scrollbar">
               {displayImages.map((image, index) => {
                 const thumbUrl = normalizeImageUrl(image.url, 100);
                 return (

--- a/src/components/pdp/ProductGallery.tsx
+++ b/src/components/pdp/ProductGallery.tsx
@@ -167,7 +167,7 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
         {/* Miniaturas */}
         {displayImages.length > 1 && (
           <div className="w-full">
-            <div className="flex gap-2 overflow-x-auto pb-2 -mx-2 px-2">
+            <div className="w-full max-w-full flex gap-2 overflow-x-auto overflow-y-hidden pb-2 -mx-2 px-2">
               {displayImages.map((image, index) => (
                 <button
                   key={index}

--- a/src/components/pdp/RelatedProducts.tsx
+++ b/src/components/pdp/RelatedProducts.tsx
@@ -122,7 +122,7 @@ export default async function RelatedProducts({
 
       {/* Mobile: carrusel horizontal con snap */}
       <div className="lg:hidden">
-        <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 snap-x snap-mandatory no-scrollbar">
+        <div className="w-full max-w-full flex gap-4 overflow-x-auto overflow-y-hidden pb-4 -mx-4 px-4 snap-x snap-mandatory no-scrollbar">
           {productCards.map((product) => (
             <div
               key={product.id}


### PR DESCRIPTION
## Objetivo
Solo arreglos críticos de mobile: zoom raro, overflow-x, contenedores que se desbordan, spacing y tap targets. **NO** rediseño visual.

## Cambios realizados

### 1. Overflow horizontal
- **Layout:** `main` usa `overflow-x-clip` y `max-w-full box-border` para contener cualquier hijo con `-mx-*`.
- **Home:** Wrapper de página con `overflow-x-clip max-w-full`; hero mantiene `-mx-4 md:mx-0` pero queda contenido.
- **FeaturedCarousel:** Contenedor con `max-w-full overflow-y-hidden` para que el scroll horizontal no expanda la página.
- **TrustBanners (mobile):** `w-full max-w-full overflow-y-hidden` en el scroll container.
- **SectionExplorer (mobile):** Wrapper `w-full max-w-full overflow-x-clip` y scroll con `overflow-y-hidden`.
- **RelatedProducts, ProductGallery (ambos):** `w-full max-w-full overflow-y-hidden` en los carruseles.
- **SearchInput (sticky):** `max-w-full overflow-x-hidden` en el contenedor sticky.

### 2. Zoom
- **globals.css:** Inputs ya tenían `font-size: 16px`; se añade `max-width: 100%` para evitar que inputs anchos fuercen overflow. Sin `maximumScale` ni `userScalable=false` en viewport.

### 3. Tap targets y nav
- **Layout:** `main` ya tenía `pb-24 md:pb-safe`; se mantiene. Se añade `overflow-x-clip` y `max-w-full` para contención.
- Sin cambios en botones flotantes (WhatsApp/Cart); si en QA se detecta que tapan CTAs, se puede ajustar offset en un PR posterior.

### 4. Tienda
- **Contención:** Página tienda con `overflow-x-clip max-w-full` en el root para que carruseles con `-mx-4` no generen scroll horizontal.
- **Duplicación:** No se encontró doble inclusión de componentes en el código (TrustBanners, SectionExplorer, QuickSearchBar y FeaturedItemsSection se renderizan una vez cada uno). Si en dispositivo se siguen viendo bloques duplicados, puede deberse a responsive (desktop + mobile a la vez por breakpoint) o a cache; revisar en dev tools.

## Archivos tocados
| Archivo | Por qué |
|--------|--------|
| `src/app/globals.css` | Inputs: `max-width: 100%` para evitar overflow; comentario sobre 16px y zoom iOS. |
| `src/app/layout.tsx` | `main`: `overflow-x-clip`, `max-w-full`, `box-border`. |
| `src/app/page.tsx` | Wrapper con `overflow-x-clip max-w-full`; cierre `</main>` → `</div>` (evitar main anidado). |
| `src/app/tienda/page.tsx` | Root con `overflow-x-clip max-w-full`. |
| `src/components/FeaturedCarousel.tsx` | Contenedor `max-w-full overflow-y-hidden`. |
| `src/components/SearchInput.client.tsx` | Sticky: `max-w-full overflow-x-hidden`. |
| `src/components/catalog/SectionExplorer.tsx` | Mobile: wrapper `overflow-x-clip`, scroll `overflow-y-hidden`. |
| `src/components/marketing/TrustBanners.tsx` | Mobile scroll: `w-full max-w-full overflow-y-hidden`. |
| `src/components/pdp/ProductGallery.client.tsx` | Thumbnails: `w-full max-w-full overflow-y-hidden`. |
| `src/components/pdp/ProductGallery.tsx` | Idem. |
| `src/components/pdp/RelatedProducts.tsx` | Carrusel: `w-full max-w-full overflow-y-hidden`. |

## QA manual
1. **Home en mobile:** Abrir / en viewport ~375px. Comprobar que no hay scroll horizontal; hero y carruseles contenidos.
2. **Tienda en mobile:** Abrir /tienda en viewport ~375px. Comprobar que no hay scroll horizontal; Trust Banners y Section Explorer con scroll interno solo.
3. **Zoom:** En iOS, enfocar un input y comprobar que no se dispara zoom raro (inputs siguen en 16px).
4. **Final de listas:** Scroll hasta abajo en Home y Tienda; comprobar que el contenido no queda tapado por la nav inferior (pb-24).

## Reglas respetadas
- No se tocó lógica de negocio (checkout, shipping, stripe, skydropx, admin).
- No se cambiaron rutas, contratos de API ni data fetching.
- No se deshabilitó zoom de usuario (sin maximumScale ni userScalable=false).
- Cambios pequeños, seguros y compilables.
