### PR TITLE
ui: pdp premium micro pass

### DIFF
--- a/docs/PR-pdp-premium-micro.md
+++ b/docs/PR-pdp-premium-micro.md
@@ -1,0 +1,69 @@
+# PR: PDP premium micro pass
+
+**Branch:** `ui/pdp-premium-micro`  
+**Título PR:** ui: pdp premium micro pass  
+**Objetivo:** Subir la calidad “premium heritage” en PDP (`/catalogo/[section]/[slug]`) con microinteracciones sutiles. Solo UI; sin tocar lógica de negocio, data fetching, add-to-cart, Supabase/Stripe/Skydropx, admin ni endpoints.
+
+---
+
+## Alcance
+
+- **Jerarquía PDP:** Título con `leading-tight` y `line-clamp-4` para títulos largos; precio con `tracking-tight`; sección/categoría y stock en `text-stone-600`; espaciado y `min-w-0` en contenedor del título.
+- **Gallery premium:** Contenedor con borde `border-stone-200/90`, `rounded-xl`, sombra suave; imagen principal con transición suave en desktop: hover `scale-[1.02]` (200ms, ease-out); mobile sin hover; thumbnails con `focus-premium` y bordes stone. Respeta `prefers-reduced-motion` (sin scale en hover cuando reduce).
+- **CTA pulse:** Botones “Agregar al carrito” y “Comprar ahora” (ProductActions) y sticky CTA (PdpStickyCTA): estado local `pulse` que aplica clase `cta-pulse-active` durante 180ms al click; clase global `.cta-pulse` con `scale(0.98)`; desactivado bajo `prefers-reduced-motion`. No se modificó la lógica de los handlers.
+- **CTA feedback:** `focus-premium`, `tap-feedback`, `min-h-[44px]` en CTAs principales y enlace WhatsApp (ProductActions y PdpStickyCTA).
+- **Related products:** Sección con borde `border-stone-200/80`; heading con `tracking-tight`; texto secundario `text-stone-600`; link “Ver más de esta categoría” con tap target ≥44px y `focus-premium` / `tap-feedback`. Las cards usan `ProductCard` (ya tiene pills, hover-lift, tap-feedback).
+- **globals.css:** Nueva clase `.cta-pulse` / `.cta-pulse-active` para el pulse visual; override en `prefers-reduced-motion` para no aplicar transform.
+
+**No se tocó:** lógica de checkout/admin/shipping/pagos/endpoints ni rutas/contratos. No se modificó add-to-cart, store, APIs ni data fetching.
+
+---
+
+## Archivos tocados
+
+| Archivo | Cambios |
+|---------|---------|
+| `src/app/globals.css` | Clases `.cta-pulse` / `.cta-pulse-active` y override reduced motion. |
+| `src/app/catalogo/[section]/[slug]/page.tsx` | Jerarquía: título (leading-tight, line-clamp-4, min-w-0), precio (tracking-tight), texto stone. Solo clases. |
+| `src/components/pdp/ProductGallery.client.tsx` | Borde/sombra heritage (stone), rounded-xl, hover scale 1.02 solo desktop y sin reduced motion; focus-premium en thumbnails y botón imagen. |
+| `src/components/product/ProductActions.client.tsx` | Pulse al click (180ms) en Agregar al carrito y Comprar ahora; focus-premium, tap-feedback, min-h-[44px]; WhatsApp link con focus-premium tap-feedback. |
+| `src/components/pdp/PdpStickyCTA.client.tsx` | Pulse al click en Agregar al carrito; focus-premium y tap-feedback en Link y button. |
+| `src/components/pdp/RelatedProducts.tsx` | Borde stone en sección; heading y texto stone; link “Ver más” con tap target y focus-premium/tap-feedback. |
+| `docs/PR-pdp-premium-micro.md` | Este documento. |
+
+---
+
+## QA manual obligatorio
+
+### Desktop (1440 y 1280)
+
+- [ ] Abrir 2 PDPs con títulos largos: jerarquía clara (título, precio, stock, CTA); título no rompe layout (line-clamp si aplica).
+- [ ] Gallery: borde y sombra sutiles; hover sobre imagen principal produce scale muy leve (1.02) sin marear; thumbnails con foco premium.
+- [ ] CTA “Agregar al carrito” y “Comprar ahora”: al hacer click, pulse breve (scale 0.98) ~180ms; foco con anillo premium.
+- [ ] Related products: grid/carrusel legible; cards con hover-lift; link “Ver más de esta categoría” con foco premium.
+
+### Mobile (390x844 y 360x800)
+
+- [ ] Mismo PDP: jerarquía legible; sin overflow horizontal.
+- [ ] Gallery: sin hover (solo estado normal); tap en imagen/thumbnails correcto.
+- [ ] CTAs con tap target ≥44px; tap feedback al tocar.
+- [ ] Sticky CTA: pulse al tocar “Agregar al carrito”; WhatsApp y botón con tap target OK.
+- [ ] Related: carrusel con snap; tap targets OK.
+
+### Reduced motion
+
+- [ ] Activar `prefers-reduced-motion: reduce` y recargar PDP. Verificar: gallery sin scale en hover; CTA sin pulse (solo tap-feedback normal si aplica); contenido visible y usable.
+
+### Contenido y lógica
+
+- [ ] Confirmar que no se cambió copy crítico ni flujos de add-to-cart/checkout.
+- [ ] Confirmación explícita: **No se tocó lógica de checkout/admin/shipping/pagos/endpoints ni rutas/contratos.**
+
+---
+
+## Validación
+
+```bash
+pnpm lint
+pnpm build
+```

