### PR TITLE
fix(ui): header search layout regression (no logic)

### DIFF
--- a/docs/HOTFIX-header-search-layout.md
+++ b/docs/HOTFIX-header-search-layout.md
@@ -1,0 +1,29 @@
+# Hotfix: Header search layout (UI-only)
+
+**Branch:** `ui/header-search-fix`  
+**Objetivo:** Corregir el layout del buscador en header: bloque angosto con "No sé qué buscar. Haz el quiz" apilado raro en desktop (ddnshop.mx). Solo UI; cero lógica.
+
+---
+
+## Cambios
+
+- **SearchAutocomplete:**
+  - Wrapper y contenedor del input: `w-full min-w-0` para contención y evitar texto en columna.
+  - Dropdown: añadido `left-0 right-0 top-full` para posicionarlo fuera del flujo, debajo del input y ancho completo; `min-w-0` en el dropdown.
+  - Nuevo prop `showQuizLink` (default `true`): en header se pasa `false` para no mostrar el enlace "No sé qué buscar. Haz el quiz" debajo del input (evita el bloque angosto en el nav).
+  - Quiz link cuando se muestra: `whitespace-nowrap` para evitar salto de línea.
+- **HeaderSearchBar:** `showQuizLink={false}`; contenedor con `w-full max-w-md min-w-0 flex-1`.
+- **HeaderSearchMobile:** `showQuizLink={false}`; contenedor del input `w-full min-w-0`.
+- **layout.tsx:** Contenedor del buscador desktop: `w-full` además de `flex-1 max-w-md min-w-0`.
+
+Breakpoints (sin cambios): desktop search `hidden md:block`; botón y panel móvil `md:hidden`.
+
+---
+
+## QA manual
+
+- **Home, desktop 1440/1280:** Header con buscador en línea; sin bloque "No sé qué buscar" debajo; dropdown de sugerencias debajo del input, ancho completo.
+- **Mobile 390/360:** Botón Buscar visible; al abrir, overlay y panel ok; tap targets ≥44px; input y resultados sin layout raro.
+- **Página /buscar:** Input y resultados normales; si quiz está activo, "No sé qué buscar. Haz el quiz" visible donde corresponda.
+
+**Confirmación:** No se tocó lógica de checkout/admin/shipping/pagos/endpoints.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -238,8 +238,8 @@ export default function RootLayout({
                 )}
               </div>
 
-              {/* Buscador desktop */}
-              <div className="hidden md:block flex-1 max-w-md min-w-0 mx-2">
+              {/* Buscador desktop: hidden en mobile, visible md+; contención para evitar overflow */}
+              <div className="hidden md:block flex-1 max-w-md min-w-0 w-full mx-2">
                 <HeaderSearchBar />
               </div>
 

--- a/src/components/header/HeaderSearchBar.client.tsx
+++ b/src/components/header/HeaderSearchBar.client.tsx
@@ -17,12 +17,13 @@ export default function HeaderSearchBar({ className = "" }: HeaderSearchBarProps
   };
 
   return (
-    <div className={`flex-1 max-w-md min-w-0 ${className}`} role="search">
+    <div className={`w-full max-w-md min-w-0 flex-1 ${className}`} role="search">
       <SearchAutocomplete
         placeholder="Buscar guantes, brackets, resinas…"
         onSearch={handleSearch}
         inputClassName="text-sm"
         className="w-full"
+        showQuizLink={false}
       />
     </div>
   );

