### PR TITLE
fix(ui): header search helper/layout (no logic)

### DIFF
--- a/docs/PR-hotfix-header-search-helper.md
+++ b/docs/PR-hotfix-header-search-helper.md
@@ -1,0 +1,66 @@
+# PR: Hotfix header search helper/layout (UI-only)
+
+**Branch:** `fix/header-search-helper-layout`  
+**Título PR:** fix(ui): header search helper/layout (no logic)  
+**Objetivo:** En contexto HEADER no debe renderizarse NADA del helper (“No sé qué buscar…”, “Haz el quiz”). Input y dropdown con ancho correcto. Solo UI; cero lógica.
+
+---
+
+## Problema (producción ddnshop.mx)
+
+El buscador del header muestra un bloque angosto con “No sé qué buscar. Haz el quiz” debajo/pegado al input; el dropdown/layout se comprime y rompe la barra. Persistía tras PR #511.
+
+---
+
+## Solución
+
+- **SearchAutocomplete:** Prop explícita `context?: "header" | "page"` (default `"page"`).
+  - Si `context === "header"`: **no se renderiza el bloque del helper** (ni texto ni link; cero).
+  - Si `context === "page"`: se puede mostrar “No sé qué buscar. Haz el quiz” cuando `NEXT_PUBLIC_ENABLE_QUIZ === "true"`.
+- **Layout (ya aplicado y reforzado):**
+  - Root wrapper: `relative w-full min-w-0`
+  - Input container: `relative w-full min-w-0`
+  - Dropdown: `absolute left-0 right-0 top-full z-50 mt-2 w-full min-w-0`
+- **Header:** Desktop (HeaderSearchBar) y móvil (HeaderSearchMobile) pasan `context="header"`.
+- **Página /buscar:** Usa QuickSearchBar → SearchAutocomplete sin `context` (default `"page"`), por lo que el helper puede mostrarse allí sin romper layout.
+
+---
+
+## Archivos tocados
+
+| Archivo | Cambios |
+|---------|---------|
+| `src/components/search/SearchAutocomplete.client.tsx` | Prop `context?: "header" \| "page"`; helper solo si `context === "page"`. Eliminado `showQuizLink`. |
+| `src/components/header/HeaderSearchBar.client.tsx` | `context="header"` en SearchAutocomplete. |
+| `src/components/header/HeaderSearchMobile.client.tsx` | `context="header"` en SearchAutocomplete. |
+| `docs/PR-hotfix-header-search-helper.md` | Este documento. |
+
+---
+
+## QA manual
+
+### Desktop (1440 y 1280)
+
+- [ ] Home: header con buscador alineado; **ningún** texto “No sé qué buscar” ni “Haz el quiz” debajo del input.
+- [ ] Al escribir en el input: dropdown debajo del input, ancho completo, sin columna estrecha.
+- [ ] Cerrar dropdown y comprobar que la barra del header no está rota.
+
+### Mobile (390x844 y 360x800)
+
+- [ ] Header: solo icono Buscar (sin helper).
+- [ ] Al abrir panel de búsqueda: input y panel ok; **ningún** helper “No sé qué buscar” en el panel del header.
+- [ ] Tap targets ≥44px; overlay y cierre correctos.
+
+### Página /buscar
+
+- [ ] Input y dropdown normales; si quiz está activo, el helper “No sé qué buscar. Haz el quiz” puede aparecer en la página sin romper layout.
+
+### Confirmación explícita
+
+**No se tocó lógica de checkout/admin/shipping/pagos/endpoints.** Solo UI del buscador en header y prop de contexto.
+
+---
+
+## Producción / deploy
+
+Si en ddnshop.mx el problema persiste tras mergear este PR, comprobar en Vercel el **commit SHA del último Production Deployment** y que coincida con el merge de esta rama. Si está desfasado, indicarlo en el reporte; el fix queda listo en código.

--- a/src/components/header/HeaderSearchBar.client.tsx
+++ b/src/components/header/HeaderSearchBar.client.tsx
@@ -23,7 +23,7 @@ export default function HeaderSearchBar({ className = "" }: HeaderSearchBarProps
         onSearch={handleSearch}
         inputClassName="text-sm"
         className="w-full"
-        showQuizLink={false}
+        context="header"
       />
     </div>
   );

