### PR TITLE
ui(catalog): polish cards, grids & search (mobile-friendly)

### DIFF
--- a/docs/PR-catalog-ui-polish.md
+++ b/docs/PR-catalog-ui-polish.md
@@ -1,0 +1,65 @@
+# PR: ui/catalog-ui-polish
+
+## Objetivo
+Mejorar UI del catálogo (/tienda), búsqueda (/buscar) y cards. Solo UI/UX; sin cambios en endpoints ni lógica de queries.
+
+## Cambios realizados
+
+### 1) ProductCard (`src/components/catalog/ProductCard.tsx`)
+- **Card**: padding `p-3` → `p-4`; sombra `hover:shadow-xl` → `hover:shadow-md`; añadido `min-w-0` para evitar overflow.
+- **Título**: ya tenía `line-clamp-2 min-h-[2.5rem]`; sin cambios.
+- **Controles**: layout `flex flex-col sm:flex-row gap-2` para que en mobile el botón sea full width debajo del quantity.
+- **Botones**: CTA principal y enlace WhatsApp con `min-h-[44px]`; botón principal `w-full sm:flex-1` (full width en mobile).
+
+### 2) Grid
+- **Catálogo sección** (`src/app/catalogo/[section]/page.tsx`): grid `gap-6` → `gap-4`; breakpoints `sm:2 lg:3 xl:4` → `sm:2 md:3 lg:4`; añadido `min-w-0`.
+- **Búsqueda** (`src/app/buscar/page.tsx`): grid con `min-w-0`; cada item con `className="min-w-0"`.
+- **FeaturedGrid** (`src/components/FeaturedGrid.tsx`): grid `grid-cols-2 md:grid-cols-4` → `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-w-0`; wrapper de cada card con `min-w-0`.
+- **ProductsGridSkeleton** (`src/components/products/ProductsGridSkeleton.tsx`): `grid-cols-2` → `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4`; añadido `min-w-0`.
+
+### 3) Búsqueda
+- **SearchAutocomplete** (`src/components/search/SearchAutocomplete.client.tsx`): input con `focus:ring-offset-2` para foco más visible.
+- **HeaderSearchBar** (`src/components/header/HeaderSearchBar.client.tsx`): wrapper con `min-w-0` y `role="search"`.
+- **HeaderSearchMobile** (`src/components/header/HeaderSearchMobile.client.tsx`): botón abrir/cerrar con `min-h-[44px] min-w-[44px] inline-flex items-center justify-center` (área táctil 44px).
+- **Empty state** (`src/app/buscar/page.tsx`): card de “no resultados” con `role="status" aria-live="polite"`.
+- **Skeleton**: `buscar/loading.tsx` ya usa `ProductsGridSkeleton`; grid del skeleton alineado a 1/2/3/4 columnas.
+
+## Archivos tocados
+
+| Archivo | Cambio |
+|--------|--------|
+| `src/components/catalog/ProductCard.tsx` | Padding, sombra, min-w-0, layout controles, min-h-[44px] y full width mobile en botones |
+| `src/app/catalogo/[section]/page.tsx` | Grid gap-4, breakpoints md:3, min-w-0 |
+| `src/app/buscar/page.tsx` | Grid min-w-0, item min-w-0, empty state role/aria-live |
+| `src/components/products/ProductsGridSkeleton.tsx` | Grid 1/2/3/4 cols, min-w-0 |
+| `src/components/search/SearchAutocomplete.client.tsx` | Input focus:ring-offset-2 |
+| `src/components/header/HeaderSearchBar.client.tsx` | min-w-0, role="search" |
+| `src/components/header/HeaderSearchMobile.client.tsx` | Botones min-h/min-w 44px |
+| `src/components/FeaturedGrid.tsx` | Grid 1/2/3/4 cols, min-w-0, item min-w-0 |
+
+## QA manual
+
+### /tienda (mobile + desktop)
+- [ ] Productos destacados en grid 1 col mobile, 2/3/4 en sm/md/lg.
+- [ ] Cards con padding consistente; títulos largos con line-clamp (2 líneas).
+- [ ] Botón “Agregar” / “Elegir opciones” full width en mobile y min-h 44px.
+- [ ] Enlace WhatsApp full width y min-h 44px.
+- [ ] Sin overflow horizontal.
+
+### /buscar (mobile + desktop)
+- [ ] Input de búsqueda con foco visible (ring + offset).
+- [ ] Resultados en grid 1/2/3/4; sin overflow.
+- [ ] Empty state se ve bien y anuncia “no resultados” (role/aria-live).
+- [ ] Loading muestra skeleton con mismo grid 1/2/3/4.
+
+### Catálogo por sección (ej. /catalogo/consumibles)
+- [ ] Grid 1/2/3/4 con gap-4; sin overflow.
+- [ ] Cards alineadas; precio y badges visibles.
+
+### Header búsqueda
+- [ ] Desktop: barra de búsqueda con buen tamaño y foco.
+- [ ] Mobile: botón de búsqueda con área táctil ≥44px; panel con input y botón cerrar ≥44px.
+
+## Rama
+
+- `ui/catalog-ui-polish`

