### PR TITLE
CARGA 8E: Product cards compactas en /tienda y /destacados (FeaturedGrid context) UI-only

### DIFF
--- a/docs/PR-carga8e-compact-cards.md
+++ b/docs/PR-carga8e-compact-cards.md
@@ -1,0 +1,60 @@
+# PR #528 — CARGA 8E: Product cards compactas en /tienda y /destacados (FeaturedGrid context) UI-only
+
+## Objetivo
+
+En /tienda y /destacados las cards seguían demasiado altas. Causas principales: CTAs grandes (especialmente WhatsApp) + padding/imagen que inflan la altura. Objetivo: “grid retail” compacto sin perder tap targets ni romper lógica.
+
+## Reglas (hard)
+
+- UI-only: NO tocar endpoints, NO tocar lógica de carrito/checkout/admin/shipping/pagos.
+- NO cambiar data fetching ni props de datos.
+- Sin dependencias nuevas.
+- Tap targets >= 44px (principal). Secundarios accesibles.
+
+## Cambios
+
+### 1. ProductCard (`src/components/catalog/ProductCard.tsx`)
+
+- **Prop `variant`:** `variant?: "default" | "compact"`. Default = comportamiento actual; compact = usado en FeaturedGrid.
+- **Compact:**
+  - Imagen: `aspect-[4/3]` mantenido; `max-h-[180px] sm:max-h-[210px]` (antes 220/260).
+  - Card: `p-3` (sin p-4 en sm).
+  - Controles: `pt-2` en lugar de pt-3.
+  - WhatsApp: link secundario outline/ghost (borde gris, texto gris, min-h 44px) en lugar de botón verde grande. Misma URL y tracking.
+- Sin cambios de lógica (addToCart, requiresSelections, trackWhatsappClick, etc.).
+
+### 2. ProductCardV2 (`src/components/catalog/ProductCardV2.tsx`)
+
+- **Prop `variant`:** mismo tipo; `variant = "default"`.
+- **Compact:** misma lógica: imagen max-h 180/210, contenido p-3, pt-2 en controles, WhatsApp como link outline.
+- Sin cambios de lógica.
+
+### 3. FeaturedGrid (`src/components/FeaturedGrid.tsx`)
+
+- Pasa `variant="compact"` a ProductCard y ProductCardV2 al renderizar el grid vertical.
+- ProductRail no tocado.
+
+## Archivos tocados
+
+| Archivo | Cambio |
+|--------|--------|
+| `src/components/catalog/ProductCard.tsx` | Prop `variant`, estilos compact (imagen, padding, WhatsApp outline). |
+| `src/components/catalog/ProductCardV2.tsx` | Prop `variant`, estilos compact. |
+| `src/components/FeaturedGrid.tsx` | Pasa `variant="compact"` a ambas cards. |
+| `docs/PR-carga8e-compact-cards.md` | Esta documentación. |
+
+## QA manual
+
+- **/tienda** (desktop 1440/1280 y móvil 390): cards más bajas; WhatsApp como link secundario; botón principal “Agregar” / “Elegir opciones” full-width y min-h 44px.
+- **/destacados** (desktop y móvil): mismo grid compacto.
+- **Antes/después:** menor altura por card; sin overflow horizontal; WhatsApp sigue abriendo el mismo enlace y tracking.
+
+## Validación
+
+- `pnpm lint` (exit 0)
+- `pnpm build` (exit 0)
+
+## Confirmación
+
+- Solo estilos (no lógica). WhatsApp sigue funcionando (misma URL, mismo onClick/trackWhatsappClick).
+- PDP y otros usos de ProductCard/ProductCardV2 sin variant siguen igual (default).

--- a/src/components/FeaturedGrid.tsx
+++ b/src/components/FeaturedGrid.tsx
@@ -99,6 +99,7 @@ export default function FeaturedGrid({
           "(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw",
         );
         const showV2 = useV2 && hasMinDataForFeaturedV2(item);
+        const cardProps = { ...props, variant: "compact" as const };
         return (
           <div
             key={item.product_id}
@@ -106,7 +107,7 @@ export default function FeaturedGrid({
             onClick={() => handleProductClick(item, index + 1)}
             style={{ "--delay": `${index * 50}ms` } as React.CSSProperties}
           >
-            {showV2 ? <ProductCardV2 {...props} /> : <ProductCard {...props} />}
+            {showV2 ? <ProductCardV2 {...cardProps} /> : <ProductCard {...cardProps} />}
           </div>
         );
       })}

--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -38,6 +38,8 @@ export type ProductCardProps = {
   priority?: boolean;
   sizes?: string;
   compact?: boolean;
+  /** "compact" = grid retail en FeaturedGrid (imagen/botones más compactos). Default = como está. */
+  variant?: "default" | "compact";
   // Para búsqueda: highlight del query
   highlightQuery?: string;
 };
