### PR TITLE
PR-H10: WhatsApp confirmado en checkout

### DIFF
--- a/docs/PR-H10_whatsapp-confirm.md
+++ b/docs/PR-H10_whatsapp-confirm.md
@@ -1,0 +1,26 @@
+# PR-H10: WhatsApp confirmado en checkout
+
+## Objetivo
+Implementar UX simple para WhatsApp en checkout:
+- Checkbox “Este es mi número de WhatsApp”
+- Texto aclaratorio debajo
+- Guardar en `orders.metadata` como `whatsapp_confirmed` (boolean)
+- Sin romper checkout/pagos/envíos/admin
+
+## Archivos tocados
+- `src/lib/checkout/schemas.ts` – `whatsappConfirmed` con default false; tipo `DatosFormValues` para formulario
+- `src/app/checkout/datos/ClientPage.tsx` – checkbox “Este es mi número de WhatsApp”, helper, A11y (id/htmlFor, focus-premium), min-h-[44px] en row; persistencia vía setDatos
+- `src/components/checkout/AddressAutocompleteClient.tsx` – prop `setValue` tipada con `DatosFormValues` (compatibilidad)
+- `src/app/admin/pedidos/[id]/page.tsx` – badge “WhatsApp confirmado: Sí/No” en detalle de pedido (solo si existe en metadata)
+
+No se modificaron: `save-order`, `create-order`, `PagoClient` (ya persistían `whatsapp_confirmed` en metadata).
+
+## QA checklist
+- [ ] Checkout datos: ingresar teléfono, marcar/desmarcar checkbox, completar flujo hasta guardar orden
+- [ ] Verificar que `metadata.whatsapp_confirmed` está en la orden (logs/server o DB)
+- [ ] Admin detalle de pedido: se muestra “WhatsApp confirmado: Sí/No” cuando existe el campo
+- [ ] `pnpm -s verify` exit 0
+- [ ] A11y: label asociado al checkbox, focus-visible (focus-premium), área clicable amplia
+
+## Confirmación
+**No se tocó:** checkout payments, Stripe, webhooks, shipping APIs, admin APIs. Solo formulario de datos de contacto en checkout, persistencia en metadata existente y visualización opcional en admin detalle de pedido.

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -311,6 +311,14 @@ export default async function AdminPedidoDetailPage({
                   <p className="font-medium">{order.shipping.contact_phone}</p>
                 </div>
               )}
+              {typeof (order.metadata as Record<string, unknown> | null)?.whatsapp_confirmed === "boolean" && (
+                <div>
+                  <p className="text-gray-600">WhatsApp confirmado</p>
+                  <p className="font-medium">
+                    {(order.metadata as { whatsapp_confirmed?: boolean }).whatsapp_confirmed ? "Sí" : "No"}
+                  </p>
+                </div>
+              )}
             </div>
 
             {/* Dirección de envío */}

--- a/src/app/checkout/datos/ClientPage.tsx
+++ b/src/app/checkout/datos/ClientPage.tsx
@@ -9,7 +9,7 @@ import { useSelectedIds } from "@/lib/store/checkoutSelectors";
 import { useCheckoutStore } from "@/lib/store/checkoutStore";
 import type { UiShippingOption } from "@/lib/store/checkoutStore";
 import type { NormalizedShippingOption } from "@/lib/shipping/normalizeRates";
-import { datosSchema, type DatosForm, MX_STATES } from "@/lib/checkout/schemas";
+import { datosSchema, type DatosFormValues, MX_STATES } from "@/lib/checkout/schemas";
 import CheckoutStepIndicatorThree from "@/components/checkout/CheckoutStepIndicatorThree";
 import CheckoutDebugPanel from "@/components/CheckoutDebugPanel";
 import Link from "next/link";
@@ -42,7 +42,7 @@ function DatosPageContent() {
     }
   }, [selectedItems.length, router]);
 
