### PR TITLE
FASE 3 CARGA 7B: Stripe receipt_url (READ-ONLY) + integración mínima en /checkout/gracias

### DIFF
--- a/docs/PR-fase3-carga7b.md
+++ b/docs/PR-fase3-carga7b.md
@@ -1,0 +1,89 @@
+# PR #524 — FASE 3 / CARGA 7B: Stripe receipt_url (READ-ONLY) + integración mínima en /checkout/gracias
+
+## Objetivo
+
+Implementar un endpoint server-side READ-ONLY que, dado un `orderId` del usuario autenticado, devuelva `receipt_url` desde Stripe: `PaymentIntent` → `latest_charge` → `Charge.receipt_url`. Integración mínima para que `ReceiptDownloadsCard` muestre "Descargar recibo" solo cuando exista.
+
+**NO se implementa:** `invoice_pdf` ni `hosted_invoice_url` (no usamos Stripe Invoices).
+
+## Reglas (hard, prioridad máxima)
+
+- NO modificar flujo de pagos (create-payment-intent, webhook, estados).
+- NO crear ni editar nada en Stripe (solo lectura).
+- NO tocar admin/shipping/skydropx.
+- NO cambiar DB schema (sin migraciones).
+- Seguridad obligatoria: sesión requerida, ownership validado (`orders.user_id === auth.user.id`), 404 si no coincide.
+- Para órdenes sin `stripe_payment_intent_id` / `payment_id` o no pagadas: responder `{ receiptUrl: null }` sin romper UI.
+
+## Cambios
+
+### Archivos tocados
+
+| Archivo | Cambio |
+|--------|--------|
+| `src/app/api/stripe/receipt/route.ts` | **Nuevo.** Endpoint `GET /api/stripe/receipt?orderId=UUID`. Auth: Supabase server auth (cookies). Valida ownership: `orders.user_id === auth.user.id` (404 si no coincide). Resuelve PaymentIntent ID desde `metadata.stripe_payment_intent_id` o `payment_id`. Si no hay PI o no es `paid`, devuelve `{ receiptUrl: null }`. Llamadas Stripe READ-ONLY: `paymentIntents.retrieve(pi, { expand: ["latest_charge"] })` → `charges.retrieve` si es necesario → `receipt_url`. Respuesta: `{ receiptUrl: string | null }`. Headers: `Cache-Control: private, max-age=60`. |
+| `src/app/checkout/gracias/GraciasContent.tsx` | **Integración mínima.** Estado `fetchedReceiptUrl` y `useEffect` que hace fetch a `/api/stripe/receipt?orderId=...` cuando `displayStatus === "paid"`, hay `orderRef` y no hay `receiptUrl` en `orderDataFromStorage`. Prioridad: `orderDataFromStorage.receipt_url` > `fetchedReceiptUrl` > `null`. Maneja errores silenciosamente (fallback UI). No toca lógica que decide "paid". |
+| `docs/PR-fase3-carga7b.md` | Esta documentación. |
+
+### No modificado
+
+- Flujo de pagos (create-payment-intent, webhook).
+- Admin, shipping, skydropx.
+- DB schema (sin migraciones).
+- Lógica de `displayStatus === "paid"` en GraciasContent.
+
+## Seguridad
+
+- **Auth:** Requiere sesión autenticada (`authSupabase.auth.getUser()`). Si no hay user → 401.
+- **Ownership:** Valida `orders.user_id === auth.user.id`. Si no coincide → 404 (no filtrar existencia).
+- **Stripe:** Solo lectura (`retrieve`, no `create`/`update`). Usa `STRIPE_SECRET_KEY` (server-only, no `NEXT_PUBLIC`).
+- **Errores:** No expone detalles de Stripe ni existencia de órdenes. Devuelve `{ receiptUrl: null }` en caso de error.
+
+## Casos que devuelven `{ receiptUrl: null }`
+
+1. **bank_transfer:** No tiene PaymentIntent (`payment_provider !== "stripe"`).
+2. **payment_id null:** No hay `stripe_payment_intent_id` en metadata ni `payment_id` en columna.
+3. **No pagado:** `payment_status !== "paid"`.
+4. **Stripe error:** Error al consultar PaymentIntent o Charge (no expone detalles).
+5. **Stripe no configurado:** `STRIPE_SECRET_KEY` faltante.
+
+## QA manual
+
+### Caso 1: Orden pagada con tarjeta (Stripe)
+
+1. Completar checkout con tarjeta de prueba.
+2. En `/checkout/gracias` con `displayStatus === "paid"`:
+   - Debe aparecer botón "Descargar recibo".
+   - Al hacer clic, debe abrir el link de Stripe en nueva pestaña.
+   - El link debe ser válido (hosted receipt de Stripe).
+
+### Caso 2: Orden bank_transfer (pending)
+
+1. Crear orden con método de pago "bank_transfer" (pending).
+2. En `/checkout/gracias`:
+   - NO debe aparecer botón "Descargar recibo".
+   - Debe mostrarse bloque "Cómo facturar" con enlace a `/facturacion` y botón WhatsApp.
+
+### Caso 3: Orden sin autenticación
+
+1. Abrir `/checkout/gracias` sin sesión (o con sesión de otro usuario).
+2. El endpoint debe devolver 401 o 404 según corresponda.
+3. La UI no debe romperse (fallback a bloque "Cómo facturar").
+
+## Confirmación
+
+- **READ-ONLY:** Solo `retrieve` en Stripe, no `create`/`update`.
+- **Ownership enforced:** `orders.user_id === auth.user.id` validado antes de consultar Stripe.
+- **Sin endpoints de escritura:** No se crea ni modifica nada en Stripe ni Supabase.
+- **Sin cambios de lógica de pagos:** No se toca create-payment-intent, webhook, ni estados de orden.
+
+## Validación
+
+- `pnpm lint` (exit 0)
+- `pnpm build` (exit 0)
+
+## Entregable
+
+- PR contra main.
+- Lista exacta de archivos tocados (arriba).
+- Confirmación explícita: READ-ONLY, ownership enforced, sin endpoints de escritura, sin cambios de lógica de pagos.