@@ -68,8 +70,10 @@ export default function ProductCard({
   priority = false,
   sizes,
   compact = false,
+  variant = "default",
   highlightQuery,
 }: ProductCardProps) {
+  const isCompact = variant === "compact" || compact;
   const addToCart = useCartStore((s) => s.addToCart);
   const { showToast } = useToast();
   const router = useRouter();
@@ -194,15 +198,15 @@ export default function ProductCard({
 
   return (
     <div
-      className="rounded-xl border border-gray-200 dark:border-gray-700 p-3 sm:p-4 flex flex-col bg-white dark:bg-gray-800 shadow-sm group min-w-0 hover-lift tap-feedback"
+      className={`rounded-xl border border-gray-200 dark:border-gray-700 flex flex-col bg-white dark:bg-gray-800 shadow-sm group min-w-0 hover-lift tap-feedback ${isCompact ? "p-3" : "p-3 sm:p-4"}`}
       style={{
         animation: "fadeInUp 0.5s ease-out backwards",
         animationDelay: "var(--delay, 0ms)",
       }}
     >
-      {/* Imagen con link a PDP - ratio 4/3 para card compacta (no poster) */}
+      {/* Imagen con link a PDP - ratio 4/3; compact = menor altura */}
       <Link href={href} prefetch={false} className="block overflow-hidden rounded-lg">
-        <div className="relative w-full aspect-[4/3] max-h-[220px] sm:max-h-[260px] bg-gradient-to-br from-gray-50 dark:from-gray-700 to-gray-100 dark:to-gray-800 rounded-lg overflow-hidden group-hover:from-gray-100 dark:group-hover:from-gray-600 group-hover:to-gray-200 dark:group-hover:to-gray-700 transition-all duration-300">
+        <div className={`relative w-full aspect-[4/3] bg-gradient-to-br from-gray-50 dark:from-gray-700 to-gray-100 dark:to-gray-800 rounded-lg overflow-hidden group-hover:from-gray-100 dark:group-hover:from-gray-600 group-hover:to-gray-200 dark:group-hover:to-gray-700 transition-all duration-300 ${isCompact ? "max-h-[180px] sm:max-h-[210px]" : "max-h-[220px] sm:max-h-[260px]"}`}>
           <ImageWithFallback
             src={image_url}
             width={400}
@@ -252,7 +256,7 @@ export default function ProductCard({
       </div>
 
       {/* Controles: cantidad y agregar al carrito */}
-      <div className="mt-auto pt-3 space-y-2">
+      <div className={`mt-auto space-y-2 ${isCompact ? "pt-2" : "pt-3"}`}>
         {canPurchase ? (
           <>
             <div className="flex flex-col sm:flex-row gap-2">
@@ -335,7 +339,7 @@ export default function ProductCard({
           </div>
         )}
 
-        {/* Acción alternativa: WhatsApp */}
+        {/* Acción alternativa: WhatsApp — compact = link secundario outline */}
         {waHref && (
           <a
             href={waHref}
@@ -350,19 +354,13 @@ export default function ProductCard({
                 title,
               });
             }}
-            className="w-full flex items-center justify-center gap-2 min-h-[44px] px-3 py-2.5 rounded-lg text-sm bg-emerald-500 text-white hover:bg-emerald-600 transition-colors font-medium focus-premium tap-feedback"
+            className={`flex items-center justify-center gap-1.5 font-medium focus-premium tap-feedback rounded-lg text-sm transition-colors ${isCompact ? "min-h-[44px] px-3 py-2 border border-stone-200 dark:border-gray-600 text-stone-600 dark:text-gray-400 hover:bg-stone-50 dark:hover:bg-gray-700/50" : "w-full min-h-[44px] px-3 py-2.5 rounded-lg bg-emerald-500 text-white hover:bg-emerald-600"}`}
             aria-label={`Consultar ${title} por WhatsApp`}
           >
-            <svg
-              width={16}
-              height={16}
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-            >
+            <svg width={16} height={16} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
             </svg>
-                <span>¿Dudas? WhatsApp</span>
+            <span>¿Dudas? WhatsApp</span>
           </a>
         )}
       </div>

--- a/src/components/catalog/ProductCardV2.tsx
+++ b/src/components/catalog/ProductCardV2.tsx
@@ -36,8 +36,10 @@ export default function ProductCardV2({
   description: _description,
   priority = false,
   sizes,
+  variant = "default",
   highlightQuery,
 }: ProductCardProps) {
+  const isCompact = variant === "compact";
   const addToCart = useCartStore((s) => s.addToCart);
   const { showToast } = useToast();
   const router = useRouter();
@@ -142,9 +144,9 @@ export default function ProductCardV2({
         animationDelay: "var(--delay, 0ms)",
       }}
     >
-      {/* Imagen: ratio 4/3 para card compacta (no poster) */}
+      {/* Imagen: ratio 4/3; compact = menor altura */}
       <Link href={href} prefetch={false} className="block overflow-hidden">
-        <div className="relative w-full aspect-[4/3] max-h-[220px] sm:max-h-[260px] bg-stone-50 dark:bg-gray-800 border-b border-stone-200/80 dark:border-gray-700">
+        <div className={`relative w-full aspect-[4/3] bg-stone-50 dark:bg-gray-800 border-b border-stone-200/80 dark:border-gray-700 ${isCompact ? "max-h-[180px] sm:max-h-[210px]" : "max-h-[220px] sm:max-h-[260px]"}`}>
           <ImageWithFallback
             src={image_url}
             width={400}
@@ -158,7 +160,7 @@ export default function ProductCardV2({
         </div>
       </Link>
 
-      <div className="p-3 sm:p-4 flex flex-col flex-1 min-w-0">
+      <div className={`flex flex-col flex-1 min-w-0 ${isCompact ? "p-3" : "p-3 sm:p-4"}`}>
         {/* Título line-clamp 2 */}
         <h3 className="text-sm font-semibold line-clamp-2 min-h-[2.5rem] text-gray-900 dark:text-gray-100">
           <Link
@@ -195,7 +197,7 @@ export default function ProductCardV2({
         </div>
 
         {/* Controles: tap targets >= 44px */}
-        <div className="mt-auto pt-4 space-y-2">
+        <div className={`mt-auto space-y-2 ${isCompact ? "pt-2" : "pt-4"}`}>
           {canPurchase ? (
             <>
               <div className="flex flex-col sm:flex-row gap-2">
@@ -253,7 +255,7 @@ export default function ProductCardV2({
                   title,
                 });
               }}
-              className="w-full flex items-center justify-center gap-2 min-h-[44px] px-3 py-2.5 rounded-lg text-sm bg-emerald-500 text-white hover:bg-emerald-600 transition-colors font-medium focus-premium tap-feedback"
+              className={`flex items-center justify-center gap-1.5 font-medium focus-premium tap-feedback rounded-lg text-sm transition-colors min-h-[44px] ${isCompact ? "px-3 py-2 border border-stone-200 dark:border-gray-600 text-stone-600 dark:text-gray-400 hover:bg-stone-50 dark:hover:bg-gray-700/50" : "w-full px-3 py-2.5 bg-emerald-500 text-white hover:bg-emerald-600"}`}
               aria-label={`Consultar ${title} por WhatsApp`}
             >
               <span>¿Dudas? WhatsApp</span>


### PR DESCRIPTION
# PR #528 — CARGA 8E: Product cards compactas en /tienda y /destacados (FeaturedGrid context) UI-only

## Objetivo

En /tienda y /destacados las cards seguían demasiado altas. Causas principales: CTAs grandes (especialmente WhatsApp) + padding/imagen que inflan la altura. Objetivo: “grid retail” compacto sin perder tap targets ni romper lógica.

## Reglas (hard)

- UI-only: NO tocar endpoints, NO tocar lógica de carrito/checkout/admin/shipping/pagos.
- NO cambiar data fetching ni props de datos.
- Sin dependencias nuevas.
- Tap targets >= 44px (principal). Secundarios accesibles.

## Cambios

### 1. ProductCard (`src/components/catalog/ProductCard.tsx`)

- **Prop `variant`:** `variant?: "default" | "compact"`. Default = comportamiento actual; compact = usado en FeaturedGrid.
- **Compact:**
  - Imagen: `aspect-[4/3]` mantenido; `max-h-[180px] sm:max-h-[210px]` (antes 220/260).
  - Card: `p-3` (sin p-4 en sm).
  - Controles: `pt-2` en lugar de pt-3.
  - WhatsApp: link secundario outline/ghost (borde gris, texto gris, min-h 44px) en lugar de botón verde grande. Misma URL y tracking.
- Sin cambios de lógica (addToCart, requiresSelections, trackWhatsappClick, etc.).

### 2. ProductCardV2 (`src/components/catalog/ProductCardV2.tsx`)

- **Prop `variant`:** mismo tipo; `variant = "default"`.
- **Compact:** misma lógica: imagen max-h 180/210, contenido p-3, pt-2 en controles, WhatsApp como link outline.
- Sin cambios de lógica.

### 3. FeaturedGrid (`src/components/FeaturedGrid.tsx`)

- Pasa `variant="compact"` a ProductCard y ProductCardV2 al renderizar el grid vertical.
- ProductRail no tocado.

## Archivos tocados

| Archivo | Cambio |
|--------|--------|
| `src/components/catalog/ProductCard.tsx` | Prop `variant`, estilos compact (imagen, padding, WhatsApp outline). |
| `src/components/catalog/ProductCardV2.tsx` | Prop `variant`, estilos compact. |
| `src/components/FeaturedGrid.tsx` | Pasa `variant="compact"` a ambas cards. |
| `docs/PR-carga8e-compact-cards.md` | Esta documentación. |

## QA manual

- **/tienda** (desktop 1440/1280 y móvil 390): cards más bajas; WhatsApp como link secundario; botón principal “Agregar” / “Elegir opciones” full-width y min-h 44px.
- **/destacados** (desktop y móvil): mismo grid compacto.
- **Antes/después:** menor altura por card; sin overflow horizontal; WhatsApp sigue abriendo el mismo enlace y tracking.

## Validación

- `pnpm lint` (exit 0)
- `pnpm build` (exit 0)

## Confirmación

- Solo estilos (no lógica). WhatsApp sigue funcionando (misma URL, mismo onClick/trackWhatsappClick).
- PDP y otros usos de ProductCard/ProductCardV2 sin variant siguen igual (default).
