### PR TITLE
PR-H11: WhatsApp links + mensaje prellenado

### DIFF
--- a/docs/PR-H11_whatsapp-links.md
+++ b/docs/PR-H11_whatsapp-links.md
@@ -1,0 +1,21 @@
+# PR-H11: WhatsApp link + mensaje prellenado (metadata.whatsapp_confirmed)
+
+## Objetivo
+Usar `buildWhatsAppUrl` y mensajes prellenados para CTAs de WhatsApp; mostrar hint cuando `whatsapp_confirmed === false` en pago-pendiente. Sin tocar Stripe/webhooks/envíos/admin APIs.
+
+## Archivos tocados
+- `src/lib/whatsapp/format.ts` (nuevo) – `normalizePhoneMX(input)`, `buildWhatsAppUrl({ phoneE164OrMX, text })`
+- `src/components/home/FinalCTA.tsx` – URL con `buildWhatsAppUrl`, texto asesor "Hola, necesito ayuda con mi compra en DDN.", aria-label, focus-premium
+- `src/components/home/HeroIntro.tsx` – mismo mensaje asesor, `buildWhatsAppUrl`, aria-label, focus-premium
+- `src/components/checkout/OrderWhatsAppBlock.tsx` – prop `whatsappConfirmed`; hint "Confirma tu WhatsApp en checkout para seguimiento" cuando false en pending; aria-label y focus-premium en link
+- `src/app/checkout/pago-pendiente/PagoPendienteClient.tsx` – pasar `whatsapp_confirmed` y `whatsapp_wa_digits` desde metadata a `OrderWhatsAppBlock`
+
+## QA checklist
+- [ ] `pnpm -s verify` exit 0
+- [ ] En `/checkout/datos`: confirmar WhatsApp true, completar flujo hasta pago-pendiente
+- [ ] En `/checkout/pago-pendiente`: botón WhatsApp abre wa.me con texto prellenado (comprobante + orderId)
+- [ ] Home CTA "Habla con un asesor" / FinalCTA WhatsApp: abre wa.me con texto "Hola, necesito ayuda con mi compra en DDN."
+- [ ] Si `whatsapp_confirmed === false` en pago-pendiente: se muestra hint "Confirma tu WhatsApp en checkout para seguimiento"; link sigue siendo a DDN
+
+## Confirmación
+**No se tocó:** pagos, Stripe, webhooks, envíos, admin, APIs. Solo helpers de WhatsApp, CTAs en Home/FinalCTA y bloque WhatsApp en pago-pendiente (link + hint).

