### PR TITLE
PR-H2: Bento trust + categorías bento

### DIFF
--- a/docs/PR-H2_bento-categorias.md
+++ b/docs/PR-H2_bento-categorias.md
@@ -1,0 +1,62 @@
+# PR-H2: Bento trust + categorías bento
+
+## Objetivo
+
+- Añadir una sección editorial tipo bento de confianza/valor (trust, B2B, soporte, envíos).
+- Rediseñar categorías como bento grid (2 grandes + varias pequeñas).
+- Añadir separadores sutiles entre bloques (con `prefers-reduced-motion` respetado).
+
+## Cambios
+
+### Componentes comunes
+
+| Archivo | Descripción |
+|--------|-------------|
+| `src/components/common/GlassCard.tsx` | Card reutilizable: `rounded-2xl`, borde suave (border + opacity), sombra ligera, soporte `className`, opcional `asChild` para futuro Slot. Sirve para tiles del bento. |
+| `src/components/common/AnimatedSeparator.tsx` | Separador (línea horizontal o mini SVG). Con motion sutil; con `prefers-reduced-motion: reduce` queda estático (sin animación). |
+
+### Componentes Home
+
+| Archivo | Descripción |
+|--------|-------------|
+| `src/components/home/BentoSection.tsx` | Sección "Confianza y servicio" editorial. Grid responsive: desktop 4 columnas (1–2 tiles con `col-span-2`), mobile 1 columna. Tiles: Atención clínicas/doctores (MessageCircle), Envíos a todo México (Truck), Pago seguro (Shield), Factura y soporte (FileText). Usa GlassCard y lucide. |
+| `src/components/home/CategoryGrid.tsx` | "Explora por categorías" en bento: 2 categorías grandes + 4–6 pequeñas. Cada card es enlace a sección/tienda. Hover: elevación suave. A11y: focus visible. |
+
+### Integración
+
+| Archivo | Cambio |
+|--------|--------|
+| `src/app/page.tsx` | Tras el hero: `<AnimatedSeparator />` → `<BentoSection />` → `<AnimatedSeparator />` → `<CategoryGrid />`. No se modifica el hero. |
+
+### Estilo / motion
+
+- Separador: keyframes `separator-fade` y `separator-draw` en `globals.css`; con `@media (prefers-reduced-motion: reduce)` las animaciones se desactivan.
+- Sin librerías nuevas.
+
+## Archivos tocados / creados
+
+- `src/components/common/GlassCard.tsx`
+- `src/components/common/AnimatedSeparator.tsx`
+- `src/components/home/BentoSection.tsx`
+- `src/components/home/CategoryGrid.tsx`
+- `src/app/page.tsx` (orden de secciones: hero → separador → bento → separador → categorías)
+- `src/app/globals.css` (keyframes del separador, ya existentes)
+- `src/lib/utils.ts` (utilidad `cn` para className; usa clsx + tailwind-merge ya en el proyecto)
+- `docs/PR-H2_bento-categorias.md` (este archivo)
+
+## QA manual
+
+- **Desktop 1440px:** Bento 4 columnas, 2 tiles con `col-span-2`; CategoryGrid 2 grandes + pequeñas; separadores visibles.
+- **Mobile 390px:** Una columna, sin overflow horizontal; bento y categorías apilados.
+- **prefers-reduced-motion:** Separador estático (sin animación).
+- **Focus visible:** Enlaces de CategoryGrid con anillo de foco visible.
+
+## Confirmación
+
+**No se tocó:** checkout, pagos/Stripe/webhook, Supabase (solo se usa `getSections` existente), admin, shipping, rutas API.
+
+## Branch / Commit / PR
+
+- **Branch:** `feat/home-pr-h2-bento-categories`
+- **Commit (conventional):** `feat(home): pr-h2 bento trust + category grid`
+- **PR:** Base `main`, title **PR-H2: Bento trust + categorías bento**, body: contenido de este documento.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -416,3 +416,41 @@ textarea {
 .animation-delay-4000 {
   animation-delay: 4s;
 }
+
+/* AnimatedSeparator: sutil, respeta prefers-reduced-motion */
+@keyframes separator-fade {
+  from {
+    opacity: 0.5;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.separator-line {
+  animation: separator-fade 0.5s ease-out;
+}
+
+.separator-stroke {
+  stroke-dasharray: 92;
+  stroke-dashoffset: 92;
+  animation: separator-draw 0.6s ease-out forwards;
+}
+
+@keyframes separator-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .separator-line,
+  .separator-stroke {
+    animation: none;
+    opacity: 1;
+  }
+  .separator-stroke {
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,12 @@ import { buttonPrimary } from "@/lib/styles/button";
 import SectionHeader from "@/components/ui/SectionHeader";
 import { HelpWidget } from "@/components/support/HelpWidget";
 import { TrustBanners } from "@/components/marketing/TrustBanners";
-import SectionExplorer from "@/components/catalog/SectionExplorer";
 import QuizCTA from "@/components/quiz/QuizCTA";
 import HeroIntro from "@/components/home/HeroIntro";
 import WhyBuySection from "@/components/home/WhyBuySection.client";
+import AnimatedSeparator from "@/components/common/AnimatedSeparator";
+import BentoSection from "@/components/home/BentoSection";
+import CategoryGrid from "@/components/home/CategoryGrid";
 
 // Lazy load componentes no críticos
 const Testimonials = dynamicImport(() => import("@/components/ui/Testimonials"), {
@@ -55,6 +57,11 @@ export default async function HomePage() {
       {/* Hero Section - PR-H1: HeroIntro con AmbientBackground + IconRail */}
       <HeroIntro />
 
+      <AnimatedSeparator />
+      <BentoSection />
+      <AnimatedSeparator />
+      <CategoryGrid />
+
       {/* Trust Banners */}
       <div className="max-w-6xl mx-auto px-4 py-8 sm:py-12">
         <TrustBanners />
@@ -63,14 +70,6 @@ export default async function HomePage() {
       {/* Quiz CTA - Móvil arriba del fold */}
       <div className="max-w-6xl mx-auto px-4 pb-4 md:hidden">
         <QuizCTA />
-      </div>
-
-      {/* Explorar por categorías */}
-      <div className="max-w-6xl mx-auto px-4 py-8 sm:py-12">
-        <SectionExplorer
-          title="Explora por categoría"
-          subtitle="Navega por nuestras categorías de productos"
-        />
       </div>
 
       {/* Productos Destacados */}

--- a/src/components/common/AnimatedSeparator.tsx
+++ b/src/components/common/AnimatedSeparator.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+type AnimatedSeparatorProps = {
+  className?: string;
+  /** "line" = línea horizontal; "svg" = mini SVG (stroke) */
+  variant?: "line" | "svg";
+};
+
+/**
+ * Separador sutil entre bloques. Respeta prefers-reduced-motion:
+ * - reduce: separador estático (sin animación)
+ * - no reduce: animación ligera (opacity/scale o stroke-dashoffset)
+ */
+export default function AnimatedSeparator({
+  className,
+  variant = "line",
+}: AnimatedSeparatorProps) {
+  const lineClasses = cn(
+    "h-px w-full max-w-2xl mx-auto",
+    "bg-gradient-to-r from-transparent via-gray-300/80 dark:via-gray-600/60 to-transparent",
+    "separator-line",
+    className
+  );
+
+  if (variant === "svg") {
+    return (
+      <div
+        className={cn("flex justify-center py-6 sm:py-8", className)}
+        aria-hidden
+      >
+        <svg
+          className="separator-svg w-24 h-1 text-gray-300 dark:text-gray-600"
+          viewBox="0 0 96 4"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 2h92"
+            stroke="currentColor"
+            strokeWidth="1"
+            strokeLinecap="round"
+            className="separator-stroke"
+          />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("py-6 sm:py-8 px-4", className)}
+      aria-hidden
+    >
+      <div className={lineClasses} />
+    </div>
+  );
+}

--- a/src/components/common/GlassCard.tsx
+++ b/src/components/common/GlassCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+type GlassCardProps = React.HTMLAttributes<HTMLDivElement> & {
+  /** Si en el futuro se usa Slot, se puede delegar; por ahora siempre div */
+  asChild?: boolean;
+};
+
+/**
+ * Card reutilizable para tiles bento: borde suave, sombra ligera, rounded-2xl.
+ * Soporta className. asChild reservado para futuro Slot.
+ */
+const GlassCard = forwardRef<HTMLDivElement, GlassCardProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "rounded-2xl border border-black/8 dark:border-white/12",
+          "bg-white/90 dark:bg-gray-900/90 backdrop-blur-[2px]",
+          "shadow-[0_1px_3px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2)]",
+          "transition-shadow duration-200 hover:shadow-md",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+GlassCard.displayName = "GlassCard";
+
+export default GlassCard;

--- a/src/components/home/BentoSection.tsx
+++ b/src/components/home/BentoSection.tsx
@@ -1,0 +1,87 @@
+import {
+  MessageCircle,
+  Truck,
+  Shield,
+  FileText,
+} from "lucide-react";
+import GlassCard from "@/components/common/GlassCard";
+import { cn } from "@/lib/utils";
+
+const tiles = [
+  {
+    title: "Atención a clínicas y doctores",
+    description: "Asesoría dedicada para tu consultorio.",
+    Icon: MessageCircle,
+    className: "col-span-2",
+  },
+  {
+    title: "Envíos a todo México",
+    description: "Entregas seguras y rastreables.",
+    Icon: Truck,
+    className: "",
+  },
+  {
+    title: "Pago seguro",
+    description: "Procesamiento confiable de pagos.",
+    Icon: Shield,
+    className: "",
+  },
+  {
+    title: "Factura y soporte",
+    description: "Facturación electrónica y soporte postventa.",
+    Icon: FileText,
+    className: "col-span-2",
+  },
+];
+
+export default function BentoSection() {
+  return (
+    <section
+      className="max-w-6xl mx-auto px-4 py-10 sm:py-14"
+      aria-labelledby="bento-trust-heading"
+    >
+      <h2
+        id="bento-trust-heading"
+        className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-2 text-center"
+      >
+        Confianza y servicio
+      </h2>
+      <p className="text-muted-foreground text-center max-w-xl mx-auto mb-8 sm:mb-10 text-sm sm:text-base">
+        Pensado para clínicas y profesionales: atención personalizada, envíos nacionales y soporte continuo.
+      </p>
+
+      <div
+        className={cn(
+          "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-5",
+          "auto-rows-fr"
+        )}
+      >
+        {tiles.map(({ title, description, Icon, className }) => (
+          <GlassCard
+            key={title}
+            className={cn(
+              "p-5 sm:p-6 flex flex-col gap-3 min-h-[120px]",
+              "border border-gray-200/80 dark:border-gray-700/60",
+              className
+            )}
+          >
+            <div
+              className="w-10 h-10 rounded-xl bg-primary-100 dark:bg-primary-900/40 flex items-center justify-center text-primary-600 dark:text-primary-400 flex-shrink-0"
+              aria-hidden
+            >
+              <Icon className="w-5 h-5" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm sm:text-base">
+                {title}
+              </h3>
+              <p className="text-muted-foreground text-xs sm:text-sm mt-0.5">
+                {description}
+              </p>
+            </div>
+          </GlassCard>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/CategoryGrid.tsx
+++ b/src/components/home/CategoryGrid.tsx
@@ -1,0 +1,178 @@
+import "server-only";
+import Link from "next/link";
+import { getSections } from "@/lib/catalog/getSections";
+import { ROUTES } from "@/lib/routes";
+import GlassCard from "@/components/common/GlassCard";
+import { cn } from "@/lib/utils";
+import {
+  Package,
+  Stethoscope,
+  Scissors,
+  Smile,
+  Droplet,
+  Syringe,
+  Shield,
+  Sparkles,
+  Grid3x3,
+  ChevronRight,
+} from "lucide-react";
+
+function getSectionIcon(slug: string) {
+  const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+    consumibles: Package,
+    equipos: Grid3x3,
+    "instrumental-clinico": Stethoscope,
+    "instrumental-ortodoncia": Scissors,
+    ortodoncia: Smile,
+    "ortodoncia-brackets-y-tubos": Sparkles,
+    "ortodoncia-arcos-y-resortes": Scissors,
+    "ortodoncia-accesorios-y-retenedores": Shield,
+    profilaxis: Droplet,
+    anestesia: Syringe,
+    "consumibles-y-profilaxis": Package,
+  };
+  for (const [key, Icon] of Object.entries(iconMap)) {
+    if (slug.toLowerCase().includes(key.toLowerCase())) return Icon;
+  }
+  return Package;
+}
+
+const FALLBACK_LARGE = [
+  { slug: "destacados", name: "Destacados" },
+  { slug: "catalogo", name: "Catálogo" },
+];
+const FALLBACK_SMALL = [
+  { slug: "tienda", name: "Ver tienda" },
+  { slug: "tienda", name: "Productos" },
+  { slug: "tienda", name: "Explorar" },
+  { slug: "tienda", name: "Más" },
+];
+
+export default async function CategoryGrid() {
+  const sections = await getSections(10);
+  const hasSections = sections.length > 0;
+  const large = hasSections ? sections.slice(0, 2) : FALLBACK_LARGE;
+  const small = hasSections ? sections.slice(2, 8) : FALLBACK_SMALL;
+
+  const hrefFor = (slug: string) =>
+    hasSections ? ROUTES.section(slug) : ROUTES.tienda();
+
+  return (
+    <section
+      className="max-w-6xl mx-auto px-4 py-10 sm:py-14"
+      aria-labelledby="category-grid-heading"
+    >
+      <h2
+        id="category-grid-heading"
+        className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-2"
+      >
+        Explora por categorías
+      </h2>
+      <p className="text-muted-foreground mb-8 sm:mb-10 text-sm sm:text-base">
+        Navega por nuestras categorías y encuentra lo que necesitas.
+      </p>
+
+      <div
+        className={cn(
+          "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-5",
+          "auto-rows-fr"
+        )}
+      >
+        {/* 2 categorías grandes */}
+        {large.map((section) => {
+          const Icon = getSectionIcon(section.slug);
+          return (
+            <Link
+              key={`${section.slug}-${section.name}-lg`}
+              href={hrefFor(section.slug)}
+              className={cn(
+                "sm:col-span-2 min-h-[140px] sm:min-h-[160px]",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-2xl"
+              )}
+              aria-label={`Ver productos de ${section.name}`}
+            >
+              <GlassCard
+                className={cn(
+                  "h-full p-5 sm:p-6 flex flex-row sm:flex-col gap-4",
+                  "border border-gray-200/80 dark:border-gray-700/60",
+                  "hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200"
+                )}
+              >
+                <div
+                  className="w-12 h-12 sm:w-14 sm:h-14 rounded-xl bg-primary-100 dark:bg-primary-900/40 flex items-center justify-center text-primary-600 dark:text-primary-400 flex-shrink-0"
+                  aria-hidden
+                >
+                  <Icon className="w-6 h-6 sm:w-7 sm:h-7" />
+                </div>
+                <div className="flex-1 min-w-0 flex flex-col justify-center">
+                  <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-base sm:text-lg">
+                    {section.name}
+                  </h3>
+                  <p className="text-muted-foreground text-sm mt-0.5 flex items-center gap-1">
+                    Ver productos
+                    <ChevronRight className="w-4 h-4 flex-shrink-0" aria-hidden />
+                  </p>
+                </div>
+              </GlassCard>
+            </Link>
+          );
+        })}
+
+        {/* 4–6 categorías pequeñas */}
+        {small.map((section, i) => {
+          const Icon = getSectionIcon(section.slug);
+          return (
+            <Link
+              key={`${section.slug}-${section.name}-sm-${i}`}
+              href={hrefFor(section.slug)}
+              className={cn(
+                "min-h-[100px]",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-2xl"
+              )}
+              aria-label={`Ver productos de ${section.name}`}
+            >
+              <GlassCard
+                className={cn(
+                  "h-full p-4 sm:p-5 flex flex-col gap-3",
+                  "border border-gray-200/80 dark:border-gray-700/60",
+                  "hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200"
+                )}
+              >
+                <div
+                  className="w-10 h-10 rounded-xl bg-primary-100 dark:bg-primary-900/40 flex items-center justify-center text-primary-600 dark:text-primary-400 flex-shrink-0"
+                  aria-hidden
+                >
+                  <Icon className="w-5 h-5" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm sm:text-base line-clamp-2">
+                    {section.name}
+                  </h3>
+                  <p className="text-muted-foreground text-xs mt-0.5 flex items-center gap-1">
+                    Ver
+                    <ChevronRight className="w-3 h-3 flex-shrink-0" aria-hidden />
+                  </p>
+                </div>
+              </GlassCard>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Ver todas: link a /tienda */}
+      <div className="mt-6 text-center">
+        <Link
+          href={ROUTES.tienda()}
+          className={cn(
+            "inline-flex items-center gap-2 text-primary-600 dark:text-primary-400 font-medium text-sm sm:text-base",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg px-3 py-1.5"
+          )}
+          aria-label="Ver toda la tienda"
+        >
+          Ver toda la tienda
+          <ChevronRight className="w-4 h-4" aria-hidden />
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Utilidad para combinar classNames con Tailwind (evita conflictos).
+ * Usado por GlassCard, AnimatedSeparator, BentoSection, CategoryGrid, etc.
+ */
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(
+  ...inputs: Array<string | undefined | null | false | 0>
+) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
# PR-H2: Bento trust + categorías bento

## Objetivo

- Añadir una sección editorial tipo bento de confianza/valor (trust, B2B, soporte, envíos).
- Rediseñar categorías como bento grid (2 grandes + varias pequeñas).
- Añadir separadores sutiles entre bloques (con `prefers-reduced-motion` respetado).

## Cambios

### Componentes comunes

| Archivo | Descripción |
|--------|-------------|
| `src/components/common/GlassCard.tsx` | Card reutilizable: `rounded-2xl`, borde suave (border + opacity), sombra ligera, soporte `className`, opcional `asChild` para futuro Slot. Sirve para tiles del bento. |
| `src/components/common/AnimatedSeparator.tsx` | Separador (línea horizontal o mini SVG). Con motion sutil; con `prefers-reduced-motion: reduce` queda estático (sin animación). |

### Componentes Home

| Archivo | Descripción |
|--------|-------------|
| `src/components/home/BentoSection.tsx` | Sección "Confianza y servicio" editorial. Grid responsive: desktop 4 columnas (1–2 tiles con `col-span-2`), mobile 1 columna. Tiles: Atención clínicas/doctores (MessageCircle), Envíos a todo México (Truck), Pago seguro (Shield), Factura y soporte (FileText). Usa GlassCard y lucide. |
| `src/components/home/CategoryGrid.tsx` | "Explora por categorías" en bento: 2 categorías grandes + 4–6 pequeñas. Cada card es enlace a sección/tienda. Hover: elevación suave. A11y: focus visible. |

### Integración

| Archivo | Cambio |
|--------|--------|
| `src/app/page.tsx` | Tras el hero: `<AnimatedSeparator />` → `<BentoSection />` → `<AnimatedSeparator />` → `<CategoryGrid />`. No se modifica el hero. |

### Estilo / motion

- Separador: keyframes `separator-fade` y `separator-draw` en `globals.css`; con `@media (prefers-reduced-motion: reduce)` las animaciones se desactivan.
- Sin librerías nuevas.

## Archivos tocados / creados

- `src/components/common/GlassCard.tsx`
- `src/components/common/AnimatedSeparator.tsx`
- `src/components/home/BentoSection.tsx`
- `src/components/home/CategoryGrid.tsx`
- `src/app/page.tsx` (orden de secciones: hero → separador → bento → separador → categorías)
- `src/app/globals.css` (keyframes del separador, ya existentes)
- `src/lib/utils.ts` (utilidad `cn` para className; usa clsx + tailwind-merge ya en el proyecto)
- `docs/PR-H2_bento-categorias.md` (este archivo)

## QA manual

- **Desktop 1440px:** Bento 4 columnas, 2 tiles con `col-span-2`; CategoryGrid 2 grandes + pequeñas; separadores visibles.
- **Mobile 390px:** Una columna, sin overflow horizontal; bento y categorías apilados.
- **prefers-reduced-motion:** Separador estático (sin animación).
- **Focus visible:** Enlaces de CategoryGrid con anillo de foco visible.

## Confirmación

**No se tocó:** checkout, pagos/Stripe/webhook, Supabase (solo se usa `getSections` existente), admin, shipping, rutas API.

## Branch / Commit / PR

- **Branch:** `feat/home-pr-h2-bento-categories`
- **Commit (conventional):** `feat(home): pr-h2 bento trust + category grid`
- **PR:** Base `main`, title **PR-H2: Bento trust + categorías bento**, body: contenido de este documento.
