### PR TITLE
PR-E1: Admin APIs (reviews + feedback)

### DIFF
--- a/docs/PR-E1_admin_api_reviews_feedback.md
+++ b/docs/PR-E1_admin_api_reviews_feedback.md
@@ -1,0 +1,111 @@
+# PR-E1: Admin API reviews y feedback
+
+APIs admin server-only para gestionar reseñas (`public.product_reviews`) y feedback del sitio (`public.site_feedback`). Sin UI. Requieren sesión de admin (mismo mecanismo que el resto de `/api/admin/*`).
+
+---
+
+## Endpoints
+
+### Reviews (product_reviews)
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| GET | `/api/admin/reviews` | Listar reseñas (filtros y paginación) |
+| PATCH | `/api/admin/reviews/[id]` | Moderar: actualizar `is_published` |
+| DELETE | `/api/admin/reviews/[id]` | Borrar reseña |
+
+### Feedback (site_feedback)
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| GET | `/api/admin/feedback` | Listar feedback (filtros y paginación) |
+| PATCH | `/api/admin/feedback/[id]` | Actualizar `status` |
+| DELETE | `/api/admin/feedback/[id]` | Borrar feedback |
+
+---
+
+## Request / Response shapes
+
+### GET /api/admin/reviews
+
+- **Query:** `status` = `pending` \| `published` \| `examples` \| `all` (default: `pending`), `product_id` (opcional), `limit` (default 50, max 100), `cursor` (opcional, offset como string).
+- **Response:** `{ items: Review[], nextCursor: string | null }`
+- **Review:** `id`, `created_at`, `product_id`, `rating`, `title`, `body`, `author_name`, `is_example`, `is_published`, `source`, `user_id`, `meta`
+
+### PATCH /api/admin/reviews/[id]
+
+- **Body:** `{ is_published: boolean }`
+- **Response:** `{ ok: true, review: { id, is_published } }` o error 4xx/5xx
+
+### DELETE /api/admin/reviews/[id]
+
+- **Response:** `{ ok: true }` o error 5xx
+
+### GET /api/admin/feedback
+
+- **Query:** `status` = `new` \| `reviewed` \| `closed` \| `spam` \| `all` (default: `new`), `q` (opcional, búsqueda en message/page_path), `limit` (default 50, max 100), `cursor` (opcional).
+- **Response:** `{ items: Feedback[], nextCursor: string | null }`
+- **Feedback:** `id`, `created_at`, `page_path`, `type`, `message`, `rating`, `email`, `phone`, `user_id`, `status`, `meta`
+
+### PATCH /api/admin/feedback/[id]
+
+- **Body:** `{ status: "new" | "reviewed" | "closed" | "spam" }`
+- **Response:** `{ ok: true, feedback: { id, status } }` o error 4xx/5xx
+
+### DELETE /api/admin/feedback/[id]
+
+- **Response:** `{ ok: true }` o error 5xx
+
+---
+
+## Ejemplos curl
+
+Reemplaza `https://tu-dominio.com` y asegúrate de enviar las cookies de sesión (o el header que use tu app para auth). Las rutas usan la sesión del usuario para validar admin vía `ADMIN_ALLOWED_EMAILS`.
+
+### Reviews (4 ejemplos)
+
+```bash
+# 1) Listar reseñas pendientes (default)
+curl -s -b "tu-cookie-de-sesion" "https://tu-dominio.com/api/admin/reviews"
+
+# 2) Listar reseñas publicadas, filtro por product_id y limit
+curl -s -b "tu-cookie-de-sesion" "https://tu-dominio.com/api/admin/reviews?status=published&product_id=UUID&limit=20"
+
+# 3) Publicar una reseña (PATCH)
+curl -s -X PATCH -b "tu-cookie-de-sesion" -H "Content-Type: application/json" \
+  -d '{"is_published":true}' "https://tu-dominio.com/api/admin/reviews/REVIEW_UUID"
+
+# 4) Borrar una reseña
+curl -s -X DELETE -b "tu-cookie-de-sesion" "https://tu-dominio.com/api/admin/reviews/REVIEW_UUID"
+```
+
+### Feedback (2 ejemplos)
+
+```bash
+# 5) Listar feedback nuevo y búsqueda por texto
+curl -s -b "tu-cookie-de-sesion" "https://tu-dominio.com/api/admin/feedback?status=new&q=contacto&limit=25"
+
+# 6) Marcar feedback como revisado
+curl -s -X PATCH -b "tu-cookie-de-sesion" -H "Content-Type: application/json" \
+  -d '{"status":"reviewed"}' "https://tu-dominio.com/api/admin/feedback/FEEDBACK_UUID"
+```
+
+---
+
+## Confirmación
+
+- **No se tocó:** checkout, pagos, envíos (Stripe/Skydropx/orders/cart). Solo rutas nuevas bajo `/api/admin/reviews` y `/api/admin/feedback`.
+- **Seguridad:** Admin-only mediante `checkAdminAccess()` (sesión + `ADMIN_ALLOWED_EMAILS`). Lectura/escritura a Supabase con **Service Role** en server; la clave no se expone al cliente.
+- **Nota:** Estos endpoints requieren estar logueado como admin (email en `ADMIN_ALLOWED_EMAILS`).
+
+---
+
+## Reporte final PR-E1
+
+- **Archivos tocados:**  
+  `src/app/api/admin/reviews/route.ts`, `src/app/api/admin/reviews/[id]/route.ts`,  
+  `src/app/api/admin/feedback/route.ts`, `src/app/api/admin/feedback/[id]/route.ts`,  
+  `docs/PR-E1_admin_api_reviews_feedback.md`
+- **Seguridad:** Admin-only con `checkAdminAccess()`; Supabase con **Service Role** solo en server. No se expone la clave al cliente.
+- **Verify:** `pnpm -s verify` → exit 0.
+- **Doc:** [docs/PR-E1_admin_api_reviews_feedback.md](PR-E1_admin_api_reviews_feedback.md)