--- a/src/app/catalogo/[section]/[slug]/page.tsx
+++ b/src/app/catalogo/[section]/[slug]/page.tsx
@@ -209,15 +209,15 @@ export default async function ProductDetailPage({ params }: Props) {
               />
             </div>
 
-            {/* Información del producto */}
+            {/* Información del producto — jerarquía premium */}
             <div className="space-y-4 sm:space-y-6">
               <div>
                 <div className="flex items-start justify-between gap-4 mb-2">
-                  <div className="flex-1">
-                    <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
+                  <div className="flex-1 min-w-0">
+                    <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 dark:text-white mb-2 leading-tight line-clamp-4">
                       {product.title}
                     </h1>
-                    <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 capitalize">
+                    <p className="text-base sm:text-lg text-stone-600 dark:text-gray-400 capitalize">
                       {product.section.replace(/-/g, " ")}
                     </p>
                   </div>
@@ -226,12 +226,12 @@ export default async function ProductDetailPage({ params }: Props) {
                 </div>
               </div>
 
-              {/* Precio y disponibilidad */}
+              {/* Precio y disponibilidad — jerarquía fuerte */}
               <div className="space-y-2">
-                <div className="text-4xl sm:text-5xl font-bold text-primary-600 dark:text-primary-400">
+                <div className="text-4xl sm:text-5xl font-bold tracking-tight text-primary-600 dark:text-primary-400">
                   {price}
                 </div>
-                <div className="flex items-center space-x-2 flex-wrap gap-2">
+                <div className="flex items-center flex-wrap gap-2">
                   {product.in_stock !== null &&
                     product.in_stock !== undefined && (
                       <span
@@ -243,7 +243,7 @@ export default async function ProductDetailPage({ params }: Props) {
                       </span>
                     )}
                   {product.in_stock && (
-                    <span className="text-sm text-gray-600 dark:text-gray-400">
+                    <span className="text-sm text-stone-600 dark:text-gray-400">
                       Lista para envío inmediato
                     </span>
                   )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -194,6 +194,13 @@ textarea {
   .tap-feedback:active {
     transform: scale(0.98);
   }
+  /* CTA pulse: breve scale al click (160–200ms); no usar con reduced motion */
+  .cta-pulse {
+    transition: transform var(--motion-med) var(--motion-ease);
+  }
+  .cta-pulse.cta-pulse-active {
+    transform: scale(0.98);
+  }
   .focus-premium {
     outline: none;
   }
@@ -231,6 +238,9 @@ textarea {
       transform: none;
     }
     .tap-feedback:active {
+      transform: none;
+    }
+    .cta-pulse.cta-pulse-active {
       transform: none;
     }
   .shimmer-silk {

--- a/src/components/pdp/PdpStickyCTA.client.tsx
+++ b/src/components/pdp/PdpStickyCTA.client.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Link from "next/link";
 import { ShoppingCart, MessageCircle } from "lucide-react";
 import { useCartStore } from "@/lib/store/cartStore";
 import { getWhatsAppProductUrl } from "@/lib/whatsapp/config";
 import { mxnFromCents } from "@/lib/utils/currency";
+
+const PULSE_MS = 180;
 
 type PdpStickyCTAProps = {
   product: {
@@ -21,10 +23,10 @@ type PdpStickyCTAProps = {
 
 export default function PdpStickyCTA({ product }: PdpStickyCTAProps) {
   const addToCart = useCartStore((state) => state.addToCart);
-  const [isAdding, setIsAdding] = React.useState(false);
+  const [isAdding, setIsAdding] = useState(false);
+  const [pulse, setPulse] = useState(false);
 
   const handleAddToCart = () => {
-    setIsAdding(true);
     addToCart({
       id: product.id,
       title: product.title,
@@ -33,6 +35,9 @@ export default function PdpStickyCTA({ product }: PdpStickyCTAProps) {
       image_url: product.image_url,
       selected: true,
     });
+    setIsAdding(true);
+    setPulse(true);
+    setTimeout(() => setPulse(false), PULSE_MS);
     setTimeout(() => setIsAdding(false), 1000);
   };
 
@@ -54,7 +59,7 @@ export default function PdpStickyCTA({ product }: PdpStickyCTAProps) {
             href={whatsappUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex-shrink-0 px-4 py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors duration-200 flex items-center justify-center gap-2 min-h-[44px] focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 active:scale-95"
+            className="flex-shrink-0 px-4 py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors duration-200 flex items-center justify-center gap-2 min-h-[44px] font-medium focus-premium tap-feedback"
             aria-label="Contactar por WhatsApp"
           >
             <MessageCircle size={20} />
@@ -64,7 +69,7 @@ export default function PdpStickyCTA({ product }: PdpStickyCTAProps) {
         <button
           onClick={handleAddToCart}
           disabled={!canBuy || isAdding}
-          className="flex-1 px-4 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200 flex items-center justify-center gap-2 min-h-[44px] font-medium focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 active:scale-95"
+          className={`cta-pulse focus-premium tap-feedback flex-1 px-4 py-3 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200 flex items-center justify-center gap-2 min-h-[44px] font-medium ${pulse ? "cta-pulse-active" : ""}`}
           aria-label="Agregar al carrito"
         >
           <ShoppingCart size={20} />

--- a/src/components/pdp/ProductGallery.client.tsx
+++ b/src/components/pdp/ProductGallery.client.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { ZoomIn } from "lucide-react";
 import { normalizeImageUrl } from "@/lib/img/normalizeImageUrl";
 import ProductLightbox from "./ProductLightbox.client";
+import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
 
 type ProductImage = {
   url: string;
@@ -20,6 +21,7 @@ type Props = {
 export default function ProductGallery({ images, title, fallbackImage }: Props) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   // Si no hay imágenes, usar fallback
   const displayImages =
@@ -27,7 +29,7 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
 
   if (displayImages.length === 0) {
     return (
-      <div className="relative w-full aspect-square bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden">
+      <div className="relative w-full aspect-square bg-white dark:bg-gray-800 rounded-xl overflow-hidden border border-stone-200/90 dark:border-gray-700 shadow-sm">
         <div className="w-full h-full flex items-center justify-center text-gray-400 dark:text-gray-500">
           Sin imagen
         </div>
@@ -47,6 +49,10 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
   const normalizedUrl = normalizeImageUrl(currentImage.url, 800);
   const lightboxImages = displayImages.map((img) => img.url);
 
+  const imageScaleClass = !prefersReducedMotion
+    ? "transition-transform duration-200 ease-out lg:group-hover:scale-[1.02]"
+    : "";
+
   return (
     <div className="space-y-4">
       {/* Desktop: Layout con thumbnails verticales */}
@@ -61,10 +67,10 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
                   key={index}
                   type="button"
                   onClick={() => handleThumbnailClick(index)}
-                  className={`relative w-20 h-20 rounded-lg overflow-hidden border-2 transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 flex-shrink-0 ${
+                  className={`relative w-20 h-20 rounded-lg overflow-hidden border-2 transition-all focus-premium flex-shrink-0 ${
                     selectedIndex === index
                       ? "border-primary-600 dark:border-primary-400 ring-2 ring-primary-200 dark:ring-primary-800"
-                      : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                      : "border-stone-200 dark:border-gray-700 hover:border-stone-300 dark:hover:border-gray-600"
                   }`}
                   aria-label={`Ver imagen ${index + 1} de ${displayImages.length}`}
                   aria-pressed={selectedIndex === index}
@@ -84,12 +90,12 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
           </div>
         )}
 
-        {/* Imagen principal */}
-        <div className="relative flex-1 aspect-square bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-sm group cursor-pointer">
+        {/* Imagen principal: borde/sombra heritage, hover scale solo desktop y sin reduced motion */}
+        <div className="relative flex-1 aspect-square bg-white dark:bg-gray-800 rounded-xl overflow-hidden border border-stone-200/90 dark:border-gray-700 shadow-sm group cursor-pointer">
           <button
             type="button"
             onClick={handleImageClick}
-            className="w-full h-full focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-lg"
+            className="w-full h-full focus-premium rounded-xl"
             aria-label={`Ver imagen ${selectedIndex + 1} en pantalla completa`}
           >
             <Image
@@ -97,7 +103,7 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
               alt={`${title} - Imagen ${selectedIndex + 1}`}
               width={800}
               height={800}
-              className="w-full h-full object-contain"
+              className={`w-full h-full object-contain ${imageScaleClass}`}
               sizes="(max-width: 1024px) 100vw, 50vw"
               priority={selectedIndex === 0}
             />
@@ -111,14 +117,14 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
         </div>
       </div>
 
-      {/* Mobile: Layout con thumbnails horizontales */}
+      {/* Mobile: Layout con thumbnails horizontales (sin hover scale) */}
       <div className="lg:hidden space-y-4">
         {/* Imagen principal */}
-        <div className="relative w-full aspect-square bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-sm">
+        <div className="relative w-full aspect-square bg-white dark:bg-gray-800 rounded-xl overflow-hidden border border-stone-200/90 dark:border-gray-700 shadow-sm">
           <button
             type="button"
             onClick={handleImageClick}
-            className="w-full h-full focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-lg"
+            className="w-full h-full focus-premium rounded-xl"
             aria-label={`Ver imagen ${selectedIndex + 1} en pantalla completa`}
           >
             <Image
@@ -151,10 +157,10 @@ export default function ProductGallery({ images, title, fallbackImage }: Props) 
                     key={index}
                     type="button"
                     onClick={() => handleThumbnailClick(index)}
-                    className={`flex-shrink-0 relative w-20 h-20 rounded-lg overflow-hidden border-2 transition-all focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+                    className={`flex-shrink-0 relative w-20 h-20 rounded-lg overflow-hidden border-2 transition-all focus-premium ${
                       selectedIndex === index
                         ? "border-primary-600 dark:border-primary-400 ring-2 ring-primary-200 dark:ring-primary-800"
-                        : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                        : "border-stone-200 dark:border-gray-700 hover:border-stone-300 dark:hover:border-gray-600"
                     }`}
                     aria-label={`Ver imagen ${index + 1} de ${displayImages.length}`}
                     aria-pressed={selectedIndex === index}

--- a/src/components/pdp/RelatedProducts.tsx
+++ b/src/components/pdp/RelatedProducts.tsx
@@ -39,7 +39,7 @@ export default async function RelatedProducts({
 
     return (
       <section
-        className="mt-12 pt-10 border-t border-gray-200 dark:border-gray-700"
+        className="mt-12 pt-10 border-t border-stone-200/80 dark:border-gray-700"
         aria-labelledby="related-products-empty"
       >
         <div className="text-center py-12 px-4">
@@ -104,18 +104,18 @@ export default async function RelatedProducts({
 
   return (
     <section
-      className="mt-12 pt-10 border-t border-gray-200 dark:border-gray-700"
+      className="mt-12 pt-10 border-t border-stone-200/80 dark:border-gray-700"
       aria-labelledby="related-products-heading"
     >
-      {/* Heading + microcopy */}
+      {/* Heading + microcopy — consistencia visual con pills y hover-lift en cards */}
       <div className="mb-6">
         <h2
           id="related-products-heading"
-          className="text-2xl font-semibold text-gray-900 dark:text-white mb-1"
+          className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white mb-1"
         >
           Productos relacionados
         </h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+        <p className="text-sm text-stone-600 dark:text-gray-400">
           Más opciones de la misma categoría
         </p>
       </div>
@@ -141,11 +141,11 @@ export default async function RelatedProducts({
         ))}
       </div>
 
-      {/* CTA secundaria: Ver más de esta categoría */}
+      {/* CTA secundaria: Ver más de esta categoría — tap target >= 44px */}
       <div className="mt-6 text-center">
         <Link
           href={ROUTES.section(sectionSlug)}
-          className="inline-flex items-center gap-2 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors focus-premium tap-feedback rounded min-h-[44px]"
+          className="inline-flex items-center justify-center gap-2 text-sm font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors focus-premium tap-feedback rounded min-h-[44px] px-4 py-2"
         >
           Ver más de esta categoría
           <ArrowRight size={16} />

--- a/src/components/product/ProductActions.client.tsx
+++ b/src/components/product/ProductActions.client.tsx
@@ -36,12 +36,16 @@ type Props = {
   product: Product;
 };
 
+const PULSE_MS = 180;
+
 export default function ProductActions({ product }: Props) {
   const [qty, setQty] = useState(1);
   const [variantDetail, setVariantDetail] = useState<string | null>(null);
   const [selectedColor, setSelectedColor] = useState<string | null>(null);
   const [colorNotes, setColorNotes] = useState<string | null>(null);
   const [toast, setToast] = useState<{ message: string; type: "error" | "success" } | null>(null);
+  const [pulseAdd, setPulseAdd] = useState(false);
+  const [pulseBuy, setPulseBuy] = useState(false);
   const { showToast } = useToast();
   const addToCart = useCartStore((s) => s.addToCart);
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -386,17 +390,23 @@ export default function ProductActions({ product }: Props) {
         </div>
 
         <div className="space-y-2">
-          {/* CTA Primario: Agregar al carrito */}
+          {/* CTA Primario: Agregar al carrito — pulse mínimo al click, focus-premium, tap target >= 44px */}
           <button
-            onClick={handleAddToCart}
+            onClick={() => {
+              handleAddToCart();
+              if (!prefersReducedMotion) {
+                setPulseAdd(true);
+                setTimeout(() => setPulseAdd(false), PULSE_MS);
+              }
+            }}
             disabled={!canBuy}
             aria-label="Agregar al carrito"
-            className={getTapClass({
+            className={`cta-pulse focus-premium tap-feedback min-h-[44px] ${pulseAdd ? "cta-pulse-active" : ""} ${getTapClass({
               kind: "button",
               enabled: microAnimsEnabled,
               reducedMotion: prefersReducedMotion,
-              className: "w-full bg-primary-600 text-white px-6 py-3 rounded-md hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 font-semibold",
-            })}
+              className: "w-full bg-primary-600 text-white px-6 py-3 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 font-semibold",
+            })}`}
             title="Agregar al carrito"
           >
             Agregar al carrito
@@ -404,15 +414,21 @@ export default function ProductActions({ product }: Props) {
 
           {/* CTA Secundario: Comprar ahora */}
           <button
-            onClick={handleBuyNow}
+            onClick={() => {
+              handleBuyNow();
+              if (!prefersReducedMotion) {
+                setPulseBuy(true);
+                setTimeout(() => setPulseBuy(false), PULSE_MS);
+              }
+            }}
             disabled={!canBuy}
             aria-label="Comprar ahora"
-            className={getTapClass({
+            className={`cta-pulse focus-premium tap-feedback min-h-[44px] ${pulseBuy ? "cta-pulse-active" : ""} ${getTapClass({
               kind: "button",
               enabled: microAnimsEnabled,
               reducedMotion: prefersReducedMotion,
-              className: "w-full border-2 border-primary-600 dark:border-primary-500 text-primary-600 dark:text-primary-400 bg-white dark:bg-gray-800 px-6 py-3 rounded-md hover:bg-primary-50 dark:hover:bg-primary-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 font-medium",
-            })}
+              className: "w-full border-2 border-primary-600 dark:border-primary-500 text-primary-600 dark:text-primary-400 bg-white dark:bg-gray-800 px-6 py-3 rounded-lg hover:bg-primary-50 dark:hover:bg-primary-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 font-medium",
+            })}`}
             title="Comprar ahora"
           >
             Comprar ahora
@@ -433,7 +449,7 @@ export default function ProductActions({ product }: Props) {
                   title: product.title,
                 });
               }}
-              className="w-full bg-emerald-500 text-white px-6 py-3 rounded-md hover:bg-emerald-600 transition-colors font-medium flex items-center justify-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+              className="w-full bg-emerald-500 text-white px-6 py-3 rounded-lg hover:bg-emerald-600 transition-colors font-medium flex items-center justify-center gap-2 min-h-[44px] focus-premium tap-feedback"
             >
               <MessageCircle className="w-5 h-5" />
               ¿Dudas? Escríbenos


### PR DESCRIPTION
# PR: PDP premium micro pass

**Branch:** `ui/pdp-premium-micro`  
**Título PR:** ui: pdp premium micro pass  
**Objetivo:** Subir la calidad “premium heritage” en PDP (`/catalogo/[section]/[slug]`) con microinteracciones sutiles. Solo UI; sin tocar lógica de negocio, data fetching, add-to-cart, Supabase/Stripe/Skydropx, admin ni endpoints.

---

## Alcance

- **Jerarquía PDP:** Título con `leading-tight` y `line-clamp-4` para títulos largos; precio con `tracking-tight`; sección/categoría y stock en `text-stone-600`; espaciado y `min-w-0` en contenedor del título.
- **Gallery premium:** Contenedor con borde `border-stone-200/90`, `rounded-xl`, sombra suave; imagen principal con transición suave en desktop: hover `scale-[1.02]` (200ms, ease-out); mobile sin hover; thumbnails con `focus-premium` y bordes stone. Respeta `prefers-reduced-motion` (sin scale en hover cuando reduce).
- **CTA pulse:** Botones “Agregar al carrito” y “Comprar ahora” (ProductActions) y sticky CTA (PdpStickyCTA): estado local `pulse` que aplica clase `cta-pulse-active` durante 180ms al click; clase global `.cta-pulse` con `scale(0.98)`; desactivado bajo `prefers-reduced-motion`. No se modificó la lógica de los handlers.
- **CTA feedback:** `focus-premium`, `tap-feedback`, `min-h-[44px]` en CTAs principales y enlace WhatsApp (ProductActions y PdpStickyCTA).
- **Related products:** Sección con borde `border-stone-200/80`; heading con `tracking-tight`; texto secundario `text-stone-600`; link “Ver más de esta categoría” con tap target ≥44px y `focus-premium` / `tap-feedback`. Las cards usan `ProductCard` (ya tiene pills, hover-lift, tap-feedback).
- **globals.css:** Nueva clase `.cta-pulse` / `.cta-pulse-active` para el pulse visual; override en `prefers-reduced-motion` para no aplicar transform.

**No se tocó:** lógica de checkout/admin/shipping/pagos/endpoints ni rutas/contratos. No se modificó add-to-cart, store, APIs ni data fetching.

---

## Archivos tocados

| Archivo | Cambios |
|---------|---------|
| `src/app/globals.css` | Clases `.cta-pulse` / `.cta-pulse-active` y override reduced motion. |
| `src/app/catalogo/[section]/[slug]/page.tsx` | Jerarquía: título (leading-tight, line-clamp-4, min-w-0), precio (tracking-tight), texto stone. Solo clases. |
| `src/components/pdp/ProductGallery.client.tsx` | Borde/sombra heritage (stone), rounded-xl, hover scale 1.02 solo desktop y sin reduced motion; focus-premium en thumbnails y botón imagen. |
| `src/components/product/ProductActions.client.tsx` | Pulse al click (180ms) en Agregar al carrito y Comprar ahora; focus-premium, tap-feedback, min-h-[44px]; WhatsApp link con focus-premium tap-feedback. |
| `src/components/pdp/PdpStickyCTA.client.tsx` | Pulse al click en Agregar al carrito; focus-premium y tap-feedback en Link y button. |
| `src/components/pdp/RelatedProducts.tsx` | Borde stone en sección; heading y texto stone; link “Ver más” con tap target y focus-premium/tap-feedback. |
| `docs/PR-pdp-premium-micro.md` | Este documento. |

---

## QA manual obligatorio

### Desktop (1440 y 1280)

- [ ] Abrir 2 PDPs con títulos largos: jerarquía clara (título, precio, stock, CTA); título no rompe layout (line-clamp si aplica).
- [ ] Gallery: borde y sombra sutiles; hover sobre imagen principal produce scale muy leve (1.02) sin marear; thumbnails con foco premium.
- [ ] CTA “Agregar al carrito” y “Comprar ahora”: al hacer click, pulse breve (scale 0.98) ~180ms; foco con anillo premium.
- [ ] Related products: grid/carrusel legible; cards con hover-lift; link “Ver más de esta categoría” con foco premium.

### Mobile (390x844 y 360x800)

- [ ] Mismo PDP: jerarquía legible; sin overflow horizontal.
- [ ] Gallery: sin hover (solo estado normal); tap en imagen/thumbnails correcto.
- [ ] CTAs con tap target ≥44px; tap feedback al tocar.
- [ ] Sticky CTA: pulse al tocar “Agregar al carrito”; WhatsApp y botón con tap target OK.
- [ ] Related: carrusel con snap; tap targets OK.

### Reduced motion

- [ ] Activar `prefers-reduced-motion: reduce` y recargar PDP. Verificar: gallery sin scale en hover; CTA sin pulse (solo tap-feedback normal si aplica); contenido visible y usable.

### Contenido y lógica

- [ ] Confirmar que no se cambió copy crítico ni flujos de add-to-cart/checkout.
- [ ] Confirmación explícita: **No se tocó lógica de checkout/admin/shipping/pagos/endpoints ni rutas/contratos.**

---

## Validación

```bash
pnpm lint
pnpm build
```
