### PR TITLE
FASE 3 CARGA 2: /tienda vitrina (rails + bento) UI-only

### DIFF
--- a/docs/PR-fase3-carga2.md
+++ b/docs/PR-fase3-carga2.md
@@ -1,0 +1,69 @@
+# PR — FASE 3 / CARGA 2: /tienda vitrina (rails + bento) — UI-only
+
+## Objetivo
+
+Hacer de `/tienda` un cambio muy notorio pero seguro:
+
+1. Encabezado editorial (ya existe StorefrontListHeader en la sección de destacados).
+2. Secciones tipo vitrina (rails horizontales) usando solo data existente (`getFeaturedItems`, `getSections`).
+3. Ritmo visual con bloques tipo bento (CSS grid), sin assets pesados (solo gradientes e íconos Lucide).
+4. Fallback: si falta data o algo falla, se renderiza el grid actual (FeaturedGrid / SectionExplorer) como hoy.
+
+## Cambios
+
+### Componentes nuevos
+
+- **`src/components/storefront/ProductRail.tsx`** (client)  
+  Rail horizontal con `overflow-x-auto`, `scroll-snap`, `gap`. Botones prev/next opcionales (solo UI, sin deps). Reutiliza `ProductCard`. Props: `items` (FeaturedItem[]), `title?`, `showPrevNext?`, `className?`.
+
+- **`src/components/storefront/SectionLinksRail.tsx`** (server)  
+  Rail horizontal de enlaces a categorías. Props: `sections` (SectionInfo[]), `title?`, `className?`. Usa `ROUTES.section(slug)`.
+
+- **`src/components/storefront/BentoDestacadosTile.client.tsx`** (client)  
+  Tile bento que muestra un rail corto de destacados (slice 0–6). Si no hay items, muestra mensaje “Pronto más destacados”.
+
+- **`src/components/storefront/TiendaVitrina.tsx`** (server)  
+  Orquesta la vitrina: llama a `getFeaturedItems()` y `getSections(8)` en `try/catch`; si falla retorna `null`. Renderiza:
+  - Bento (grid 3 tiles): editorial (copy), Destacados (BentoDestacadosTile), Explora por categoría (link a `#section-explorer-heading`).
+  - Rail “Destacados” (ProductRail) solo si hay featured.
+  - Rail “Explora por categoría” (SectionLinksRail) solo si hay sections.
+
+### Archivos tocados
+
+- `src/app/tienda/page.tsx`: se inserta `<Suspense fallback={null}><TiendaVitrina /></Suspense>` entre QuickSearchBar y SectionExplorer. El contenido actual (SectionExplorer + FeaturedItemsSection) se mantiene como fallback.
+
+### No modificado
+
+- `getFeaturedItems()`, `getSections()`, `/api/products/search`.
+- `ProductCard`, `FeaturedGrid`, `SectionExplorer` (solo reutilizados).
+- Endpoints, checkout, admin, shipping, pagos.
+- Sin dependencias nuevas. Sin “modo oscuro” ni assets pesados (solo gradientes/íconos Lucide).
+
+## QA manual
+
+### /tienda — Desktop (1440 / 1280)
+
+1. Entrar a `/tienda`.
+2. Bento: 3 tiles visibles (editorial, Destacados con rail corto, Explora por categoría). Sin overflow raro.
+3. Rail “Destacados”: scroll horizontal; botones Anterior/Siguiente desplazan el rail.
+4. Rail “Explora por categoría”: enlaces a secciones con scroll horizontal.
+5. Más abajo: SectionExplorer y sección “Productos destacados” (grid o empty state) igual que antes.
+
+### /tienda — Móvil (390 / 360)
+
+1. Bento: tiles apilados; tile Destacados con scroll horizontal (swipe).
+2. Rails: swipe horizontal funciona; tap targets ≥ 44px (botones prev/next, enlaces).
+3. Fallback: si no hay destacados, el bento muestra “Pronto más destacados” en el tile y la sección “Productos destacados” muestra el empty state con chips/CTAs.
+
+### Fallback
+
+- Si `getFeaturedItems()` o `getSections()` fallan, `TiendaVitrina` retorna `null` y la página muestra solo hero, TrustBanners, QuickSearchBar, SectionExplorer y FeaturedItemsSection (grid o empty como hoy).
+
+## Confirmación
+
+**UI-only.** Sin cambios de lógica de datos ni de endpoints.
+
+## Validación
+
+- `pnpm lint` (acepta warnings preexistentes).
+- `pnpm build` (debe pasar).

