### PR TITLE
FASE 3 CARGA 6B: ReceiptDownloadsCard polish (UI-only, cero riesgo)

### DIFF
--- a/docs/PR-fase3-carga6b.md
+++ b/docs/PR-fase3-carga6b.md
@@ -1,0 +1,56 @@
+# PR #522 — FASE 3 / CARGA 6B: ReceiptDownloadsCard polish (UI-only, cero riesgo)
+
+## Objetivo
+
+Pulir la experiencia de "Recibo / Factura" en `/checkout/gracias` sin tocar pagos ni Stripe:
+
+- Mejor copy (más claro, sin prometer facturación automática)
+- Estados visuales (con y sin URLs)
+- Detalles de layout (spacing, alineación, botones consistentes)
+- Accesibilidad (aria, focus, targets 44px)
+
+## Reglas (hard rules)
+
+- NO crear endpoints Stripe.
+- NO tocar checkout flow, webhook, orders update, payment status logic.
+- NO tocar admin/shipping/pagos.
+- Sin dependencias nuevas.
+- No mover ni cambiar la condición de render: seguir mostrándolo solo cuando `displayStatus === "paid"`.
+
+## Cambios
+
+### Archivos tocados
+
+| Archivo | Cambio |
+|--------|--------|
+| `src/components/checkout/ReceiptDownloadsCard.tsx` | **Polish:** Título "Recibo y facturación". Sin URLs: copy "La descarga del recibo/factura no está disponible aquí." + "Si necesitas factura, usa el formulario de facturación o contáctanos por WhatsApp." Bloque "Cómo facturar" con Link principal a `/facturacion` (button style) "Abrir formulario de facturación", secundario "Contactar por WhatsApp". Opcional: mostrar "Correo: …" si `customerEmail` existe. A11y: `section` con `aria-labelledby`, `role="status"` en mensaje sin URLs, `role="group"` en acciones, `aria-label` en botones (Abrir formulario de facturación, Contactar por WhatsApp). min-h 44px, focus-premium, tap-feedback. Con URLs: botones "Descargar recibo/factura" con aria-labels. |
+| `src/app/checkout/gracias/GraciasContent.tsx` | **Unificación:** ReceiptDownloadsCard se renderiza en un solo lugar cuando `displayStatus === "paid"` (después del bloque de resumen o del mensaje "no datos completos"). Eliminada la card de dentro del resumen y del bloque "no datos completos" para evitar duplicación visual. No se toca lógica de displayStatus ni de datos. |
+| `docs/PR-fase3-carga6b.md` | Esta documentación. |
+
+### No modificado
+
+- Endpoints Stripe, checkout, webhook, órdenes, payment status.
+- Admin, shipping, pagos.
+- Condición de render: sigue siendo solo cuando `displayStatus === "paid"`.
+
+## QA manual
+
+### /checkout/gracias con displayStatus === "paid"
+
+1. **Sin URLs:** Deben verse CTAs "Abrir formulario de facturación" (principal) y "Contactar por WhatsApp" (secundario). No deben aparecer botones de descarga. Copy: "La descarga del recibo/factura no está disponible aquí." y "Si necesitas factura, usa el formulario de facturación o contáctanos por WhatsApp." Si hay `customerEmail`, debe mostrarse "Correo: …".
+2. **Con URLs (simular en dev):** Deben aparecer botones "Descargar recibo" y/o "Descargar factura".
+3. **Sin duplicado:** La card "Recibo y facturación" debe aparecer una sola vez en la página (1440 y 390).
+
+## Confirmación
+
+**UI-only.** Sin endpoints Stripe, sin cambios de lógica de pagos/admin/shipping. Sin dependencias nuevas.
+
+## Validación
+
+- `pnpm lint` (exit 0)
+- `pnpm build` (exit 0)
+
+## Entregable
+
+- Rama, commit (feat o chore), push y PR #522 contra main.
+- Link del PR + estado de checks + lista exacta de archivos tocados.

--- a/src/app/checkout/gracias/GraciasContent.tsx
+++ b/src/app/checkout/gracias/GraciasContent.tsx
@@ -1159,47 +1159,35 @@ export default function GraciasContent() {
             );
           })()}
 