--- a/src/app/api/stripe/receipt/route.ts
+++ b/src/app/api/stripe/receipt/route.ts
@@ -1,0 +1,222 @@
+import { NextRequest, NextResponse } from "next/server";
+import { unstable_noStore as noStore } from "next/cache";
+import Stripe from "stripe";
+import { createActionSupabase } from "@/lib/supabase/server-actions";
+import { createClient } from "@supabase/supabase-js";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+// Verificar que STRIPE_SECRET_KEY existe (server-only, no NEXT_PUBLIC)
+if (!process.env.STRIPE_SECRET_KEY) {
+  console.error("[stripe/receipt] STRIPE_SECRET_KEY no está configurado");
+}
+
+const stripe = process.env.STRIPE_SECRET_KEY
+  ? new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: "2025-02-24.acacia",
+    })
+  : null;
+
+/**
+ * GET /api/stripe/receipt?orderId=UUID
+ * 
+ * Endpoint READ-ONLY para obtener receipt_url desde Stripe.
+ * 
+ * Seguridad:
+ * - Requiere sesión autenticada (user logueado)
+ * - Valida ownership: orders.user_id === auth.user.id
+ * - Solo lectura en Stripe (no crea ni modifica nada)
+ * 
+ * Casos que devuelven { receiptUrl: null }:
+ * - bank_transfer (no tiene PaymentIntent)
+ * - payment_id null
+ * - payment_status != 'paid'
+ * - Stripe error (no expone detalles)
+ */
+export async function GET(req: NextRequest) {
+  noStore();
+
+  try {
+    // 1. Verificar Stripe configurado
+    if (!stripe || !process.env.STRIPE_SECRET_KEY) {
+      return NextResponse.json(
+        { receiptUrl: null },
+        {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, no-cache",
+          },
+        },
+      );
+    }
+
+    // 2. Obtener orderId de query params
+    const { searchParams } = new URL(req.url);
+    const orderId = searchParams.get("orderId");
+
+    if (!orderId || typeof orderId !== "string" || orderId.trim().length === 0) {
+      return NextResponse.json(
+        { error: "orderId es requerido" },
+        { status: 400 },
+      );
+    }
+
+    // 3. Autenticación: obtener usuario de sesión
+    const authSupabase = createActionSupabase();
+    const {
+      data: { user },
+      error: authError,
+    } = await authSupabase.auth.getUser();
+
+    if (authError || !user?.id) {
+      return NextResponse.json(
+        { error: "No autenticado" },
+        { status: 401 },
+      );
+    }
+
+    // 4. Consultar orden en Supabase y validar ownership
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      console.error("[stripe/receipt] Faltan variables de Supabase");
+      return NextResponse.json(
+        { receiptUrl: null },
+        {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, no-cache",
+          },
+        },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    const { data: order, error: orderError } = await supabase
+      .from("orders")
+      .select("id, user_id, payment_provider, payment_id, payment_status, metadata")
+      .eq("id", orderId.trim())
+      .maybeSingle();
+
+    if (orderError || !order) {
+      // 404 si no existe (no filtrar existencia)
+      return NextResponse.json(
+        { error: "Orden no encontrada" },
+        { status: 404 },
+      );
+    }
+
+    // 5. Validar ownership: orders.user_id === auth.user.id
+    if (order.user_id !== user.id) {
+      // 404 para no filtrar existencia (mejor UX que 403)
+      return NextResponse.json(
+        { error: "Orden no encontrada" },
+        { status: 404 },
+      );
+    }
+
+    // 6. Resolver PaymentIntent ID
+    const metadata = (order.metadata as Record<string, unknown>) || {};
+    const paymentIntentId =
+      (metadata.stripe_payment_intent_id as string | undefined) ||
+      order.payment_id ||
+      null;
+
+    // 7. Si no hay PaymentIntent ID o no es Stripe, devolver null
+    if (!paymentIntentId || order.payment_provider !== "stripe") {
+      return NextResponse.json(
+        { receiptUrl: null },
+        {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, max-age=60",
+          },
+        },
+      );
+    }
+
+    // 8. Si no está pagado, devolver null (no filtrar existencia)
+    if (order.payment_status !== "paid") {
+      return NextResponse.json(
+        { receiptUrl: null },
+        {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, max-age=60",
+          },
+        },
+      );
+    }
+
+    // 9. Consultar Stripe READ-ONLY: PaymentIntent con expand latest_charge
+    try {
+      const paymentIntent = await stripe.paymentIntents.retrieve(
+        paymentIntentId,
+        {
+          expand: ["latest_charge"],
+        },
+      );
+
+      // 10. Obtener receipt_url desde Charge
+      let receiptUrl: string | null = null;
+
+      if (paymentIntent.latest_charge) {
+        // latest_charge puede ser string (id) u objeto Charge (si expand funcionó)
+        if (typeof paymentIntent.latest_charge === "string") {
+          // Si es string, hacer otra llamada para obtener el Charge
+          const charge = await stripe.charges.retrieve(paymentIntent.latest_charge);
+          receiptUrl = charge.receipt_url || null;
+        } else {
+          // Si es objeto Charge (expand funcionó), leer receipt_url directamente
+          receiptUrl = (paymentIntent.latest_charge as Stripe.Charge).receipt_url || null;
+        }
+      }
+
+      return NextResponse.json(
+        { receiptUrl },
+        {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, max-age=60",
+          },
+        },
+      );
+    } catch (stripeError) {
+      // Si hay error de Stripe, devolver null (no exponer detalles)
+      if (process.env.NODE_ENV === "development") {
+        console.warn("[stripe/receipt] Error al consultar Stripe:", stripeError);
+      }
+      return NextResponse.json(
+        { receiptUrl: null },
+        {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, no-cache",
+          },
+        },
+      );
+    }
+  } catch (error) {
+    // Error inesperado: devolver null (no romper UI)
+    if (process.env.NODE_ENV === "development") {
+      console.error("[stripe/receipt] Error inesperado:", error);
+    }
+    return NextResponse.json(
+      { receiptUrl: null },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "private, no-cache",
+        },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## FASE 3 / CARGA 7B: Stripe receipt_url (READ-ONLY) + integración mínima en /checkout/gracias

**Objetivo:** Implementar endpoint server-side READ-ONLY que devuelve `receipt_url` desde Stripe (`PaymentIntent` → `latest_charge` → `Charge.receipt_url`) e integración mínima para que `ReceiptDownloadsCard` muestre "Descargar recibo" cuando exista.

**NO se implementa:** `invoice_pdf` ni `hosted_invoice_url` (no usamos Stripe Invoices).

### Cambios

- **`src/app/api/stripe/receipt/route.ts` (nuevo):** Endpoint `GET /api/stripe/receipt?orderId=UUID`. Auth: Supabase server auth (cookies). Valida ownership: `orders.user_id === auth.user.id` (404 si no coincide). Resuelve PaymentIntent ID desde `metadata.stripe_payment_intent_id` o `payment_id`. Si no hay PI o no es `paid`, devuelve `{ receiptUrl: null }`. Llamadas Stripe READ-ONLY: `paymentIntents.retrieve(pi, { expand: ["latest_charge"] })` → `charges.retrieve` si es necesario → `receipt_url`. Respuesta: `{ receiptUrl: string | null }`. Headers: `Cache-Control: private, max-age=60`.
- **`src/app/checkout/gracias/GraciasContent.tsx` (modificado):** Integración mínima. Estado `fetchedReceiptUrl` y `useEffect` que hace fetch a `/api/stripe/receipt?orderId=...` cuando `displayStatus === "paid"`, hay `orderRef` y no hay `receiptUrl` en `orderDataFromStorage`. Prioridad: `orderDataFromStorage.receipt_url` > `fetchedReceiptUrl` > `null`. Maneja errores silenciosamente (fallback UI). No toca lógica que decide "paid".
- **`docs/PR-fase3-carga7b.md` (creado):** Documentación con objetivo, seguridad, casos que devuelven null, QA manual, confirmación.

### Seguridad

- **Auth:** Requiere sesión autenticada (`authSupabase.auth.getUser()`). Si no hay user → 401.
- **Ownership:** Valida `orders.user_id === auth.user.id`. Si no coincide → 404 (no filtrar existencia).
- **Stripe:** Solo lectura (`retrieve`, no `create`/`update`). Usa `STRIPE_SECRET_KEY` (server-only, no `NEXT_PUBLIC`).
- **Errores:** No expone detalles de Stripe ni existencia de órdenes. Devuelve `{ receiptUrl: null }` en caso de error.

### Casos que devuelven `{ receiptUrl: null }`

1. bank_transfer (no tiene PaymentIntent)
2. payment_id null
3. payment_status != 'paid'
4. Stripe error (no expone detalles)
5. Stripe no configurado

### QA manual

- **Caso 1:** Orden pagada con tarjeta → debe aparecer botón "Descargar recibo" y abrir link válido.
- **Caso 2:** Orden bank_transfer (pending) → NO debe aparecer botón, solo bloque "Cómo facturar".

### Confirmación

- **READ-ONLY:** Solo `retrieve` en Stripe, no `create`/`update`.
- **Ownership enforced:** `orders.user_id === auth.user.id` validado antes de consultar Stripe.
- **Sin endpoints de escritura:** No se crea ni modifica nada en Stripe ni Supabase.
- **Sin cambios de lógica de pagos:** No se toca create-payment-intent, webhook, ni estados de orden.