--- a/src/app/tienda/page.tsx
+++ b/src/app/tienda/page.tsx
@@ -13,6 +13,7 @@ import QuickSearchBar from "@/components/search/QuickSearchBar";
 import SectionExplorer from "@/components/catalog/SectionExplorer";
 import StorefrontListHeader from "@/components/storefront/StorefrontListHeader";
 import EmptyState from "@/components/storefront/EmptyState";
+import TiendaVitrina from "@/components/storefront/TiendaVitrina";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -149,6 +150,11 @@ export default async function TiendaPage() {
       <div className="max-w-7xl mx-auto px-4 pb-8">
         <QuickSearchBar />
       </div>
+
+      {/* Vitrina: bento + rails (fallback: si falla, no se renderiza; el grid actual sigue debajo) */}
+      <Suspense fallback={null}>
+        <TiendaVitrina />
+      </Suspense>
 
       {/* Section Explorer */}
       <div className="max-w-7xl mx-auto px-4 pb-8">

--- a/src/components/storefront/BentoDestacadosTile.client.tsx
+++ b/src/components/storefront/BentoDestacadosTile.client.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import ProductRail from "./ProductRail";
+import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
+
+type Props = {
+  items: FeaturedItem[];
+};
+
+/**
+ * Tile bento: rail corto de destacados (solo UI).
+ */
+export default function BentoDestacadosTile({ items }: Props) {
+  if (!items?.length) {
+    return (
+      <div className="rounded-xl border border-stone-200/90 dark:border-gray-700 bg-stone-50/80 dark:bg-gray-800/50 p-4 flex items-center justify-center min-h-[200px]">
+        <p className="text-sm text-stone-500 dark:text-gray-400">Pronto más destacados</p>
+      </div>
+    );
+  }
+
+  const slice = items.slice(0, 6);
+  return (
+    <div className="rounded-xl border border-stone-200/90 dark:border-gray-700 bg-white dark:bg-gray-800/80 overflow-hidden h-full min-h-[280px]">
+      <ProductRail items={slice} title="Destacados" showPrevNext={false} className="h-full" />
+    </div>
+  );
+}

--- a/src/components/storefront/ProductRail.tsx
+++ b/src/components/storefront/ProductRail.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useRef } from "react";
+import ProductCard from "@/components/catalog/ProductCard";
+import type { FeaturedItem } from "@/lib/catalog/getFeatured.server";
+import type { ProductCardProps } from "@/components/catalog/ProductCard";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+const CARD_MIN_WIDTH = 260;
+const SCROLL_OFFSET = 280;
+
+function toProductCardProps(
+  item: FeaturedItem,
+  priority?: boolean,
+  sizes?: string,
+): ProductCardProps {
+  return {
+    id: item.product_id,
+    section: item.section,
+    product_slug: item.product_slug,
+    title: item.title,
+    price_cents: item.price_cents,
+    image_url: item.image_url,
+    in_stock: item.in_stock,
+    is_active: item.is_active,
+    description: item.description,
+    priority,
+    sizes,
+  };
+}
+
+export type ProductRailProps = {
+  items: FeaturedItem[];
+  title?: string;
+  showPrevNext?: boolean;
+  /** Clase adicional para el contenedor del rail */
+  className?: string;
+};
+
+/**
+ * Rail horizontal de productos (overflow-x-auto + scroll-snap).
+ * Reutiliza ProductCard. Botones prev/next opcionales, sin deps.
+ */
+export default function ProductRail({
+  items,
+  title,
+  showPrevNext = true,
+  className = "",
+}: ProductRailProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  if (!items?.length) return null;
+
+  const scroll = (direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const offset = direction === "left" ? -SCROLL_OFFSET : SCROLL_OFFSET;
+    el.scrollBy({ left: offset, behavior: "smooth" });
+  };
+
+  return (
+    <section
+      className={`relative ${className}`}
+      aria-labelledby={title ? "product-rail-title" : undefined}
+    >
+      {(title || showPrevNext) && (
+        <div className="flex items-center justify-between gap-4 mb-4">
+          {title && (
+            <h2
+              id="product-rail-title"
+              className="text-xl font-semibold tracking-tight text-gray-900 dark:text-white"
+            >
+              {title}
+            </h2>
+          )}
+          {showPrevNext && items.length > 1 && (
+            <div className="flex items-center gap-1 shrink-0" aria-hidden>
+              <button
+                type="button"
+                onClick={() => scroll("left")}
+                className="p-2 rounded-lg border border-stone-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-300 hover:bg-stone-50 dark:hover:bg-gray-700 transition-colors focus-premium tap-feedback min-h-[44px] min-w-[44px] inline-flex items-center justify-center"
+                aria-label="Anterior"
+              >
+                <ChevronLeft className="w-5 h-5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => scroll("right")}
+                className="p-2 rounded-lg border border-stone-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-300 hover:bg-stone-50 dark:hover:bg-gray-700 transition-colors focus-premium tap-feedback min-h-[44px] min-w-[44px] inline-flex items-center justify-center"
+                aria-label="Siguiente"
+              >
+                <ChevronRight className="w-5 h-5" />
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      <div
+        ref={scrollRef}
+        className="overflow-x-auto overflow-y-hidden pb-2 -mx-1 px-1 scroll-smooth snap-x snap-mandatory no-scrollbar"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+      >
+        <div className="flex gap-4 w-max">
+          {items.map((item, index) => (
+            <div
+              key={item.product_id}
+              className="flex-shrink-0 snap-start"
+              style={{ minWidth: CARD_MIN_WIDTH }}
+            >
+              <ProductCard
+                {...toProductCardProps(
+                  item,
+                  index < 3,
+                  "(max-width: 640px) 70vw, 260px"
+                )}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/storefront/SectionLinksRail.tsx
+++ b/src/components/storefront/SectionLinksRail.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { ROUTES } from "@/lib/routes";
+import type { SectionInfo } from "@/lib/catalog/getSections";
+
+export type SectionLinksRailProps = {
+  sections: SectionInfo[];
+  title?: string;
+  className?: string;
+};
+
+/**
+ * Rail horizontal de enlaces a categorías (solo UI, sin backend).
+ */
+export default function SectionLinksRail({
+  sections,
+  title,
+  className = "",
+}: SectionLinksRailProps) {
+  if (!sections?.length) return null;
+
+  return (
+    <section
+      className={`relative ${className}`}
+      aria-labelledby={title ? "section-links-rail-title" : undefined}
+    >
+      {title && (
+        <h2
+          id="section-links-rail-title"
+          className="text-xl font-semibold tracking-tight text-gray-900 dark:text-white mb-4"
+        >
+          {title}
+        </h2>
+      )}
+      <div className="overflow-x-auto overflow-y-hidden pb-2 -mx-1 px-1 scroll-smooth snap-x snap-mandatory no-scrollbar">
+        <div className="flex gap-3 w-max">
+          {sections.map((section) => (
+            <Link
+              key={section.slug}
+              href={ROUTES.section(section.slug)}
+              className="flex-shrink-0 snap-start w-[180px] sm:w-[200px] rounded-xl border border-stone-200/90 dark:border-gray-700 bg-white dark:bg-gray-800/80 p-4 hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 focus-premium tap-feedback min-h-[44px] flex items-center justify-between gap-2 group"
+              aria-label={`Ver ${section.name}`}
+            >
+              <span className="text-sm font-medium text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 truncate">
+                {section.name}
+              </span>
+              <ChevronRight className="w-4 h-4 text-stone-400 dark:text-gray-500 shrink-0" aria-hidden />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/storefront/TiendaVitrina.tsx
+++ b/src/components/storefront/TiendaVitrina.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { getFeaturedItems } from "@/lib/catalog/getFeatured.server";
+import { getSections } from "@/lib/catalog/getSections";
+import { ROUTES } from "@/lib/routes";
+import { LayoutGrid, Sparkles } from "lucide-react";
+import ProductRail from "./ProductRail";
+import SectionLinksRail from "./SectionLinksRail";
+import BentoDestacadosTile from "./BentoDestacadosTile.client";
+
+/**
+ * Vitrina /tienda: bento + rails con data existente.
+ * Fallback: si fetch falla, retorna null y la página muestra el grid actual.
+ */
+export default async function TiendaVitrina() {
+  let featured: Awaited<ReturnType<typeof getFeaturedItems>> = [];
+  let sections: Awaited<ReturnType<typeof getSections>> = [];
+
+  try {
+    const [f, s] = await Promise.all([
+      getFeaturedItems(),
+      getSections(8),
+    ]);
+    featured = f ?? [];
+    sections = s ?? [];
+  } catch {
+    return null;
+  }
+
+  const hasFeatured = featured.length > 0;
+  const hasSections = sections.length > 0;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8 space-y-10">
+      {/* Bento: 2–4 tiles */}
+      <div
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6"
+        role="presentation"
+      >
+        {/* Tile editorial (copy) */}
+        <div className="rounded-xl border border-stone-200/90 dark:border-gray-700 bg-gradient-to-br from-stone-50 to-amber-50/30 dark:from-gray-800/80 dark:to-amber-900/10 p-6 sm:p-8 flex flex-col justify-center min-h-[200px]">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-amber-100/90 dark:bg-amber-900/30 border border-amber-200/70 dark:border-amber-800/50 text-amber-800 dark:text-amber-200 mb-4">
+            <Sparkles className="w-6 h-6" aria-hidden />
+          </div>
+          <h2 className="text-xl font-semibold tracking-tight text-gray-900 dark:text-white mb-2">
+            Productos para tu consultorio
+          </h2>
+          <p className="text-sm text-stone-600 dark:text-gray-400">
+            Insumos, equipos e instrumental organizados por categoría. Envío rápido y puntos de lealtad.
+          </p>
+        </div>
+
+        {/* Tile Destacados (rail corto) */}
+        <div className="sm:col-span-2 lg:col-span-1 min-h-[280px]">
+          <BentoDestacadosTile items={featured} />
+        </div>
+
+        {/* Tile Explora por categoría */}
+        <Link
+          href={ROUTES.tienda() + "#section-explorer-heading"}
+          className="rounded-xl border border-stone-200/90 dark:border-gray-700 bg-white dark:bg-gray-800/80 p-6 sm:p-8 flex flex-col items-center justify-center gap-3 min-h-[200px] hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 focus-premium tap-feedback group"
+          aria-label="Explorar por categorías"
+        >
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-primary-100 dark:bg-primary-900/30 border border-primary-200/70 dark:border-primary-800/50 text-primary-600 dark:text-primary-400 group-hover:bg-primary-200 dark:group-hover:bg-primary-900/50 transition-colors">
+            <LayoutGrid className="w-6 h-6" aria-hidden />
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+            Explora por categoría
+          </h3>
+          <p className="text-sm text-stone-500 dark:text-gray-400">
+            Ver secciones
+          </p>
+        </Link>
+      </div>
+
+      {/* Rail Destacados (solo si hay data) */}
+      {hasFeatured && (
+        <ProductRail
+          items={featured}
+          title="Destacados"
+          showPrevNext
+          className="mt-6"
+        />
+      )}
+
+      {/* Rail Top por categoría (solo si hay sections) */}
+      {hasSections && (
+        <SectionLinksRail
+          sections={sections}
+          title="Explora por categoría"
+          className="mt-8"
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Cambios

- **ProductRail** (`src/components/storefront/ProductRail.tsx`): rail horizontal con `overflow-x-auto`, `scroll-snap`, `gap`; botones prev/next opcionales (sin deps); reutiliza `ProductCard`.
- **SectionLinksRail** (`src/components/storefront/SectionLinksRail.tsx`): rail horizontal de enlaces a categorías (`getSections`).
- **BentoDestacadosTile** (`src/components/storefront/BentoDestacadosTile.client.tsx`): tile bento con rail corto de destacados (slice 0–6).
- **TiendaVitrina** (`src/components/storefront/TiendaVitrina.tsx`): bento (3 tiles: editorial, Destacados, Explora por categoría) + rails "Destacados" y "Explora por categoría"; `try/catch` para fallback (retorna `null` si falla).
- **/tienda**: vitrina insertada entre QuickSearchBar y SectionExplorer con `<Suspense fallback={null}>`; contenido actual (SectionExplorer + FeaturedItemsSection) se mantiene como fallback.

## Archivos tocados

- `src/components/storefront/ProductRail.tsx` (nuevo)
- `src/components/storefront/SectionLinksRail.tsx` (nuevo)
- `src/components/storefront/BentoDestacadosTile.client.tsx` (nuevo)
- `src/components/storefront/TiendaVitrina.tsx` (nuevo)
- `src/app/tienda/page.tsx` (integración vitrina)
- `docs/PR-fase3-carga2.md` (documentación + QA)

## QA manual

- **/tienda — Desktop (1440/1280):** Bento con 3 tiles; rail Destacados con scroll y botones Anterior/Siguiente; rail Explora por categoría; SectionExplorer y grid destacados debajo.
- **/tienda — Móvil (390/360):** Bento apilado; swipe en rails; tap targets ≥ 44px.
- **Fallback:** Sin destacados, tile muestra "Pronto más destacados"; si fetch falla, vitrina no se renderiza y el resto de la página igual.

## Confirmación

**UI-only.** No se tocaron endpoints, datos, checkout, admin, shipping ni pagos.

## Build

`pnpm lint` y `pnpm build` ejecutados antes del commit: compilación correcta, 57 páginas generadas.