-  const form = useForm<DatosForm>({
+  const form = useForm<DatosFormValues>({
     resolver: zodResolver(datosSchema),
     mode: "onChange",
     reValidateMode: "onChange",
@@ -272,7 +272,7 @@ function DatosPageContent() {
   }, [setValue]);
 
   // Sanitización: trim en blur para campos de texto
-  const handleBlur = (field: keyof DatosForm) => {
+  const handleBlur = (field: keyof DatosFormValues) => {
     const value = watch(field);
     if (typeof value === "string") {
       setValue(field, value.trim() as never, { shouldValidate: true });
@@ -664,7 +664,7 @@ function DatosPageContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cpValue, stateValue, cityValue, selectedItems, fetchShippingRates]);
 
-  const onSubmit: SubmitHandler<DatosForm> = async (values) => {
+  const onSubmit: SubmitHandler<DatosFormValues> = async (values) => {
     setSubmitError(null);
     try {
       const store = useCheckoutStore.getState();
@@ -715,7 +715,7 @@ function DatosPageContent() {
         }
       }
 
-      store.setDatos(values); // avanza step -> "pago" y persiste checkoutItems
+      store.setDatos({ ...values, whatsappConfirmed: values.whatsappConfirmed ?? false }); // avanza step -> "pago" y persiste checkoutItems
       router.push("/checkout/pago");
     } catch (err) {
       console.error("submit(datos) failed", err);
@@ -964,23 +964,23 @@ function DatosPageContent() {
             </p>
           )}
           
-          {/* Checkbox de confirmación WhatsApp (OBLIGATORIO) */}
-          <div className="mt-3">
-            <label className="flex items-start gap-2 cursor-pointer">
+          {/* Checkbox: Este es mi número de WhatsApp (metadata.whatsapp_confirmed) */}
+          <div className="mt-3 min-h-[44px] flex flex-col justify-center">
+            <label htmlFor="whatsappConfirmed" className="flex items-start gap-2 cursor-pointer">
               <input
+                id="whatsappConfirmed"
                 type="checkbox"
                 {...register("whatsappConfirmed")}
-                className="mt-0.5 h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                className="mt-0.5 h-4 w-4 text-primary-600 focus-premium border-gray-300 rounded"
+                aria-describedby="whatsapp-confirmed-help"
               />
               <span className="text-sm text-gray-700">
-                Confirmo que este es mi número de WhatsApp *
+                Este es mi número de WhatsApp
               </span>
             </label>
-            {errors.whatsappConfirmed && (
-              <p className="text-red-500 text-sm mt-1" role="alert">
-                {errors.whatsappConfirmed.message}
-              </p>
-            )}
+            <p id="whatsapp-confirmed-help" className="text-gray-500 text-xs mt-1 ml-6">
+              Lo usaremos para enviarte actualizaciones y para que puedas mandar tu comprobante si pagas por transferencia.
+            </p>
           </div>
         </div>
 

--- a/src/components/checkout/AddressAutocompleteClient.tsx
+++ b/src/components/checkout/AddressAutocompleteClient.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import type { UseFormSetValue, UseFormRegisterReturn } from "react-hook-form";
-import type { DatosForm } from "@/lib/checkout/schemas";
+import type { DatosFormValues } from "@/lib/checkout/schemas";
 
 // Tipos para Google Places API
 interface AddressComponents {
@@ -16,7 +16,7 @@ interface AddressComponents {
 }
 
 interface AddressAutocompleteClientProps {
-  setValue: UseFormSetValue<DatosForm>;
+  setValue: UseFormSetValue<DatosFormValues>;
   register: UseFormRegisterReturn<"address">;
   errors?: { address?: { message?: string } };
   onAddressSelect?: (address: string) => void;

--- a/src/lib/checkout/schemas.ts
+++ b/src/lib/checkout/schemas.ts
@@ -68,9 +68,7 @@ export const datosSchema = z.object({
       return normalizeToMx10(v);
     })
     .refine((v) => isValidMx10(v), { message: "Ingresa un teléfono de 10 dígitos" }),
-  whatsappConfirmed: z.boolean().refine((v) => v === true, {
-    message: "Debes confirmar que este es tu número de WhatsApp para continuar",
-  }),
+  whatsappConfirmed: z.boolean().default(false),
   shippingAddressConfirmed: z.boolean().refine((v) => v === true, {
     message: "Debes confirmar que tu dirección es correcta para continuar",
   }),
@@ -92,3 +90,5 @@ export const datosSchema = z.object({
 });
 
 export type DatosForm = z.infer<typeof datosSchema>;
+/** Valores del formulario (input); whatsappConfirmed puede venir sin marcar */
+export type DatosFormValues = z.input<typeof datosSchema>;


### PR DESCRIPTION
# PR-H10: WhatsApp confirmado en checkout

## Objetivo
Implementar UX simple para WhatsApp en checkout:
- Checkbox “Este es mi número de WhatsApp”
- Texto aclaratorio debajo
- Guardar en `orders.metadata` como `whatsapp_confirmed` (boolean)
- Sin romper checkout/pagos/envíos/admin

## Archivos tocados
- `src/lib/checkout/schemas.ts` – `whatsappConfirmed` con default false; tipo `DatosFormValues` para formulario
- `src/app/checkout/datos/ClientPage.tsx` – checkbox “Este es mi número de WhatsApp”, helper, A11y (id/htmlFor, focus-premium), min-h-[44px] en row; persistencia vía setDatos
- `src/components/checkout/AddressAutocompleteClient.tsx` – prop `setValue` tipada con `DatosFormValues` (compatibilidad)
- `src/app/admin/pedidos/[id]/page.tsx` – badge “WhatsApp confirmado: Sí/No” en detalle de pedido (solo si existe en metadata)

No se modificaron: `save-order`, `create-order`, `PagoClient` (ya persistían `whatsapp_confirmed` en metadata).

## QA checklist
- [ ] Checkout datos: ingresar teléfono, marcar/desmarcar checkbox, completar flujo hasta guardar orden
- [ ] Verificar que `metadata.whatsapp_confirmed` está en la orden (logs/server o DB)
- [ ] Admin detalle de pedido: se muestra “WhatsApp confirmado: Sí/No” cuando existe el campo
- [ ] `pnpm -s verify` exit 0
- [ ] A11y: label asociado al checkbox, focus-visible (focus-premium), área clicable amplia

## Confirmación
**No se tocó:** checkout payments, Stripe, webhooks, shipping APIs, admin APIs. Solo formulario de datos de contacto en checkout, persistencia en metadata existente y visualización opcional en admin detalle de pedido.
