### PR TITLE
PR-H12: Persistir whatsapp_wa_digits en order.metadata

### DIFF
--- a/docs/PR-H12_whatsapp-digits.md
+++ b/docs/PR-H12_whatsapp-digits.md
@@ -1,0 +1,22 @@
+# PR-H12: Persistir whatsapp_wa_digits en order.metadata al confirmar WhatsApp
+
+## Objetivo
+Al marcar "Este es mi número de WhatsApp" en /checkout/datos, persistir en `order.metadata`:
+- `whatsapp_confirmed`: true solo si hay teléfono válido y confirmado.
+- `whatsapp_wa_digits`: string "52" + 10 dígitos (normalizePhoneMX). Si no confirmado o digits null, no incluir o false.
+
+Sin tocar Stripe, envíos, admin ni APIs ajenas a checkout/metadata.
+
+## Archivos tocados
+- `src/app/api/checkout/create-order/route.ts` – Usa `normalizePhoneMX(phone)` cuando `whatsappConfirmed`; `whatsapp_wa_digits` = digits o undefined; degrada a `whatsapp_confirmed: false` si digits es null.
+- `src/app/api/checkout/save-order/route.ts` – Schema con `whatsappWaDigits` opcional; metadata `whatsapp_wa_digits` solo si confirmado y hay digits (payload o metadata existente).
+- `src/app/checkout/gracias/GraciasContent.tsx` – Al llamar save-order, calcula `waDigits = normalizePhoneMX(phone)` si confirmado y envía `whatsappConfirmed` y `whatsappWaDigits` en el body.
+
+## QA checklist
+- [ ] `pnpm -s verify` exit 0.
+- [ ] /checkout/datos: phone 10 dígitos, checkbox confirmado → crear orden → metadata con `whatsapp_confirmed: true` y `whatsapp_wa_digits: "52..."`.
+- [ ] /checkout/datos: confirm=false → metadata `whatsapp_confirmed: false` y sin `whatsapp_wa_digits`.
+- [ ] Phone inválido + confirm=true → metadata `whatsapp_confirmed: false` (sin crash).
+
+## Confirmación
+No se tocó: Stripe, webhooks, envíos, admin, otras APIs. Solo create-order, save-order y GraciasContent (payload save-order).

--- a/src/app/api/checkout/create-order/route.ts
+++ b/src/app/api/checkout/create-order/route.ts
@@ -3,7 +3,8 @@ import { unstable_noStore as noStore } from "next/cache";
 import { createClient } from "@supabase/supabase-js";
 import { createActionSupabase } from "@/lib/supabase/server-actions";
 import { z } from "zod";
-import { toMxE164, toMxWhatsAppDigits, isValidMx10 } from "@/lib/phone/mx";
+import { toMxE164, isValidMx10 } from "@/lib/phone/mx";
+import { normalizePhoneMX } from "@/lib/whatsapp/format";
 import { normalizeShippingPricing } from "@/lib/shipping/normalizeShippingPricing";
 import { normalizeShippingMetadata } from "@/lib/shipping/normalizeShippingMetadata";
 
