### PR TITLE
PR-A: Feedback + Product Reviews (DB+RLS+API)

### DIFF
--- a/docs/PR-A_feedback_reviews.md
+++ b/docs/PR-A_feedback_reviews.md
@@ -1,0 +1,126 @@
+# PR-A: Feedback y reseñas (solo DB + APIs)
+
+Objetivo: tablas `site_feedback` y `product_reviews`, RLS, y rutas `/api/feedback` (POST) y `/api/reviews` (GET + POST). Sin UI.
+
+## Archivos tocados
+- `ops/sql/2026-02-22_feedback_and_reviews.sql`
+- `docs/PR-A_feedback_reviews.md`
+- `src/app/api/feedback/route.ts`
+- `src/app/api/reviews/route.ts`
+
+---
+
+## SQL PARA PEGAR EN SUPABASE
+
+Ejecutar en **Supabase Dashboard → SQL Editor**. Idempotente (create if not exists, drop policy if exists).
+
+```sql
+-- PR-A: feedback and reviews (idempotent)
+-- Run in Supabase SQL Editor. No destructive operations.
+
+-- A) public.site_feedback
+create table if not exists public.site_feedback (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  page_path text null,
+  type text not null,
+  message text not null,
+  rating int2 null check (rating between 1 and 5),
+  email text null,
+  phone text null,
+  user_id uuid null,
+  status text not null default 'new',
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_site_feedback_page_path_created_at
+  on public.site_feedback (page_path, created_at desc);
+
+alter table public.site_feedback enable row level security;
+
+drop policy if exists "site_feedback_insert_anon_authenticated" on public.site_feedback;
+create policy "site_feedback_insert_anon_authenticated" on public.site_feedback
+  for insert to anon, authenticated with check (true);
+
+-- B) public.product_reviews
+create table if not exists public.product_reviews (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  product_id uuid not null references public.products(id) on delete cascade,
+  rating int2 not null check (rating between 1 and 5),
+  title text null,
+  body text null,
+  author_name text null,
+  is_example boolean not null default false,
+  is_published boolean not null default false,
+  source text null,
+  user_id uuid null,
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_product_reviews_product_id_created_at
+  on public.product_reviews (product_id, created_at desc);
+
+create index if not exists idx_product_reviews_product_id_published
+  on public.product_reviews (product_id) where is_published = true;
+
+alter table public.product_reviews enable row level security;
+
+drop policy if exists "product_reviews_select_published" on public.product_reviews;
+create policy "product_reviews_select_published" on public.product_reviews
+  for select to anon, authenticated using (is_published = true);
+
+drop policy if exists "product_reviews_insert_anon_authenticated" on public.product_reviews;
+create policy "product_reviews_insert_anon_authenticated" on public.product_reviews
+  for insert to anon, authenticated
+  with check (
+    is_published = false
+    and is_example = false
+    and (source is null or source = 'user')
+  );
+```
+
+---
+
+## APIs
+
+- **POST /api/feedback** — Body: `type` (bug|idea|opinion|other), `message` (min 10), opcional: `rating` 1–5, `email`, `phone`, `page_path`. Throttle 3 req/10 min por IP. Res: 201 `{ status: "ok" }`.
+- **GET /api/reviews?product_id=uuid** — Res: `product_id`, `average_rating`, `review_count`, `real_reviews`, `example_reviews`.
+- **POST /api/reviews** — Body: `product_id`, `rating` 1–5, opcional: `title`, `body` (min 10), `author_name`. Inserta con `is_published=false`, `is_example=false`, `source='user'`. Res: 200 `{ message: "Gracias, tu reseña será revisada" }`.
+
+---
+
+Confirmación: **NO UI incluida**. No se toca checkout, admin, stripe, shipping, orders.
+
+---
+
+## Reporte para PR description
+
+### Lista de archivos tocados
+- `ops/sql/2026-02-22_feedback_and_reviews.sql`
+- `docs/PR-A_feedback_reviews.md`
+- `src/app/api/feedback/route.ts`
+- `src/app/api/reviews/route.ts`
+
+### Bloque SQL completo para Supabase
+Véase sección **SQL PARA PEGAR EN SUPABASE** arriba (mismo contenido que `ops/sql/2026-02-22_feedback_and_reviews.sql`).
+
+### 3 ejemplos de prueba (curl)
+
+```bash
+# 1) POST feedback
+curl -s -X POST http://localhost:3000/api/feedback \
+  -H "Content-Type: application/json" \
+  -d '{"type":"opinion","message":"Me gustaría ver más filtros en la búsqueda.","rating":4}'
+
+# 2) GET reviews (sustituir PRODUCT_UUID por un uuid de products)
+curl -s "http://localhost:3000/api/reviews?product_id=PRODUCT_UUID"
+
+# 3) POST review (sustituir PRODUCT_UUID)
+curl -s -X POST http://localhost:3000/api/reviews \
+  -H "Content-Type: application/json" \
+  -d '{"product_id":"PRODUCT_UUID","rating":5,"title":"Muy buen producto","body":"Llegó rápido y bien empaquetado.","author_name":"Ana"}'
+```
+
+### Confirmación
+**NO UI incluida.** Solo DB (SQL) + RLS + APIs. No se modifican checkout, admin, stripe, shipping, orders.