--- a/src/app/checkout/pago-pendiente/PagoPendienteClient.tsx
+++ b/src/app/checkout/pago-pendiente/PagoPendienteClient.tsx
@@ -160,7 +160,15 @@ export default function PagoPendienteClient({ order, error }: Props) {
                 {/* Bloque de WhatsApp */}
                 {order.total_cents && (() => {
                   const rawMetadata = (order.metadata ?? null) as
-                    | { contact_name?: string; contactName?: string; contact_email?: string; contactEmail?: string; shortId?: string }
+                    | {
+                        contact_name?: string;
+                        contactName?: string;
+                        contact_email?: string;
+                        contactEmail?: string;
+                        shortId?: string;
+                        whatsapp_confirmed?: boolean;
+                        whatsapp_wa_digits?: string;
+                      }
                     | null;
                   const customerName =
                     rawMetadata?.contact_name ??
@@ -178,6 +186,8 @@ export default function PagoPendienteClient({ order, error }: Props) {
                       totalCents={order.total_cents}
                       customerName={customerName}
                       customerEmail={customerEmail}
+                      whatsappWaDigits={rawMetadata?.whatsapp_wa_digits ?? null}
+                      whatsappConfirmed={rawMetadata?.whatsapp_confirmed}
                       orderId={order.id}
                       shortId={rawMetadata?.shortId || null}
                       paymentMethod={order.payment_method || null}

--- a/src/components/checkout/OrderWhatsAppBlock.tsx
+++ b/src/components/checkout/OrderWhatsAppBlock.tsx
@@ -11,6 +11,7 @@ interface OrderWhatsAppBlockProps {
   customerName?: string | null;
   customerEmail?: string | null;
   whatsappWaDigits?: string | null; // Número de WhatsApp del cliente (desde metadata.whatsapp_wa_digits)
+  whatsappConfirmed?: boolean; // metadata.whatsapp_confirmed; si false, se muestra hint opcional
   // Props adicionales para analytics
   orderId?: string;
   shortId?: string | null;
@@ -27,6 +28,7 @@ export function OrderWhatsAppBlock(props: OrderWhatsAppBlockProps) {
     customerName,
     customerEmail,
     whatsappWaDigits,
+    whatsappConfirmed,
     orderId,
     shortId,
     paymentMethod,
@@ -60,6 +62,9 @@ export function OrderWhatsAppBlock(props: OrderWhatsAppBlockProps) {
     ? "Si necesitas ayuda con tu pedido o quieres hacer un ajuste, mándanos mensaje por WhatsApp con tu número de pedido."
     : "Cuando tengas tu comprobante de transferencia, envíanoslo por WhatsApp para validar tu pago más rápido.";
 
+  const showWhatsAppHint =
+    !isPaid && whatsappConfirmed === false ? true : false;
+
   const handleClick = () => {
     if (orderId) {
       trackWhatsAppOrderSupportClick({
@@ -89,12 +94,18 @@ export function OrderWhatsAppBlock(props: OrderWhatsAppBlockProps) {
             target="_blank"
             rel="noreferrer"
             onClick={handleClick}
-            className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+            className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700 focus-premium"
+            aria-label={isPaid ? "Contactar por WhatsApp sobre tu pedido" : "Enviar comprobante por WhatsApp"}
           >
             <span>WhatsApp</span>
           </Link>
         </div>
       </div>
+      {showWhatsAppHint && (
+        <p className="mt-2 text-xs text-emerald-700/90">
+          Confirma tu WhatsApp en checkout para seguimiento.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/home/FinalCTA.tsx
+++ b/src/components/home/FinalCTA.tsx
@@ -3,15 +3,21 @@
 import Link from "next/link";
 import { MessageCircle } from "lucide-react";
 import { ROUTES } from "@/lib/routes";
-import { getWhatsAppUrl } from "@/lib/whatsapp/config";
+import { getWhatsAppPhone } from "@/lib/whatsapp/config";
+import { buildWhatsAppUrl } from "@/lib/whatsapp/format";
 import { buttonPrimary } from "@/lib/styles/button";
+
+const ASESOR_MESSAGE = "Hola, necesito ayuda con mi compra en DDN.";
 
 /**
  * CTA final editorial: /tienda, /facturacion (o /contacto fallback), WhatsApp.
  * QR placeholder visual (sin librerías).
  */
 export default function FinalCTA() {
-  const waUrl = getWhatsAppUrl("Hola, me interesa hacer un pedido.");
+  const ddnPhone = getWhatsAppPhone();
+  const waUrl = ddnPhone
+    ? buildWhatsAppUrl({ phoneE164OrMX: ddnPhone, text: ASESOR_MESSAGE })
+    : null;
   const facturacionHref = "/facturacion";
 
   return (
@@ -52,8 +58,8 @@ export default function FinalCTA() {
               href={waUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-xl border-2 border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/30 text-green-800 dark:text-green-200 px-6 py-3 font-semibold hover:border-green-400 dark:hover:border-green-600 hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 min-h-[48px] inline-flex items-center justify-center gap-2"
-              aria-label="Contactar por WhatsApp"
+              className="rounded-xl border-2 border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/30 text-green-800 dark:text-green-200 px-6 py-3 font-semibold hover:border-green-400 dark:hover:border-green-600 hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors focus-premium min-h-[48px] inline-flex items-center justify-center gap-2"
+              aria-label="Habla con un asesor por WhatsApp"
             >
               <MessageCircle className="w-5 h-5" aria-hidden />
               WhatsApp

--- a/src/components/home/HeroIntro.tsx
+++ b/src/components/home/HeroIntro.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { MessageCircle } from "lucide-react";
 import { ROUTES } from "@/lib/routes";
-import { getWhatsAppUrl } from "@/lib/whatsapp/config";
+import { getWhatsAppPhone } from "@/lib/whatsapp/config";
+import { buildWhatsAppUrl } from "@/lib/whatsapp/format";
 import { buttonBase } from "@/lib/styles/button";
 import AmbientBackground from "./AmbientBackground";
 import Logo from "@/components/common/Logo";
@@ -18,7 +19,11 @@ import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
 export default function HeroIntro() {
   const prefersReducedMotion = usePrefersReducedMotion();
   const microAnimsEnabled = process.env.NEXT_PUBLIC_MOBILE_MICRO_ANIMS === "true";
-  const waUrl = getWhatsAppUrl("Hola, me gustaría hablar con un asesor sobre productos dentales.");
+  const ASESOR_MESSAGE = "Hola, necesito ayuda con mi compra en DDN.";
+  const ddnPhone = getWhatsAppPhone();
+  const waUrl = ddnPhone
+    ? buildWhatsAppUrl({ phoneE164OrMX: ddnPhone, text: ASESOR_MESSAGE })
+    : null;
 
   const primaryClass = `${buttonBase} rounded-2xl bg-primary-600 text-white hover:bg-primary-700 text-base sm:text-lg font-semibold px-8 sm:px-10 py-3 sm:py-4 transition-all duration-200 shadow-md hover:shadow-lg focus:outline-none focus:ring-4 focus:ring-primary-300 focus:ring-offset-2 focus:ring-offset-transparent`;
 
@@ -55,7 +60,7 @@ export default function HeroIntro() {
           >
             <span className="whitespace-nowrap">Explorar catálogo</span>
           </Link>
-          <Link
+          <a
             href={waUrl ?? "#"}
             target="_blank"
             rel="noopener noreferrer"
@@ -63,12 +68,13 @@ export default function HeroIntro() {
               kind: "button",
               enabled: microAnimsEnabled,
               reducedMotion: prefersReducedMotion,
-              className: secondaryClass,
+              className: secondaryClass + " focus-premium",
             })}
+            aria-label="Habla con un asesor por WhatsApp"
           >
             <MessageCircle className="inline-block mr-2 w-5 h-5 shrink-0" aria-hidden />
             <span className="whitespace-nowrap">Habla con un asesor</span>
-          </Link>
+          </a>
         </div>
 
         {/* Icon Rail - beneficios */}

--- a/src/lib/whatsapp/format.ts
+++ b/src/lib/whatsapp/format.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers para URLs de WhatsApp (wa.me) y normalización de teléfono MX.
+ * PR-H11: links + mensaje prellenado; sin tocar pagos/envíos/admin.
+ */
+
+/** Quita espacios, guiones, paréntesis; deja solo dígitos */
+function digitsOnly(input: string): string {
+  return input.replace(/\D/g, "");
+}
+
+/**
+ * Normaliza un teléfono mexicano a dígitos para wa.me (52 + 10 dígitos).
+ * - Quita espacios, guiones, paréntesis.
+ * - Si empieza con +52 o 52, normaliza a últimos 10 y antepone 52.
+ * - Si son 10 dígitos, asume MX y antepone 52.
+ * @returns "52" + 10 dígitos o null si no es válido
+ */
+export function normalizePhoneMX(input: string): string | null {
+  const d = digitsOnly(input);
+  if (d.length === 10 && /^\d{10}$/.test(d)) {
+    return "52" + d;
+  }
+  if (d.length >= 10 && (d.startsWith("52") || d.startsWith("521"))) {
+    const ten = d.slice(-10);
+    if (/^\d{10}$/.test(ten)) return "52" + ten;
+  }
+  return null;
+}
+
+/**
+ * Construye URL de WhatsApp (wa.me) con mensaje prellenado.
+ * @param phoneE164OrMX - Teléfono solo dígitos (sin +), ej. 525531033715
+ * @param text - Mensaje a prellenar
+ */
+export function buildWhatsAppUrl(params: {
+  phoneE164OrMX: string;
+  text: string;
+}): string {
+  const digits = digitsOnly(params.phoneE164OrMX);
+  const encoded = encodeURIComponent(params.text);
+  return `https://wa.me/${digits || "0"}?text=${encoded}`;
+}


### PR DESCRIPTION
# PR-H11: WhatsApp link + mensaje prellenado (metadata.whatsapp_confirmed)

## Objetivo
Usar `buildWhatsAppUrl` y mensajes prellenados para CTAs de WhatsApp; mostrar hint cuando `whatsapp_confirmed === false` en pago-pendiente. Sin tocar Stripe/webhooks/envíos/admin APIs.

## Archivos tocados
- `src/lib/whatsapp/format.ts` (nuevo) – `normalizePhoneMX(input)`, `buildWhatsAppUrl({ phoneE164OrMX, text })`
- `src/components/home/FinalCTA.tsx` – URL con `buildWhatsAppUrl`, texto asesor "Hola, necesito ayuda con mi compra en DDN.", aria-label, focus-premium
- `src/components/home/HeroIntro.tsx` – mismo mensaje asesor, `buildWhatsAppUrl`, aria-label, focus-premium
- `src/components/checkout/OrderWhatsAppBlock.tsx` – prop `whatsappConfirmed`; hint "Confirma tu WhatsApp en checkout para seguimiento" cuando false en pending; aria-label y focus-premium en link
- `src/app/checkout/pago-pendiente/PagoPendienteClient.tsx` – pasar `whatsapp_confirmed` y `whatsapp_wa_digits` desde metadata a `OrderWhatsAppBlock`

## QA checklist
- [ ] `pnpm -s verify` exit 0
- [ ] En `/checkout/datos`: confirmar WhatsApp true, completar flujo hasta pago-pendiente
- [ ] En `/checkout/pago-pendiente`: botón WhatsApp abre wa.me con texto prellenado (comprobante + orderId)
- [ ] Home CTA "Habla con un asesor" / FinalCTA WhatsApp: abre wa.me con texto "Hola, necesito ayuda con mi compra en DDN."
- [ ] Si `whatsapp_confirmed === false` en pago-pendiente: se muestra hint "Confirma tu WhatsApp en checkout para seguimiento"; link sigue siendo a DDN

## Confirmación
**No se tocó:** pagos, Stripe, webhooks, envíos, admin, APIs. Solo helpers de WhatsApp, CTAs en Home/FinalCTA y bloque WhatsApp en pago-pendiente (link + hint).