@@ -266,12 +267,13 @@ export async function POST(req: NextRequest) {
     const phone = orderData.phone || null;
     const whatsappConfirmed = orderData.whatsappConfirmed ?? false;
     const shippingAddressConfirmed = orderData.shippingAddressConfirmed ?? false;
-    
-    // Normalizar teléfono para WhatsApp si es válido
+    // PR-H12: whatsapp_wa_digits = "52" + 10 dígitos solo si confirmado y teléfono válido
+    const whatsappWaDigits =
+      whatsappConfirmed && phone ? normalizePhoneMX(phone) : null;
+    const confirmed = !!(whatsappConfirmed && whatsappWaDigits);
     const whatsappDigits10 = phone && isValidMx10(phone) ? phone : null;
     const whatsappE164 = whatsappDigits10 ? toMxE164(whatsappDigits10) : null;
-    const whatsappWaDigits = whatsappDigits10 ? toMxWhatsAppDigits(whatsappDigits10) : null;
-    
+
     const metadata: Record<string, unknown> = {
       subtotal_cents, // Subtotal real (sin envío ni descuentos)
       shipping_cost_cents: shippingCostCents, // Costo de envío en centavos
@@ -286,8 +288,8 @@ export async function POST(req: NextRequest) {
       whatsapp_raw: phone || null,
       whatsapp_digits10: whatsappDigits10,
       whatsapp_e164: whatsappE164,
-      whatsapp_wa_digits: whatsappWaDigits,
-      whatsapp_confirmed: whatsappConfirmed,
+      whatsapp_wa_digits: whatsappWaDigits ?? undefined,
+      whatsapp_confirmed: confirmed,
       // Confirmación de dirección
       shipping_address_confirmed: shippingAddressConfirmed,
     };

--- a/src/app/api/checkout/save-order/route.ts
+++ b/src/app/api/checkout/save-order/route.ts
@@ -29,6 +29,7 @@ const SaveOrderRequestSchema = z.object({
   payment_id: z.string().optional(),
   metadata: z.record(z.unknown()).optional(),
   whatsappConfirmed: z.boolean().optional().default(false),
+  whatsappWaDigits: z.string().optional(), // "52" + 10 dígitos (PR-H12)
   shippingAddressConfirmed: z.boolean().optional().default(false),
 });
 
@@ -234,10 +235,19 @@ export async function POST(req: NextRequest) {
       contact_city: metadataFromPayload.contact_city || null,
       contact_state: metadataFromPayload.contact_state || null,
       contact_cp: metadataFromPayload.contact_cp || null,
-      // Confirmaciones (preservar existentes o usar nuevos valores)
+      // Confirmaciones (preservar existentes o usar nuevos valores) (PR-H12)
       whatsapp_confirmed: metadataFromPayload.whatsapp_confirmed ?? orderData.whatsappConfirmed ?? false,
       shipping_address_confirmed: metadataFromPayload.shipping_address_confirmed ?? orderData.shippingAddressConfirmed ?? false,
     };
+    const confirmed = metadata.whatsapp_confirmed as boolean;
+    const digits =
+      orderData.whatsappWaDigits ??
+      (typeof metadataFromPayload.whatsapp_wa_digits === "string"
+        ? metadataFromPayload.whatsapp_wa_digits
+        : undefined);
+    if (confirmed && digits) {
+      metadata.whatsapp_wa_digits = digits;
+    }
 
     // Guardar dirección de envío en metadata.shipping_address (merge seguro, preservar si ya existe)
     if (metadataFromPayload.shipping_address && typeof metadataFromPayload.shipping_address === "object") {

--- a/src/app/checkout/gracias/GraciasContent.tsx
+++ b/src/app/checkout/gracias/GraciasContent.tsx
@@ -20,6 +20,7 @@ import { clearCartAction } from "@/lib/actions/cart.server";
 import OrderPointsInfo from "@/components/loyalty/OrderPointsInfo";
 import { OrderWhatsAppBlock } from "@/components/checkout/OrderWhatsAppBlock";
 import ReceiptDownloadsCard from "@/components/checkout/ReceiptDownloadsCard";
+import { normalizePhoneMX } from "@/lib/whatsapp/format";
 
 type LastOrder = {
   orderRef: string;
@@ -259,6 +260,8 @@ export default function GraciasContent() {
             const urlParams = new URLSearchParams(window.location.search);
             const paymentIntentId = urlParams.get("payment_intent");
             
+            const waConfirmed = checkoutDatos.whatsappConfirmed ?? false;
+            const waDigits = waConfirmed ? normalizePhoneMX(checkoutDatos.phone ?? "") : null;
             fetch(`/api/checkout/save-order`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -270,6 +273,8 @@ export default function GraciasContent() {
                 status: "paid",
                 payment_provider: "stripe",
                 payment_id: paymentIntentId || undefined,
+                whatsappConfirmed: waConfirmed && !!waDigits,
+                whatsappWaDigits: waDigits ?? undefined,
                 metadata: {
                   subtotal_cents: subtotalCents,
                   shipping_cost_cents: shippingCents,
@@ -422,6 +427,8 @@ export default function GraciasContent() {
                   const subtotalCents = totalCents - shippingCents + discountCents;
                   
                   if (itemsForSave.length > 0 && totalCents > 0) {
+                    const waConfirmed = checkoutDatos.whatsappConfirmed ?? false;
+                    const waDigits = waConfirmed ? normalizePhoneMX(checkoutDatos.phone ?? "") : null;
                     fetch(`/api/checkout/save-order`, {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
@@ -433,6 +440,8 @@ export default function GraciasContent() {
                         status: "paid",
                         payment_provider: "stripe",
                         payment_id: pi.id,
+                        whatsappConfirmed: waConfirmed && !!waDigits,
+                        whatsappWaDigits: waDigits ?? undefined,
                         metadata: {
                           subtotal_cents: subtotalCents,
                           shipping_cost_cents: shippingCents,


### PR DESCRIPTION
# PR-H12: Persistir whatsapp_wa_digits en order.metadata al confirmar WhatsApp

## Objetivo
Al marcar "Este es mi número de WhatsApp" en /checkout/datos, persistir en `order.metadata`:
- `whatsapp_confirmed`: true solo si hay teléfono válido y confirmado.
- `whatsapp_wa_digits`: string "52" + 10 dígitos (normalizePhoneMX). Si no confirmado o digits null, no incluir o false.

Sin tocar Stripe, envíos, admin ni APIs ajenas a checkout/metadata.

## Archivos tocados
- `src/app/api/checkout/create-order/route.ts` – Usa `normalizePhoneMX(phone)` cuando `whatsappConfirmed`; `whatsapp_wa_digits` = digits o undefined; degrada a `whatsapp_confirmed: false` si digits es null.
- `src/app/api/checkout/save-order/route.ts` – Schema con `whatsappWaDigits` opcional; metadata `whatsapp_wa_digits` solo si confirmado y hay digits (payload o metadata existente).
- `src/app/checkout/gracias/GraciasContent.tsx` – Al llamar save-order, calcula `waDigits = normalizePhoneMX(phone)` si confirmado y envía `whatsappConfirmed` y `whatsappWaDigits` en el body.

## QA checklist
- [ ] `pnpm -s verify` exit 0.
- [ ] /checkout/datos: phone 10 dígitos, checkbox confirmado → crear orden → metadata con `whatsapp_confirmed: true` y `whatsapp_wa_digits: "52..."`.
- [ ] /checkout/datos: confirm=false → metadata `whatsapp_confirmed: false` y sin `whatsapp_wa_digits`.
- [ ] Phone inválido + confirm=true → metadata `whatsapp_confirmed: false` (sin crash).

## Confirmación
No se tocó: Stripe, webhooks, envíos, admin, otras APIs. Solo create-order, save-order y GraciasContent (payload save-order).