--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -273,7 +273,7 @@ export default async function BuscarPage({ searchParams }: Props) {
 
       {items.length === 0 && (
         <>
-          <div className="bg-card rounded-xl border border-border p-8 sm:p-12 text-center max-w-2xl mx-auto shadow-sm">
+          <div className="bg-card rounded-xl border border-border p-8 sm:p-12 text-center max-w-2xl mx-auto shadow-sm" role="status" aria-live="polite">
             <div className="w-20 h-20 mx-auto rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center mb-6">
               <AlertCircle className="w-10 h-10 text-primary-600 dark:text-primary-400" aria-hidden="true" />
             </div>
@@ -364,10 +364,11 @@ export default async function BuscarPage({ searchParams }: Props) {
 
       {items.length > 0 && (
         <>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-w-0">
             {items.map((it, index) => (
               <div
                 key={it.id}
+                className="min-w-0"
                 style={{ "--delay": `${index * 50}ms` } as React.CSSProperties}
               >
                 <SearchResultCard

--- a/src/app/catalogo/[section]/page.tsx
+++ b/src/app/catalogo/[section]/page.tsx
@@ -283,7 +283,7 @@ export default async function CatalogoSectionPage({ params, searchParams }: Prop
           </div>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-w-0">
           {products.map((product, idx) => {
             // Usar ProductCard canónico
             return (

--- a/src/components/FeaturedGrid.tsx
+++ b/src/components/FeaturedGrid.tsx
@@ -72,10 +72,11 @@ export default function FeaturedGrid({
   };
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-w-0">
       {items.map((item, index) => (
         <div
           key={item.product_id}
+          className="min-w-0"
           onClick={() => handleProductClick(item, index + 1)}
           style={{ "--delay": `${index * 50}ms` } as React.CSSProperties}
         >

--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -194,7 +194,7 @@ export default function ProductCard({
 
   return (
     <div 
-      className="rounded-2xl border border-gray-200 dark:border-gray-700 p-3 flex flex-col bg-white dark:bg-gray-800 shadow-sm hover:shadow-xl transition-all duration-300 ease-out hover:-translate-y-1 active:scale-[0.98] group"
+      className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 flex flex-col bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition-all duration-300 ease-out hover:-translate-y-0.5 active:scale-[0.98] group min-w-0"
       style={{
         animation: "fadeInUp 0.5s ease-out backwards",
         animationDelay: "var(--delay, 0ms)",
@@ -276,20 +276,22 @@ export default function ProductCard({
       </div>
 
       {/* Controles: cantidad y agregar al carrito */}
-      <div className="mt-auto pt-2 space-y-2">
+      <div className="mt-auto pt-3 space-y-2">
         {canPurchase ? (
           <>
-            <div className="flex items-center gap-2">
-              <QuantityInput
-                value={qty}
-                onChange={handleQtyChange}
-                min={1}
-                max={99}
-                disabled={isAdding}
-                compact={compact}
-                ariaLabel="Cantidad del producto"
-              />
-              {/* CTA Primario: Agregar al carrito o Elegir opciones */}
+            <div className="flex flex-col sm:flex-row gap-2">
+              <div className="flex items-center gap-2">
+                <QuantityInput
+                  value={qty}
+                  onChange={handleQtyChange}
+                  min={1}
+                  max={99}
+                  disabled={isAdding}
+                  compact={compact}
+                  ariaLabel="Cantidad del producto"
+                />
+              </div>
+              {/* CTA Primario: Agregar al carrito o Elegir opciones - full width en mobile, min-h tap target */}
               <button
                 type="button"
                 onClick={handleAddToCart}
@@ -304,7 +306,7 @@ export default function ProductCard({
                   kind: "button",
                   enabled: microAnimsEnabled,
                   reducedMotion: prefersReducedMotion,
-                  className: `flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-sm bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-all duration-200 font-semibold shadow-md ${
+                  className: `w-full sm:flex-1 flex items-center justify-center gap-2 min-h-[44px] px-3 py-2.5 rounded-lg text-sm bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-all duration-200 font-semibold shadow-md ${
                     isAdding 
                       ? "scale-95 bg-primary-700" 
                       : microAnimsEnabled ? "" : "hover:scale-[1.02] active:scale-[0.98] hover:shadow-lg"
@@ -374,7 +376,7 @@ export default function ProductCard({
                 title,
               });
             }}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm bg-emerald-500 text-white hover:bg-emerald-600 transition-colors font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+            className="w-full flex items-center justify-center gap-2 min-h-[44px] px-3 py-2.5 rounded-lg text-sm bg-emerald-500 text-white hover:bg-emerald-600 transition-colors font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
             aria-label={`Consultar ${title} por WhatsApp`}
           >
             <svg

--- a/src/components/header/HeaderSearchBar.client.tsx
+++ b/src/components/header/HeaderSearchBar.client.tsx
@@ -17,7 +17,7 @@ export default function HeaderSearchBar({ className = "" }: HeaderSearchBarProps
   };
 
   return (
-    <div className={`flex-1 max-w-md ${className}`}>
+    <div className={`flex-1 max-w-md min-w-0 ${className}`} role="search">
       <SearchAutocomplete
         placeholder="Buscar guantes, brackets, resinas…"
         onSearch={handleSearch}

--- a/src/components/header/HeaderSearchMobile.client.tsx
+++ b/src/components/header/HeaderSearchMobile.client.tsx
@@ -80,7 +80,7 @@ export default function HeaderSearchMobile() {
         type="button"
         onClick={() => setIsOpen(true)}
         aria-label="Abrir búsqueda"
-        className="md:hidden p-2 text-foreground hover:text-primary-600 dark:hover:text-primary-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg"
+        className="md:hidden p-2 min-h-[44px] min-w-[44px] inline-flex items-center justify-center text-foreground hover:text-primary-600 dark:hover:text-primary-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg"
       >
         <Search size={20} aria-hidden="true" />
       </button>
@@ -111,7 +111,7 @@ export default function HeaderSearchMobile() {
                   type="button"
                   onClick={() => setIsOpen(false)}
                   aria-label="Cerrar búsqueda"
-                  className="p-2 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg"
+                  className="p-2 min-h-[44px] min-w-[44px] inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg"
                 >
                   <X size={20} aria-hidden="true" />
                 </button>

--- a/src/components/products/ProductsGridSkeleton.tsx
+++ b/src/components/products/ProductsGridSkeleton.tsx
@@ -8,7 +8,7 @@ export default function ProductsGridSkeleton({
   count = 8,
 }: ProductsGridSkeletonProps) {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-w-0">
       {Array.from({ length: count }).map((_, index) => (
         <ProductCardSkeleton key={index} />
       ))}

--- a/src/components/search/SearchAutocomplete.client.tsx
+++ b/src/components/search/SearchAutocomplete.client.tsx
@@ -317,7 +317,7 @@ export default function SearchAutocomplete({
           aria-activedescendant={
             activeIndex >= 0 ? `suggestion-${activeIndex}` : undefined
           }
-          className={`w-full min-h-[44px] pl-10 pr-10 py-3 border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all ${inputClassName}`}
+          className={`w-full min-h-[44px] pl-10 pr-10 py-3 border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:border-transparent transition-all ${inputClassName}`}
         />
         {/* Voice search button */}
         {voiceSupported && (


### PR DESCRIPTION
# PR: ui/catalog-ui-polish

## Objetivo
Mejorar UI del catálogo (/tienda), búsqueda (/buscar) y cards. Solo UI/UX; sin cambios en endpoints ni lógica de queries.

## Cambios realizados

### 1) ProductCard (`src/components/catalog/ProductCard.tsx`)
- **Card**: padding `p-3` → `p-4`; sombra `hover:shadow-xl` → `hover:shadow-md`; añadido `min-w-0` para evitar overflow.
- **Título**: ya tenía `line-clamp-2 min-h-[2.5rem]`; sin cambios.
- **Controles**: layout `flex flex-col sm:flex-row gap-2` para que en mobile el botón sea full width debajo del quantity.
- **Botones**: CTA principal y enlace WhatsApp con `min-h-[44px]`; botón principal `w-full sm:flex-1` (full width en mobile).

### 2) Grid
- **Catálogo sección** (`src/app/catalogo/[section]/page.tsx`): grid `gap-6` → `gap-4`; breakpoints `sm:2 lg:3 xl:4` → `sm:2 md:3 lg:4`; añadido `min-w-0`.
- **Búsqueda** (`src/app/buscar/page.tsx`): grid con `min-w-0`; cada item con `className="min-w-0"`.
- **FeaturedGrid** (`src/components/FeaturedGrid.tsx`): grid `grid-cols-2 md:grid-cols-4` → `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 min-w-0`; wrapper de cada card con `min-w-0`.
- **ProductsGridSkeleton** (`src/components/products/ProductsGridSkeleton.tsx`): `grid-cols-2` → `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4`; añadido `min-w-0`.

### 3) Búsqueda
- **SearchAutocomplete** (`src/components/search/SearchAutocomplete.client.tsx`): input con `focus:ring-offset-2` para foco más visible.
- **HeaderSearchBar** (`src/components/header/HeaderSearchBar.client.tsx`): wrapper con `min-w-0` y `role="search"`.
- **HeaderSearchMobile** (`src/components/header/HeaderSearchMobile.client.tsx`): botón abrir/cerrar con `min-h-[44px] min-w-[44px] inline-flex items-center justify-center` (área táctil 44px).
- **Empty state** (`src/app/buscar/page.tsx`): card de “no resultados” con `role="status" aria-live="polite"`.
- **Skeleton**: `buscar/loading.tsx` ya usa `ProductsGridSkeleton`; grid del skeleton alineado a 1/2/3/4 columnas.

## Archivos tocados

| Archivo | Cambio |
|--------|--------|
| `src/components/catalog/ProductCard.tsx` | Padding, sombra, min-w-0, layout controles, min-h-[44px] y full width mobile en botones |
| `src/app/catalogo/[section]/page.tsx` | Grid gap-4, breakpoints md:3, min-w-0 |
| `src/app/buscar/page.tsx` | Grid min-w-0, item min-w-0, empty state role/aria-live |
| `src/components/products/ProductsGridSkeleton.tsx` | Grid 1/2/3/4 cols, min-w-0 |
| `src/components/search/SearchAutocomplete.client.tsx` | Input focus:ring-offset-2 |
| `src/components/header/HeaderSearchBar.client.tsx` | min-w-0, role="search" |
| `src/components/header/HeaderSearchMobile.client.tsx` | Botones min-h/min-w 44px |
| `src/components/FeaturedGrid.tsx` | Grid 1/2/3/4 cols, min-w-0, item min-w-0 |

## QA manual

### /tienda (mobile + desktop)
- [ ] Productos destacados en grid 1 col mobile, 2/3/4 en sm/md/lg.
- [ ] Cards con padding consistente; títulos largos con line-clamp (2 líneas).
- [ ] Botón “Agregar” / “Elegir opciones” full width en mobile y min-h 44px.
- [ ] Enlace WhatsApp full width y min-h 44px.
- [ ] Sin overflow horizontal.

### /buscar (mobile + desktop)
- [ ] Input de búsqueda con foco visible (ring + offset).
- [ ] Resultados en grid 1/2/3/4; sin overflow.
- [ ] Empty state se ve bien y anuncia “no resultados” (role/aria-live).
- [ ] Loading muestra skeleton con mismo grid 1/2/3/4.

### Catálogo por sección (ej. /catalogo/consumibles)
- [ ] Grid 1/2/3/4 con gap-4; sin overflow.
- [ ] Cards alineadas; precio y badges visibles.

### Header búsqueda
- [ ] Desktop: barra de búsqueda con buen tamaño y foco.
- [ ] Mobile: botón de búsqueda con área táctil ≥44px; panel con input y botón cerrar ≥44px.

## Rama

- `ui/catalog-ui-polish`