--- a/src/components/header/HeaderSearchMobile.client.tsx
+++ b/src/components/header/HeaderSearchMobile.client.tsx
@@ -122,7 +122,7 @@ export default function HeaderSearchMobile() {
                 <SearchAutocomplete
                   placeholder="Buscar guantes, brackets, resinas…"
                   onSearch={handleSearch}
-                  showQuizLink={false}
+                  context="header"
                 />
               </div>
 

--- a/src/components/search/SearchAutocomplete.client.tsx
+++ b/src/components/search/SearchAutocomplete.client.tsx
@@ -21,14 +21,16 @@ type SuggestItem = {
   price_cents: number | null;
 };
 
+type SearchAutocompleteContext = "header" | "page";
+
 type SearchAutocompleteProps = {
   placeholder?: string;
   className?: string;
   inputClassName?: string;
   initialQuery?: string;
   onSearch?: (query: string) => void;
-  /** En header no mostramos el enlace "No sé qué buscar" debajo del input para no romper layout */
-  showQuizLink?: boolean;
+  /** "header" = no renderizar helper (ni texto ni link). "page" = puede mostrar "No sé qué buscar. Haz el quiz" si quiz está activo. */
+  context?: SearchAutocompleteContext;
 };
 
 export default function SearchAutocomplete({
@@ -37,7 +39,7 @@ export default function SearchAutocomplete({
   inputClassName = "",
   initialQuery = "",
   onSearch,
-  showQuizLink = true,
+  context = "page",
 }: SearchAutocompleteProps) {
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
@@ -373,8 +375,8 @@ export default function SearchAutocomplete({
         )}
       </div>
 
-      {/* Quiz link - Solo fuera del header (evita bloque angosto debajo del input en nav) */}
-      {showQuizLink && process.env.NEXT_PUBLIC_ENABLE_QUIZ === "true" && (
+      {/* Helper "No sé qué buscar. Haz el quiz" — solo en context="page"; en header no se renderiza nada */}
+      {context === "page" && process.env.NEXT_PUBLIC_ENABLE_QUIZ === "true" && (
         <div className="mt-2 text-center">
           <Link
             href="/quiz"


### PR DESCRIPTION
# PR: Hotfix header search helper/layout (UI-only)

**Branch:** `fix/header-search-helper-layout`  
**Título PR:** fix(ui): header search helper/layout (no logic)  
**Objetivo:** En contexto HEADER no debe renderizarse NADA del helper (“No sé qué buscar…”, “Haz el quiz”). Input y dropdown con ancho correcto. Solo UI; cero lógica.

---

## Problema (producción ddnshop.mx)

El buscador del header muestra un bloque angosto con “No sé qué buscar. Haz el quiz” debajo/pegado al input; el dropdown/layout se comprime y rompe la barra. Persistía tras PR #511.

---

## Solución

- **SearchAutocomplete:** Prop explícita `context?: "header" | "page"` (default `"page"`).
  - Si `context === "header"`: **no se renderiza el bloque del helper** (ni texto ni link; cero).
  - Si `context === "page"`: se puede mostrar “No sé qué buscar. Haz el quiz” cuando `NEXT_PUBLIC_ENABLE_QUIZ === "true"`.
- **Layout (ya aplicado y reforzado):**
  - Root wrapper: `relative w-full min-w-0`
  - Input container: `relative w-full min-w-0`
  - Dropdown: `absolute left-0 right-0 top-full z-50 mt-2 w-full min-w-0`
- **Header:** Desktop (HeaderSearchBar) y móvil (HeaderSearchMobile) pasan `context="header"`.
- **Página /buscar:** Usa QuickSearchBar → SearchAutocomplete sin `context` (default `"page"`), por lo que el helper puede mostrarse allí sin romper layout.

---

## Archivos tocados

| Archivo | Cambios |
|---------|---------|
| `src/components/search/SearchAutocomplete.client.tsx` | Prop `context?: "header" \| "page"`; helper solo si `context === "page"`. Eliminado `showQuizLink`. |
| `src/components/header/HeaderSearchBar.client.tsx` | `context="header"` en SearchAutocomplete. |
| `src/components/header/HeaderSearchMobile.client.tsx` | `context="header"` en SearchAutocomplete. |
| `docs/PR-hotfix-header-search-helper.md` | Este documento. |

---

## QA manual

### Desktop (1440 y 1280)

- [ ] Home: header con buscador alineado; **ningún** texto “No sé qué buscar” ni “Haz el quiz” debajo del input.
- [ ] Al escribir en el input: dropdown debajo del input, ancho completo, sin columna estrecha.
- [ ] Cerrar dropdown y comprobar que la barra del header no está rota.

### Mobile (390x844 y 360x800)

- [ ] Header: solo icono Buscar (sin helper).
- [ ] Al abrir panel de búsqueda: input y panel ok; **ningún** helper “No sé qué buscar” en el panel del header.
- [ ] Tap targets ≥44px; overlay y cierre correctos.

### Página /buscar

- [ ] Input y dropdown normales; si quiz está activo, el helper “No sé qué buscar. Haz el quiz” puede aparecer en la página sin romper layout.

### Confirmación explícita

**No se tocó lógica de checkout/admin/shipping/pagos/endpoints.** Solo UI del buscador en header y prop de contexto.

---

## Producción / deploy

Si en ddnshop.mx el problema persiste tras mergear este PR, comprobar en Vercel el **commit SHA del último Production Deployment** y que coincida con el merge de esta rama. Si está desfasado, indicarlo en el reporte; el fix queda listo en código.