--- a/src/app/api/admin/feedback/[id]/route.ts
+++ b/src/app/api/admin/feedback/[id]/route.ts
@@ -1,0 +1,105 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const ALLOWED_STATUSES = ["new", "reviewed", "closed", "spam"] as const;
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Missing Supabase config");
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+/**
+ * PATCH /api/admin/feedback/[id]
+ * Body: { status: "new"|"reviewed"|"closed"|"spam" }
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse<unknown>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json({ ok: false, code: "unauthorized", message: "No autorizado" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ ok: false, code: "bad_request", message: "id requerido" }, { status: 400 });
+    }
+
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body.status !== "string" || !ALLOWED_STATUSES.includes(body.status)) {
+      return NextResponse.json(
+        { ok: false, code: "bad_request", message: "Body debe incluir status: new|reviewed|closed|spam" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("site_feedback")
+      .update({ status: body.status })
+      .eq("id", id)
+      .select("id, status")
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        return NextResponse.json({ ok: false, code: "not_found", message: "Feedback no encontrado" }, { status: 404 });
+      }
+      console.error("[admin/feedback PATCH]", error);
+      return NextResponse.json({ ok: false, code: "error", message: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, feedback: data });
+  } catch (err) {
+    console.error("[admin/feedback PATCH]", err);
+    return NextResponse.json(
+      { ok: false, code: "error", message: err instanceof Error ? err.message : "Error" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/feedback/[id]
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse<unknown>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json({ ok: false, code: "unauthorized", message: "No autorizado" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ ok: false, code: "bad_request", message: "id requerido" }, { status: 400 });
+    }
+
+    const supabase = getServiceRoleClient();
+    const { error } = await supabase.from("site_feedback").delete().eq("id", id);
+
+    if (error) {
+      console.error("[admin/feedback DELETE]", error);
+      return NextResponse.json({ ok: false, code: "error", message: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[admin/feedback DELETE]", err);
+    return NextResponse.json(
+      { ok: false, code: "error", message: err instanceof Error ? err.message : "Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/feedback/route.ts
+++ b/src/app/api/admin/feedback/route.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type FeedbackRow = {
+  id: string;
+  created_at: string;
+  page_path: string | null;
+  type: string;
+  message: string;
+  rating: number | null;
+  email: string | null;
+  phone: string | null;
+  user_id: string | null;
+  status: string;
+  meta: Record<string, unknown>;
+};
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Missing Supabase config");
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+/**
+ * GET /api/admin/feedback
+ * Query: status=new|reviewed|closed|spam|all, q?, limit?, cursor?
+ * Response: { items: Feedback[], nextCursor: string|null }
+ */
+export async function GET(req: NextRequest): Promise<NextResponse<unknown>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json({ ok: false, code: "unauthorized", message: "No autorizado" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const status = (searchParams.get("status") ?? "new") as "new" | "reviewed" | "closed" | "spam" | "all";
+    const q = searchParams.get("q")?.trim();
+    const limitRaw = searchParams.get("limit");
+    const limit = Math.min(Math.max(limitRaw ? parseInt(limitRaw, 10) : 50, 1), 100);
+    const cursorRaw = searchParams.get("cursor");
+    const offset = cursorRaw ? Math.max(0, parseInt(cursorRaw, 10)) : 0;
+
+    const supabase = getServiceRoleClient();
+
+    let query = supabase
+      .from("site_feedback")
+      .select("*")
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (status !== "all") {
+      query = query.eq("status", status);
+    }
+
+    if (q && q.length > 0) {
+      const term = q.replace(/[%_\\]/g, "\\$&");
+      query = query.or(`message.ilike.%${term}%,page_path.ilike.%${term}%`);
+    }
+
+    const { data: rows, error } = await query;
+
+    if (error) {
+      console.error("[admin/feedback GET]", error);
+      return NextResponse.json(
+        { ok: false, code: "error", message: error.message },
+        { status: 500 },
+      );
+    }
+
+    const items = (rows ?? []).map((r: FeedbackRow) => ({
+      id: r.id,
+      created_at: r.created_at,
+      page_path: r.page_path,
+      type: r.type,
+      message: r.message,
+      rating: r.rating,
+      email: r.email,
+      phone: r.phone,
+      user_id: r.user_id,
+      status: r.status,
+      meta: r.meta ?? {},
+    }));
+
+    const nextCursor = items.length === limit ? String(offset + limit) : null;
+
+    return NextResponse.json({ items, nextCursor });
+  } catch (err) {
+    console.error("[admin/feedback GET]", err);
+    return NextResponse.json(
+      { ok: false, code: "error", message: err instanceof Error ? err.message : "Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/reviews/[id]/route.ts
+++ b/src/app/api/admin/reviews/[id]/route.ts
@@ -1,0 +1,103 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Missing Supabase config");
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+/**
+ * PATCH /api/admin/reviews/[id]
+ * Body: { is_published: boolean }
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse<unknown>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json({ ok: false, code: "unauthorized", message: "No autorizado" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ ok: false, code: "bad_request", message: "id requerido" }, { status: 400 });
+    }
+
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body.is_published !== "boolean") {
+      return NextResponse.json(
+        { ok: false, code: "bad_request", message: "Body debe incluir is_published (boolean)" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("product_reviews")
+      .update({ is_published: body.is_published })
+      .eq("id", id)
+      .select("id, is_published")
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        return NextResponse.json({ ok: false, code: "not_found", message: "Reseña no encontrada" }, { status: 404 });
+      }
+      console.error("[admin/reviews PATCH]", error);
+      return NextResponse.json({ ok: false, code: "error", message: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, review: data });
+  } catch (err) {
+    console.error("[admin/reviews PATCH]", err);
+    return NextResponse.json(
+      { ok: false, code: "error", message: err instanceof Error ? err.message : "Error" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/reviews/[id]
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse<unknown>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json({ ok: false, code: "unauthorized", message: "No autorizado" }, { status: 403 });
+    }
+
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ ok: false, code: "bad_request", message: "id requerido" }, { status: 400 });
+    }
+
+    const supabase = getServiceRoleClient();
+    const { error } = await supabase.from("product_reviews").delete().eq("id", id);
+
+    if (error) {
+      console.error("[admin/reviews DELETE]", error);
+      return NextResponse.json({ ok: false, code: "error", message: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[admin/reviews DELETE]", err);
+    return NextResponse.json(
+      { ok: false, code: "error", message: err instanceof Error ? err.message : "Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/reviews/route.ts
+++ b/src/app/api/admin/reviews/route.ts
@@ -1,0 +1,107 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type ReviewRow = {
+  id: string;
+  created_at: string;
+  product_id: string;
+  rating: number;
+  title: string | null;
+  body: string | null;
+  author_name: string | null;
+  is_example: boolean;
+  is_published: boolean;
+  source: string | null;
+  user_id: string | null;
+  meta: Record<string, unknown>;
+};
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("Missing Supabase config");
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+/**
+ * GET /api/admin/reviews
+ * Query: status=pending|published|examples|all, product_id?, limit?, cursor?
+ * Response: { items: Review[], nextCursor: string|null }
+ */
+export async function GET(req: NextRequest): Promise<NextResponse<unknown>> {
+  try {
+    const access = await checkAdminAccess();
+    if (access.status !== "allowed") {
+      return NextResponse.json({ ok: false, code: "unauthorized", message: "No autorizado" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const status = (searchParams.get("status") ?? "pending") as "pending" | "published" | "examples" | "all";
+    const productId = searchParams.get("product_id") ?? undefined;
+    const limitRaw = searchParams.get("limit");
+    const limit = Math.min(Math.max(limitRaw ? parseInt(limitRaw, 10) : 50, 1), 100);
+    const cursorRaw = searchParams.get("cursor");
+    const offset = cursorRaw ? Math.max(0, parseInt(cursorRaw, 10)) : 0;
+
+    const supabase = getServiceRoleClient();
+
+    let query = supabase
+      .from("product_reviews")
+      .select("*")
+      .order("created_at", { ascending: false })
+      .order("id", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (status === "pending") {
+      query = query.eq("is_published", false).eq("is_example", false);
+    } else if (status === "published") {
+      query = query.eq("is_published", true).eq("is_example", false);
+    } else if (status === "examples") {
+      query = query.eq("is_example", true);
+    }
+
+    if (productId) {
+      query = query.eq("product_id", productId);
+    }
+
+    const { data: rows, error } = await query;
+
+    if (error) {
+      console.error("[admin/reviews GET]", error);
+      return NextResponse.json(
+        { ok: false, code: "error", message: error.message },
+        { status: 500 },
+      );
+    }
+
+    const items = (rows ?? []).map((r: ReviewRow) => ({
+      id: r.id,
+      created_at: r.created_at,
+      product_id: r.product_id,
+      rating: r.rating,
+      title: r.title,
+      body: r.body,
+      author_name: r.author_name,
+      is_example: r.is_example,
+      is_published: r.is_published,
+      source: r.source,
+      user_id: r.user_id,
+      meta: r.meta ?? {},
+    }));
+
+    const nextCursor = items.length === limit ? String(offset + limit) : null;
+
+    return NextResponse.json({ items, nextCursor });
+  } catch (err) {
+    console.error("[admin/reviews GET]", err);
+    return NextResponse.json(
+      { ok: false, code: "error", message: err instanceof Error ? err.message : "Error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Reporte final PR-E1

- **Archivos tocados:**  
  `src/app/api/admin/reviews/route.ts`, `src/app/api/admin/reviews/[id]/route.ts`,  
  `src/app/api/admin/feedback/route.ts`, `src/app/api/admin/feedback/[id]/route.ts`,  
  `docs/PR-E1_admin_api_reviews_feedback.md`
- **Seguridad:** Admin-only con `checkAdminAccess()`; Supabase con **Service Role** solo en server. No se expone la clave al cliente.
- **Verify:** `pnpm -s verify` → exit 0.
- **Doc:** [docs/PR-E1_admin_api_reviews_feedback.md](https://github.com/hekouo/dental-noriega/blob/feat/admin-moderation-api-pr-e1/docs/PR-E1_admin_api_reviews_feedback.md)