--- a/src/components/header/HeaderSearchMobile.client.tsx
+++ b/src/components/header/HeaderSearchMobile.client.tsx
@@ -118,10 +118,11 @@ export default function HeaderSearchMobile() {
               </div>
 
               {/* Input de búsqueda */}
-              <div className="mb-6">
+              <div className="mb-6 w-full min-w-0">
                 <SearchAutocomplete
                   placeholder="Buscar guantes, brackets, resinas…"
                   onSearch={handleSearch}
+                  showQuizLink={false}
                 />
               </div>
 

--- a/src/components/search/SearchAutocomplete.client.tsx
+++ b/src/components/search/SearchAutocomplete.client.tsx
@@ -27,6 +27,8 @@ type SearchAutocompleteProps = {
   inputClassName?: string;
   initialQuery?: string;
   onSearch?: (query: string) => void;
+  /** En header no mostramos el enlace "No sé qué buscar" debajo del input para no romper layout */
+  showQuizLink?: boolean;
 };
 
 export default function SearchAutocomplete({
@@ -35,6 +37,7 @@ export default function SearchAutocomplete({
   inputClassName = "",
   initialQuery = "",
   onSearch,
+  showQuizLink = true,
 }: SearchAutocompleteProps) {
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
@@ -289,8 +292,8 @@ export default function SearchAutocomplete({
   };
 
   return (
-    <div className={`relative ${className}`}>
-      <div className="relative">
+    <div className={`relative w-full min-w-0 ${className}`}>
+      <div className="relative w-full min-w-0">
         <Search
           className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
           size={20}
@@ -370,25 +373,25 @@ export default function SearchAutocomplete({
         )}
       </div>
 
-      {/* Quiz link - Solo si está habilitado */}
-      {process.env.NEXT_PUBLIC_ENABLE_QUIZ === "true" && (
+      {/* Quiz link - Solo fuera del header (evita bloque angosto debajo del input en nav) */}
+      {showQuizLink && process.env.NEXT_PUBLIC_ENABLE_QUIZ === "true" && (
         <div className="mt-2 text-center">
           <Link
             href="/quiz"
-            className="text-sm text-muted-foreground hover:text-foreground underline transition-colors"
+            className="text-sm text-muted-foreground hover:text-foreground underline transition-colors whitespace-nowrap"
           >
             No sé qué buscar. Haz el quiz
           </Link>
         </div>
       )}
 
-      {/* Dropdown */}
+      {/* Dropdown - absolute fuera del flujo, ancho completo debajo del input */}
       {isOpen && (suggestions.length > 0 || isLoading) && (
         <div
           ref={dropdownRef}
           id="search-suggestions"
           role="listbox"
-          className="absolute z-50 w-full mt-2 bg-card border border-border rounded-2xl shadow-lg max-h-[400px] overflow-y-auto"
+          className="absolute left-0 right-0 top-full z-50 mt-2 w-full min-w-0 bg-card border border-border rounded-2xl shadow-lg max-h-[400px] overflow-y-auto"
         >
           {isLoading ? (
             <ul className="py-2" role="status" aria-live="polite" aria-label="Cargando sugerencias">


### PR DESCRIPTION
# Hotfix: Header search layout (UI-only)

**Branch:** `ui/header-search-fix`  
**Objetivo:** Corregir el layout del buscador en header: bloque angosto con "No sé qué buscar. Haz el quiz" apilado raro en desktop (ddnshop.mx). Solo UI; cero lógica.

---

## Cambios

- **SearchAutocomplete:**
  - Wrapper y contenedor del input: `w-full min-w-0` para contención y evitar texto en columna.
  - Dropdown: añadido `left-0 right-0 top-full` para posicionarlo fuera del flujo, debajo del input y ancho completo; `min-w-0` en el dropdown.
  - Nuevo prop `showQuizLink` (default `true`): en header se pasa `false` para no mostrar el enlace "No sé qué buscar. Haz el quiz" debajo del input (evita el bloque angosto en el nav).
  - Quiz link cuando se muestra: `whitespace-nowrap` para evitar salto de línea.
- **HeaderSearchBar:** `showQuizLink={false}`; contenedor con `w-full max-w-md min-w-0 flex-1`.
- **HeaderSearchMobile:** `showQuizLink={false}`; contenedor del input `w-full min-w-0`.
- **layout.tsx:** Contenedor del buscador desktop: `w-full` además de `flex-1 max-w-md min-w-0`.

Breakpoints (sin cambios): desktop search `hidden md:block`; botón y panel móvil `md:hidden`.

---

## QA manual

- **Home, desktop 1440/1280:** Header con buscador en línea; sin bloque "No sé qué buscar" debajo; dropdown de sugerencias debajo del input, ancho completo.
- **Mobile 390/360:** Botón Buscar visible; al abrir, overlay y panel ok; tap targets ≥44px; input y resultados sin layout raro.
- **Página /buscar:** Input y resultados normales; si quiz está activo, "No sé qué buscar. Haz el quiz" visible donde corresponda.

**Confirmación:** No se tocó lógica de checkout/admin/shipping/pagos/endpoints.