-          {/* Recibo / Factura (Stripe-like card): botones solo si hay URLs; si no, fallback a facturación y WhatsApp */}
-          {displayStatus === "paid" && (() => {
-            const checkoutDatos = useCheckoutStore.getState().datos;
-            const receiptUrl = (orderDataFromStorage as { receipt_url?: string | null })?.receipt_url ?? null;
-            const invoicePdfUrl = (orderDataFromStorage as { invoice_pdf_url?: string | null })?.invoice_pdf_url ?? null;
-            return (
-              <div className="mt-4">
-                <ReceiptDownloadsCard
-                  orderId={orderRef || undefined}
-                  receiptUrl={receiptUrl}
-                  invoicePdfUrl={invoicePdfUrl}
-                  customerEmail={checkoutDatos?.email ?? null}
-                />
-              </div>
-            );
-          })()}
         </div>
       )}
 
       {/* Mensaje si no hay datos completos */}
       {displayItems.length === 0 && displayTotal === 0 && !shippingMethod && (
-        <>
-          <div className="mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
-            <p className="text-gray-600 text-center">
-              Hemos registrado tu compra. En breve te contactaremos para confirmar
-              los detalles.
-            </p>
-          </div>
-          {/* Recibo / Factura cuando no hay resumen pero sí pago confirmado */}
-          {displayStatus === "paid" && (
-            <div className="mb-8">
-              <ReceiptDownloadsCard
-                orderId={orderRef || undefined}
-                receiptUrl={null}
-                invoicePdfUrl={null}
-                customerEmail={useCheckoutStore.getState().datos?.email ?? null}
-              />
-            </div>
-          )}
-        </>
+        <div className="mb-8 p-6 bg-gray-50 rounded-lg border border-gray-200">
+          <p className="text-gray-600 text-center">
+            Hemos registrado tu compra. En breve te contactaremos para confirmar
+            los detalles.
+          </p>
+        </div>
       )}
+
+      {/* Recibo y facturación: un solo lugar cuando displayStatus === "paid" (evita duplicación) */}
+      {displayStatus === "paid" && (() => {
+        const checkoutDatos = useCheckoutStore.getState().datos;
+        const receiptUrl = (orderDataFromStorage as { receipt_url?: string | null })?.receipt_url ?? null;
+        const invoicePdfUrl = (orderDataFromStorage as { invoice_pdf_url?: string | null })?.invoice_pdf_url ?? null;
+        return (
+          <div className="mb-8">
+            <ReceiptDownloadsCard
+              orderId={orderRef || undefined}
+              receiptUrl={receiptUrl}
+              invoicePdfUrl={invoicePdfUrl}
+              customerEmail={checkoutDatos?.email ?? null}
+            />
+          </div>
+        );
+      })()}
 
       {/* Botones de navegación */}
       <div className="flex flex-col sm:flex-row gap-3 justify-center mb-8">