--- a/ops/sql/2026-02-22_feedback_and_reviews.sql
+++ b/ops/sql/2026-02-22_feedback_and_reviews.sql
@@ -1,0 +1,63 @@
+-- PR-A: feedback and reviews (idempotent)
+-- Run in Supabase SQL Editor. No destructive operations.
+
+-- A) public.site_feedback
+create table if not exists public.site_feedback (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  page_path text null,
+  type text not null,
+  message text not null,
+  rating int2 null check (rating between 1 and 5),
+  email text null,
+  phone text null,
+  user_id uuid null,
+  status text not null default 'new',
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_site_feedback_page_path_created_at
+  on public.site_feedback (page_path, created_at desc);
+
+alter table public.site_feedback enable row level security;
+
+drop policy if exists "site_feedback_insert_anon_authenticated" on public.site_feedback;
+create policy "site_feedback_insert_anon_authenticated" on public.site_feedback
+  for insert to anon, authenticated with check (true);
+
+-- B) public.product_reviews
+create table if not exists public.product_reviews (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  product_id uuid not null references public.products(id) on delete cascade,
+  rating int2 not null check (rating between 1 and 5),
+  title text null,
+  body text null,
+  author_name text null,
+  is_example boolean not null default false,
+  is_published boolean not null default false,
+  source text null,
+  user_id uuid null,
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_product_reviews_product_id_created_at
+  on public.product_reviews (product_id, created_at desc);
+
+create index if not exists idx_product_reviews_product_id_published
+  on public.product_reviews (product_id) where is_published = true;
+
+alter table public.product_reviews enable row level security;
+
+drop policy if exists "product_reviews_select_published" on public.product_reviews;
+create policy "product_reviews_select_published" on public.product_reviews
+  for select to anon, authenticated using (is_published = true);
+
+drop policy if exists "product_reviews_insert_anon_authenticated" on public.product_reviews;
+create policy "product_reviews_insert_anon_authenticated" on public.product_reviews
+  for insert to anon, authenticated
+  with check (
+    is_published = false
+    and is_example = false
+    and (source is null or source = 'user')
+  );

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getPublicSupabase } from "@/lib/supabase/public";
+
+export const dynamic = "force-dynamic";
+
+const THROTTLE_WINDOW_MS = 10 * 60 * 1000;
+const THROTTLE_MAX = 3;
+const throttleMap = new Map<string, number[]>();
+
+function getClientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  const xri = req.headers.get("x-real-ip");
+  if (xri) return xri.trim();
+  return "unknown";
+}
+
+function throttle(ip: string): boolean {
+  const now = Date.now();
+  let times = throttleMap.get(ip) ?? [];
+  times = times.filter((t) => now - t < THROTTLE_WINDOW_MS);
+  if (times.length >= THROTTLE_MAX) return false;
+  times.push(now);
+  throttleMap.set(ip, times);
+  return true;
+}
+
+const bodySchema = z.object({
+  type: z.enum(["bug", "idea", "opinion", "other"]),
+  message: z.string().min(10, "message min 10 caracteres"),
+  rating: z.number().int().min(1).max(5).optional(),
+  email: z.string().email().optional().nullable(),
+  phone: z.string().optional().nullable(),
+  page_path: z.string().optional().nullable(),
+});
+
+export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  if (!throttle(ip)) {
+    return NextResponse.json({ error: "Demasiadas solicitudes" }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Body JSON inválido" }, { status: 400 });
+  }
+
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.errors[0]?.message ?? "Validación fallida" },
+      { status: 422 },
+    );
+  }
+
+  const pagePath = parsed.data.page_path ?? (() => {
+    try {
+      const ref = req.headers.get("referer");
+      return ref ? new URL(ref).pathname : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  const supabase = getPublicSupabase();
+  const { error } = await supabase.from("site_feedback").insert({
+    type: parsed.data.type,
+    message: parsed.data.message,
+    rating: parsed.data.rating ?? null,
+    email: parsed.data.email ?? null,
+    phone: parsed.data.phone ?? null,
+    page_path: pagePath,
+    status: "new",
+    meta: {
+      ip,
+      user_agent: req.headers.get("user-agent") ?? null,
+    },
+  });
+
+  if (error) {
+    console.error("[POST /api/feedback]", error);
+    return NextResponse.json({ error: "Error al guardar" }, { status: 500 });
+  }
+
+  return NextResponse.json({ status: "ok" }, { status: 201 });
+}

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getPublicSupabase } from "@/lib/supabase/public";
+
+export const dynamic = "force-dynamic";
+
+const postBodySchema = z.object({
+  product_id: z.string().uuid(),
+  rating: z.number().int().min(1).max(5),
+  title: z.string().optional().nullable(),
+  body: z.string().optional().nullable(),
+  author_name: z.string().optional().nullable(),
+}).refine((d) => !d.body || d.body.length >= 10, { message: "body min 10 caracteres", path: ["body"] });
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const productId = url.searchParams.get("product_id");
+  if (!productId) {
+    return NextResponse.json({ error: "product_id requerido" }, { status: 400 });
+  }
+  const uuidSchema = z.string().uuid();
+  const parsed = uuidSchema.safeParse(productId);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "product_id uuid inválido" }, { status: 422 });
+  }
+
+  const supabase = getPublicSupabase();
+  const { data: rows, error } = await supabase
+    .from("product_reviews")
+    .select("id, rating, title, body, author_name, is_example, created_at")
+    .eq("product_id", parsed.data)
+    .eq("is_published", true)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("[GET /api/reviews]", error);
+    return NextResponse.json({ error: "Error al cargar reseñas" }, { status: 500 });
+  }
+
+  const real = (rows ?? []).filter((r) => !r.is_example);
+  const example = (rows ?? []).filter((r) => r.is_example);
+  const all = rows ?? [];
+  const sum = all.reduce((s, r) => s + r.rating, 0);
+  const average_rating = all.length ? Math.round((sum / all.length) * 10) / 10 : 0;
+
+  return NextResponse.json({
+    product_id: parsed.data,
+    average_rating,
+    review_count: all.length,
+    real_reviews: real,
+    example_reviews: example,
+  });
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Body JSON inválido" }, { status: 400 });
+  }
+
+  const parsed = postBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.errors[0]?.message ?? "Validación fallida" },
+      { status: 422 },
+    );
+  }
+
+  const supabase = getPublicSupabase();
+  const { error } = await supabase.from("product_reviews").insert({
+    product_id: parsed.data.product_id,
+    rating: parsed.data.rating,
+    title: parsed.data.title ?? null,
+    body: parsed.data.body ?? null,
+    author_name: parsed.data.author_name ?? null,
+    is_example: false,
+    is_published: false,
+    source: "user",
+    meta: {},
+  });
+
+  if (error) {
+    console.error("[POST /api/reviews]", error);
+    return NextResponse.json({ error: "Error al guardar reseña" }, { status: 500 });
+  }
+
+  return NextResponse.json({ message: "Gracias, tu reseña será revisada" }, { status: 200 });
+}