--- a/src/components/checkout/ReceiptDownloadsCard.tsx
+++ b/src/components/checkout/ReceiptDownloadsCard.tsx
@@ -13,14 +13,14 @@ export type ReceiptDownloadsCardProps = {
 };
 
 /**
- * Tarjeta estilo Stripe para Recibo / Factura en /checkout/gracias.
- * Botones solo si existen URLs; si no, estado "no disponible" + CTAs a facturación y WhatsApp.
+ * Tarjeta estilo Stripe para Recibo y facturación en /checkout/gracias.
+ * Botones de descarga solo si existen URLs; si no, bloque "Cómo facturar" con CTAs a facturación y WhatsApp.
  */
 export default function ReceiptDownloadsCard({
   orderId,
   receiptUrl,
   invoicePdfUrl,
-  customerEmail: _customerEmail,
+  customerEmail,
 }: ReceiptDownloadsCardProps) {
   const hasReceipt = !!receiptUrl;
   const hasInvoice = !!invoicePdfUrl;
@@ -31,29 +31,39 @@ export default function ReceiptDownloadsCard({
   );
 
   return (
-    <div className="rounded-xl border border-stone-200/90 dark:border-gray-700 bg-stone-50/50 dark:bg-gray-800/50 p-5 sm:p-6 shadow-sm">
+    <section
+      className="rounded-xl border border-stone-200/90 dark:border-gray-700 bg-stone-50/50 dark:bg-gray-800/50 p-5 sm:p-6 shadow-sm"
+      aria-labelledby="receipt-card-title"
+    >
       <div className="flex items-start gap-3">
-        <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200/70 dark:border-amber-800/50 flex items-center justify-center text-amber-700 dark:text-amber-300">
-          <FileText className="w-5 h-5" aria-hidden />
+        <div
+          className="flex-shrink-0 w-10 h-10 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200/70 dark:border-amber-800/50 flex items-center justify-center text-amber-700 dark:text-amber-300"
+          aria-hidden
+        >
+          <FileText className="w-5 h-5" />
         </div>
-        <div className="min-w-0 flex-1">
-          <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
-            Recibo / Factura
-          </h3>
+        <div className="min-w-0 flex-1 space-y-3">
+          <h2
+            id="receipt-card-title"
+            className="text-base font-semibold text-gray-900 dark:text-white"
+          >
+            Recibo y facturación
+          </h2>
           {orderId && (
-            <p className="text-sm text-stone-600 dark:text-gray-400 mb-3">
+            <p className="text-sm text-stone-600 dark:text-gray-400">
               Pedido {orderId}
             </p>
           )}
 
           {hasAnyDownload ? (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2" role="group" aria-label="Descargas disponibles">
               {hasReceipt && (
                 <a
                   href={receiptUrl!}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 min-h-[44px] px-4 py-2.5 rounded-lg bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 hover:bg-stone-50 dark:hover:bg-gray-700 transition-colors text-sm font-medium focus-premium tap-feedback"
+                  aria-label="Descargar recibo (abre en nueva pestaña)"
                 >
                   <Download className="w-4 h-4" aria-hidden />
                   Descargar recibo
@@ -65,6 +75,7 @@ export default function ReceiptDownloadsCard({
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 min-h-[44px] px-4 py-2.5 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-colors text-sm font-medium focus-premium tap-feedback"
+                  aria-label="Descargar factura (abre en nueva pestaña)"
                 >
                   <Download className="w-4 h-4" aria-hidden />
                   Descargar factura
@@ -72,32 +83,42 @@ export default function ReceiptDownloadsCard({
               )}
             </div>
           ) : (
-            <>
-              <p className="text-sm text-stone-600 dark:text-gray-400 mb-3">
-                El recibo o factura estarán disponibles por correo o en tu cuenta. Si necesitas una copia, puedes solicitarla.
+            <div role="status">
+              <p className="text-sm text-stone-600 dark:text-gray-400 mb-2">
+                La descarga del recibo/factura no está disponible aquí.
               </p>
-              <div className="flex flex-wrap gap-2">
+              <p className="text-sm text-stone-600 dark:text-gray-400 mb-3">
+                Si necesitas factura, usa el formulario de facturación o contáctanos por WhatsApp.
+              </p>
+              {customerEmail && (
+                <p className="text-sm text-stone-500 dark:text-gray-500 mb-3">
+                  Correo: {customerEmail}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-2" role="group" aria-label="Cómo facturar">
                 <Link
                   href="/facturacion"
-                  className="inline-flex items-center justify-center min-h-[44px] px-4 py-2.5 rounded-lg bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 hover:bg-stone-50 dark:hover:bg-gray-700 transition-colors text-sm font-medium focus-premium tap-feedback"
+                  className="inline-flex items-center justify-center min-h-[44px] px-4 py-2.5 rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-colors text-sm font-medium focus-premium tap-feedback"
+                  aria-label="Abrir formulario de facturación"
                 >
-                  Información de facturación
+                  Abrir formulario de facturación
                 </Link>
                 {whatsappHref && (
                   <a
                     href={whatsappHref}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center min-h-[44px] px-4 py-2.5 rounded-lg bg-emerald-500 text-white hover:bg-emerald-600 transition-colors text-sm font-medium focus-premium tap-feedback"
+                    className="inline-flex items-center justify-center min-h-[44px] px-4 py-2.5 rounded-lg bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 hover:bg-stone-50 dark:hover:bg-gray-700 transition-colors text-sm font-medium focus-premium tap-feedback"
+                    aria-label="Contactar por WhatsApp"
                   >
-                    Pedir por WhatsApp
+                    Contactar por WhatsApp
                   </a>
                 )}
               </div>
-            </>
+            </div>
           )}
         </div>
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
- **Qué se agregó:** Polish de ReceiptDownloadsCard: copy "Recibo y facturación", mensaje sin URLs ("La descarga del recibo/factura no está disponible aquí." + "Si necesitas factura, usa el formulario de facturación o contáctanos por WhatsApp."). Bloque "Cómo facturar" con CTA principal "Abrir formulario de facturación" (link a /facturacion) y secundario "Contactar por WhatsApp". Opcional: mostrar "Correo: …" si customerEmail existe. A11y: section con aria-labelledby, role="status"/role="group", aria-label en botones. Un único lugar de render en GraciasContent cuando displayStatus === "paid" (evita duplicación).
- **Dónde se integró:** GraciasContent: ReceiptDownloadsCard se muestra una sola vez cuando displayStatus === "paid", después del bloque de resumen o del mensaje "no datos completos".
- **Fallback:** Sin URLs se muestran CTAs a /facturacion y WhatsApp; no se promete facturación automática.
- **Archivos tocados:**
  - `src/components/checkout/ReceiptDownloadsCard.tsx` (modificado)
  - `src/app/checkout/gracias/GraciasContent.tsx` (modificado)
  - `docs/PR-fase3-carga6b.md` (creado)
- **QA manual:** /checkout/gracias con displayStatus === "paid" en 1440 y 390: sin URLs ver CTAs "Abrir formulario de facturación" y "Contactar por WhatsApp"; con URLs ver botones "Descargar recibo/factura". Verificar que la card no aparezca dos veces.
- **Confirmación:** UI-only, sin endpoints Stripe, sin cambios de lógica de pagos/admin/shipping.