### PR DESCRIPTION
# PR-A: Feedback y reseñas (solo DB + APIs)

Objetivo: tablas `site_feedback` y `product_reviews`, RLS, y rutas `/api/feedback` (POST) y `/api/reviews` (GET + POST). Sin UI.

## Archivos tocados
- `ops/sql/2026-02-22_feedback_and_reviews.sql`
- `docs/PR-A_feedback_reviews.md`
- `src/app/api/feedback/route.ts`
- `src/app/api/reviews/route.ts`

---

## SQL PARA PEGAR EN SUPABASE

Ejecutar en **Supabase Dashboard → SQL Editor**. Idempotente (create if not exists, drop policy if exists).

```sql
-- PR-A: feedback and reviews (idempotent)
-- Run in Supabase SQL Editor. No destructive operations.

-- A) public.site_feedback
create table if not exists public.site_feedback (
  id uuid primary key default gen_random_uuid(),
  created_at timestamptz not null default now(),
  page_path text null,
  type text not null,
  message text not null,
  rating int2 null check (rating between 1 and 5),
  email text null,
  phone text null,
  user_id uuid null,
  status text not null default 'new',
  meta jsonb not null default '{}'::jsonb
);

create index if not exists idx_site_feedback_page_path_created_at
  on public.site_feedback (page_path, created_at desc);

alter table public.site_feedback enable row level security;

drop policy if exists "site_feedback_insert_anon_authenticated" on public.site_feedback;
create policy "site_feedback_insert_anon_authenticated" on public.site_feedback
  for insert to anon, authenticated with check (true);

-- B) public.product_reviews
create table if not exists public.product_reviews (
  id uuid primary key default gen_random_uuid(),
  created_at timestamptz not null default now(),
  product_id uuid not null references public.products(id) on delete cascade,
  rating int2 not null check (rating between 1 and 5),
  title text null,
  body text null,
  author_name text null,
  is_example boolean not null default false,
  is_published boolean not null default false,
  source text null,
  user_id uuid null,
  meta jsonb not null default '{}'::jsonb
);

create index if not exists idx_product_reviews_product_id_created_at
  on public.product_reviews (product_id, created_at desc);

create index if not exists idx_product_reviews_product_id_published
  on public.product_reviews (product_id) where is_published = true;

alter table public.product_reviews enable row level security;

drop policy if exists "product_reviews_select_published" on public.product_reviews;
create policy "product_reviews_select_published" on public.product_reviews
  for select to anon, authenticated using (is_published = true);

drop policy if exists "product_reviews_insert_anon_authenticated" on public.product_reviews;
create policy "product_reviews_insert_anon_authenticated" on public.product_reviews
  for insert to anon, authenticated
  with check (
    is_published = false
    and is_example = false
    and (source is null or source = 'user')
  );
```

---

## APIs

- **POST /api/feedback** — Body: `type` (bug|idea|opinion|other), `message` (min 10), opcional: `rating` 1–5, `email`, `phone`, `page_path`. Throttle 3 req/10 min por IP. Res: 201 `{ status: "ok" }`.
- **GET /api/reviews?product_id=uuid** — Res: `product_id`, `average_rating`, `review_count`, `real_reviews`, `example_reviews`.
- **POST /api/reviews** — Body: `product_id`, `rating` 1–5, opcional: `title`, `body` (min 10), `author_name`. Inserta con `is_published=false`, `is_example=false`, `source='user'`. Res: 200 `{ message: "Gracias, tu reseña será revisada" }`.

---

Confirmación: **NO UI incluida**. No se toca checkout, admin, stripe, shipping, orders.

---

## Reporte para PR description

### Lista de archivos tocados
- `ops/sql/2026-02-22_feedback_and_reviews.sql`
- `docs/PR-A_feedback_reviews.md`
- `src/app/api/feedback/route.ts`
- `src/app/api/reviews/route.ts`

### Bloque SQL completo para Supabase
Véase sección **SQL PARA PEGAR EN SUPABASE** arriba (mismo contenido que `ops/sql/2026-02-22_feedback_and_reviews.sql`).

### 3 ejemplos de prueba (curl)

```bash
# 1) POST feedback
curl -s -X POST http://localhost:3000/api/feedback \
  -H "Content-Type: application/json" \
  -d '{"type":"opinion","message":"Me gustaría ver más filtros en la búsqueda.","rating":4}'

# 2) GET reviews (sustituir PRODUCT_UUID por un uuid de products)
curl -s "http://localhost:3000/api/reviews?product_id=PRODUCT_UUID"

# 3) POST review (sustituir PRODUCT_UUID)
curl -s -X POST http://localhost:3000/api/reviews \
  -H "Content-Type: application/json" \
  -d '{"product_id":"PRODUCT_UUID","rating":5,"title":"Muy buen producto","body":"Llegó rápido y bien empaquetado.","author_name":"Ana"}'
```

### Confirmación
**NO UI incluida.** Solo DB (SQL) + RLS + APIs. No se modifican checkout, admin, stripe, shipping, orders.
