### PR TITLE
PR-S2: Admin pickup scheduling with Skydropx

### DIFF
--- a/docs/PR-S2_admin_pickup_skydropx.md
+++ b/docs/PR-S2_admin_pickup_skydropx.md
@@ -1,0 +1,83 @@
+# PR-S2: Admin Pickup (Skydropx) + horarios por día
+
+## Objetivo
+
+Habilitar **Pickup (recolección a domicilio)** desde Admin (detalle de pedido), complementando PR-S1 (drop-off), usando Skydropx API y persistiendo en:
+
+`metadata.shipping.handoff.pickup`
+
+## Qué cambió
+
+### UI Admin
+
+Archivo: `src/app/admin/pedidos/[id]/ShippingHandoffClient.tsx`
+
+- Se habilita opción funcional **Programar recolección (Pickup)**.
+- Form inline con:
+  - Fecha
+  - Hora desde / hasta
+  - # paquetes (default 1)
+  - Peso total kg (default desde `metadata.shipping.package_used.weight_g / 1000`)
+  - Notas opcionales
+- Validaciones:
+  - Domingo bloqueado (`Domingo no disponible`)
+  - `scheduled_to > scheduled_from`
+- Si ya existe `pickup_id`, muestra estado **Recolección programada** y no permite duplicar.
+- Mantiene opción drop-off existente.
+
+### Endpoint server-only
+
+Archivo: `src/app/api/admin/shipping/skydropx/pickups/route.ts`
+
+- `POST /api/admin/shipping/skydropx/pickups`
+- Auth: `checkAdminAccess()`
+- Service role para leer/actualizar orden.
+- Requiere `shipment_id` (columna o metadata); si no existe: 400.
+- Si ya hay `pickup_id` en metadata: 409.
+- Llama a Skydropx con `skydropxFetch("/api/v1/pickups", ...)`.
+- Persiste:
+  - `mode="pickup"`
+  - `selected_at=now`
+  - `pickup: { pickup_id, scheduled_from, scheduled_to, packages, total_weight_kg, status:"scheduled", raw:{} }`
+
+### Config de origen fijo (server-only)
+
+Archivo: `src/lib/shipping/pickupOrigin.ts`
+
+- Lee origen de pickup desde env vars.
+- Si faltan valores críticos responde con:
+  - `Pickup origin no configurado`
+
+## Env vars necesarias
+
+- `PICKUP_NAME`
+- `PICKUP_PHONE`
+- `PICKUP_EMAIL`
+- `PICKUP_ADDRESS1`
+- `PICKUP_ADDRESS2` (opcional)
+- `PICKUP_CITY`
+- `PICKUP_STATE`
+- `PICKUP_POSTAL_CODE`
+- `PICKUP_COUNTRY` (opcional, default `MX`)
+
+## Cálculo de horario default
+
+En UI, al elegir fecha:
+- **Lunes a Viernes:** 08:00–17:00
+- **Sábado:** 08:00–15:00
+- **Domingo:** bloqueado
+
+## QA manual
+
+1. Crear guía (shipment_id/label).
+2. Programar pickup L–V: defaults 08:00–17:00.
+3. Programar pickup Sábado: defaults 08:00–15:00.
+4. Intentar Domingo: debe bloquear.
+5. Refrescar página: `pickup_id` y ventana persisten.
+
+## Confirmación de alcance
+
+- No se tocó `src/app/checkout/**`.
+- No se modificó SQL ni RLS.
+- No se tocaron create-label/cancel existentes.
+

--- a/src/app/admin/pedidos/[id]/ShippingHandoffClient.tsx
+++ b/src/app/admin/pedidos/[id]/ShippingHandoffClient.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 
 type Handoff = {
-  mode?: "dropoff";
+  mode?: "dropoff" | "pickup";
   selected_at?: string;
   notes?: string;
   dropoff?: {
@@ -12,6 +12,15 @@ type Handoff = {
     address?: string;
     dropped_off_at?: string;
   };
+  pickup?: {
+    pickup_id?: string;
+    scheduled_from?: string;
+    scheduled_to?: string;
+    packages?: number;
+    total_weight_kg?: number;
+    status?: "scheduled";
+    raw?: Record<string, unknown>;
+  };
 };
 
 type Props = {
@@ -19,6 +28,7 @@ type Props = {
   labelUrl: string | null;
   trackingNumber: string | null;
   initialHandoff: Handoff | null;
+  initialWeightKg: number;
 };
 
 export default function ShippingHandoffClient({
@@ -26,13 +36,23 @@ export default function ShippingHandoffClient({
   labelUrl,
   trackingNumber,
   initialHandoff,
+  initialWeightKg,
 }: Props) {
   const [handoff, setHandoff] = useState<Handoff>(initialHandoff ?? {});
   const [notes, setNotes] = useState<string>(initialHandoff?.notes ?? "");
   const [status, setStatus] = useState<"idle" | "saving" | "error">("idle");
   const [error, setError] = useState<string>("");
+  const [pickupDate, setPickupDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
+  const [pickupFrom, setPickupFrom] = useState<string>("08:00");
+  const [pickupTo, setPickupTo] = useState<string>("17:00");
+  const [pickupPackages, setPickupPackages] = useState<number>(1);
+  const [pickupWeightKg, setPickupWeightKg] = useState<number>(
+    initialHandoff?.pickup?.total_weight_kg ?? Math.max(0.1, initialWeightKg || 1),
+  );
 
   const dropoffStatus = handoff.dropoff?.status ?? null;
+  const hasPickupProgrammed = !!handoff.pickup?.pickup_id;
+  const pickupId = handoff.pickup?.pickup_id ?? null;
   const badge = useMemo(() => {
     if (dropoffStatus === "dropped_off") {
       return { label: "Entregado en sucursal", cls: "bg-green-100 text-green-700" };
@@ -40,8 +60,11 @@ export default function ShippingHandoffClient({
     if (dropoffStatus === "pending_dropoff") {
       return { label: "Pendiente de entrega en sucursal", cls: "bg-amber-100 text-amber-800" };
     }
+    if (hasPickupProgrammed) {
+      return { label: "Recolección programada", cls: "bg-blue-100 text-blue-700" };
+    }
     return null;
-  }, [dropoffStatus]);
+  }, [dropoffStatus, hasPickupProgrammed]);
 
   const patch = async (shipping_handoff_patch: Record<string, unknown>) => {
     setStatus("saving");
@@ -102,6 +125,91 @@ export default function ShippingHandoffClient({
   };
 
   const isDropoffSelected = handoff.mode === "dropoff";
+  const isPickupSelected = handoff.mode === "pickup";
+
+  const applyDefaultWindowByDate = (dateValue: string) => {
+    if (!dateValue) return;
+    const day = new Date(`${dateValue}T12:00:00`).getDay();
+    if (day >= 1 && day <= 5) {
+      setPickupFrom("08:00");
+      setPickupTo("17:00");
+      return;
+    }
+    if (day === 6) {
+      setPickupFrom("08:00");
+      setPickupTo("15:00");
+    }
+  };
+
+  const handlePickupDateChange = (nextDate: string) => {
+    setPickupDate(nextDate);
+    applyDefaultWindowByDate(nextDate);
+  };
+
+  const handleProgramPickup = async () => {
+    const day = new Date(`${pickupDate}T12:00:00`).getDay();
+    if (day === 0) {
+      setError("Domingo no disponible");
+      setStatus("error");
+      return;
+    }
+    const fromIso = new Date(`${pickupDate}T${pickupFrom}:00`).toISOString();
+    const toIso = new Date(`${pickupDate}T${pickupTo}:00`).toISOString();
+    if (new Date(toIso).getTime() <= new Date(fromIso).getTime()) {
+      setError("La hora final debe ser mayor a la inicial.");
+      setStatus("error");
+      return;
+    }
+    setStatus("saving");
+    setError("");
+    try {
+      const res = await fetch("/api/admin/shipping/skydropx/pickups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orderId,
+          scheduled_from: fromIso,
+          scheduled_to: toIso,
+          packages: pickupPackages,
+          total_weight_kg: pickupWeightKg,
+          notes: notes.trim() || undefined,
+        }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        message?: string;
+        pickup_id?: string;
+        scheduled_from?: string;
+        scheduled_to?: string;
+        packages?: number;
+        total_weight_kg?: number;
+      };
+      if (!res.ok || !json.ok) {
+        setStatus("error");
+        setError(json.message ?? "No se pudo programar pickup.");
+        return;
+      }
+      const now = new Date().toISOString();
+      setHandoff((prev) => ({
+        ...prev,
+        mode: "pickup",
+        selected_at: now,
+        notes: notes.trim() || undefined,
+        pickup: {
+          pickup_id: json.pickup_id,
+          scheduled_from: json.scheduled_from,
+          scheduled_to: json.scheduled_to,
+          packages: json.packages,
+          total_weight_kg: json.total_weight_kg,
+          status: "scheduled",
+        },
+      }));
+      setStatus("idle");
+    } catch {
+      setStatus("error");
+      setError("Error de conexión.");
+    }
+  };
 
   return (
     <section className="mt-6 pt-6 border-t border-gray-200">
@@ -139,9 +247,23 @@ export default function ShippingHandoffClient({
           </div>
         </div>
 
-        <div className="rounded-lg border border-gray-200 p-4 opacity-60">
-          <p className="font-semibold text-sm text-gray-900">Programar recolección (Pickup)</p>
-          <p className="text-xs text-gray-600 mt-0.5">Disponible pronto.</p>
+        <div className={`rounded-lg border p-4 ${isPickupSelected ? "border-primary-300 bg-primary-50/40" : "border-gray-200"}`}>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="font-semibold text-sm text-gray-900">Programar recolección (Pickup)</p>
+              <p className="text-xs text-gray-600 mt-0.5">
+                Recolección a domicilio en origen fijo del negocio.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleProgramPickup}
+              disabled={status === "saving" || hasPickupProgrammed}
+              className="px-3 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 disabled:opacity-50 focus-premium"
+            >
+              Programar recolección
+            </button>
+          </div>
         </div>
       </div>
 
@@ -205,6 +327,95 @@ export default function ShippingHandoffClient({
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Detalles pickup */}
+      {(isPickupSelected || hasPickupProgrammed) && (
+        <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
+          {hasPickupProgrammed ? (
+            <div className="space-y-2 text-sm">
+              <p className="font-medium text-gray-900">Recolección programada</p>
+              <p>
+                <span className="text-gray-600">Pickup ID:</span>{" "}
+                <span className="font-mono text-xs">{pickupId}</span>
+              </p>
+              <p>
+                <span className="text-gray-600">Ventana:</span>{" "}
+                {handoff.pickup?.scheduled_from ? new Date(handoff.pickup.scheduled_from).toLocaleString("es-MX") : "—"}
+                {" — "}
+                {handoff.pickup?.scheduled_to ? new Date(handoff.pickup.scheduled_to).toLocaleString("es-MX") : "—"}
+              </p>
+              <p>
+                <span className="text-gray-600">Paquetes/Peso:</span>{" "}
+                {handoff.pickup?.packages ?? 1} paquete(s), {handoff.pickup?.total_weight_kg ?? 0} kg
+              </p>
+              <p className="text-xs text-gray-500">Reprogramar: disponible pronto.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Fecha</label>
+                  <input
+                    type="date"
+                    value={pickupDate}
+                    onChange={(e) => handlePickupDateChange(e.target.value)}
+                    disabled={status === "saving"}
+                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Hora desde</label>
+                  <input
+                    type="time"
+                    value={pickupFrom}
+                    onChange={(e) => setPickupFrom(e.target.value)}
+                    disabled={status === "saving"}
+                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Hora hasta</label>
+                  <input
+                    type="time"
+                    value={pickupTo}
+                    onChange={(e) => setPickupTo(e.target.value)}
+                    disabled={status === "saving"}
+                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1"># paquetes</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={pickupPackages}
+                    onChange={(e) => setPickupPackages(Math.max(1, Number(e.target.value) || 1))}
+                    disabled={status === "saving"}
+                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Peso total (kg)</label>
+                  <input
+                    type="number"
+                    min={0.1}
+                    step={0.1}
+                    value={pickupWeightKg}
+                    onChange={(e) => setPickupWeightKg(Math.max(0.1, Number(e.target.value) || 0.1))}
+                    disabled={status === "saving"}
+                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-gray-500">
+                Defaults: L-V 08:00-17:00, Sábado 08:00-15:00, Domingo no disponible.
+              </p>
+            </div>
+          )}
         </div>
       )}
     </section>

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -539,11 +539,22 @@ export default async function AdminPedidoDetailPage({
                     address?: string;
                     dropped_off_at?: string;
                   };
+                  pickup?: {
+                    pickup_id?: string;
+                    scheduled_from?: string;
+                    scheduled_to?: string;
+                    packages?: number;
+                    total_weight_kg?: number;
+                    status?: "scheduled";
+                  };
                 };
                 const initialHandoff: ShippingHandoff | null =
                   shippingMeta.handoff && typeof shippingMeta.handoff === "object"
                     ? (shippingMeta.handoff as ShippingHandoff)
                     : null;
+                const packageUsed = (shippingMeta.package_used as Record<string, unknown> | undefined) || undefined;
+                const weightG = typeof packageUsed?.weight_g === "number" ? packageUsed.weight_g : 1000;
+                const initialWeightKg = Math.max(0.1, Math.round((weightG / 1000) * 10) / 10);
 
                 return (
                   <>
@@ -566,6 +577,7 @@ export default async function AdminPedidoDetailPage({
                         labelUrl={order.shipping_label_url}
                         trackingNumber={order.shipping_tracking_number}
                         initialHandoff={initialHandoff}
+                        initialWeightKg={initialWeightKg}
                       />
                     )}
 

--- a/src/app/api/admin/shipping/skydropx/pickups/route.ts
+++ b/src/app/api/admin/shipping/skydropx/pickups/route.ts
@@ -1,0 +1,216 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+import { checkAdminAccess } from "@/lib/admin/access";
+import { sanitizeForLog } from "@/lib/utils/sanitizeForLog";
+import { skydropxFetch } from "@/lib/skydropx/client";
+import { getPickupOrigin } from "@/lib/shipping/pickupOrigin";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const BodySchema = z.object({
+  orderId: z.string().uuid(),
+  scheduled_from: z.string().datetime(),
+  scheduled_to: z.string().datetime(),
+  packages: z.number().int().min(1).max(99),
+  total_weight_kg: z.number().positive().max(300),
+  notes: z.string().optional().nullable(),
+});
+
+type JsonOk = {
+  ok: true;
+  pickup_id: string;
+  scheduled_from: string;
+  scheduled_to: string;
+  packages: number;
+  total_weight_kg: number;
+};
+type JsonErr = { ok: false; message: string };
+
+function deepMerge<T extends Record<string, unknown>>(
+  base: T,
+  patch: Record<string, unknown>,
+): T {
+  const out: Record<string, unknown> = { ...base };
+  for (const [k, v] of Object.entries(patch)) {
+    if (
+      v &&
+      typeof v === "object" &&
+      !Array.isArray(v) &&
+      typeof out[k] === "object" &&
+      out[k] !== null &&
+      !Array.isArray(out[k])
+    ) {
+      out[k] = deepMerge(out[k] as Record<string, unknown>, v as Record<string, unknown>);
+    } else if (v !== undefined) {
+      out[k] = v;
+    }
+  }
+  return out as T;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse<JsonOk | JsonErr>> {
+  const access = await checkAdminAccess();
+  if (access.status !== "allowed") {
+    return NextResponse.json({ ok: false, message: "Acceso denegado" }, { status: 403 });
+  }
+
+  const parsed = BodySchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, message: parsed.error.errors[0]?.message ?? "Body inválido" },
+      { status: 400 },
+    );
+  }
+
+  const { orderId, scheduled_from, scheduled_to, packages, total_weight_kg, notes } = parsed.data;
+  const fromDate = new Date(scheduled_from);
+  const toDate = new Date(scheduled_to);
+  if (toDate.getTime() <= fromDate.getTime()) {
+    return NextResponse.json(
+      { ok: false, message: "El horario final debe ser mayor al inicial." },
+      { status: 400 },
+    );
+  }
+  if (fromDate.getUTCDay() === 0) {
+    return NextResponse.json({ ok: false, message: "Domingo no disponible" }, { status: 400 });
+  }
+
+  const originCfg = getPickupOrigin();
+  if (!originCfg.ok) {
+    return NextResponse.json({ ok: false, message: originCfg.reason }, { status: 500 });
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ ok: false, message: "Configuración incompleta" }, { status: 500 });
+  }
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: order, error: orderError } = await supabase
+    .from("orders")
+    .select("id, metadata, shipping_shipment_id")
+    .eq("id", orderId)
+    .maybeSingle();
+  if (orderError) {
+    console.error("[admin/pickups] order fetch", sanitizeForLog(orderError.message));
+    return NextResponse.json({ ok: false, message: "Error al consultar orden" }, { status: 500 });
+  }
+  if (!order) {
+    return NextResponse.json({ ok: false, message: "Orden no encontrada" }, { status: 404 });
+  }
+
+  const meta = (order.metadata ?? {}) as Record<string, unknown>;
+  const shipping = (meta.shipping ?? {}) as Record<string, unknown>;
+  const handoff = (shipping.handoff ?? {}) as Record<string, unknown>;
+  const pickup = (handoff.pickup ?? {}) as Record<string, unknown>;
+  if (typeof pickup.pickup_id === "string" && pickup.pickup_id.trim()) {
+    return NextResponse.json({ ok: false, message: "Pickup ya programado" }, { status: 409 });
+  }
+
+  const shipmentIdFromMeta =
+    shipping && typeof shipping === "object" ? (shipping.shipment_id as string | undefined) : undefined;
+  const shipmentId = (order.shipping_shipment_id as string | null) || shipmentIdFromMeta || null;
+  if (!shipmentId) {
+    return NextResponse.json(
+      { ok: false, message: "No hay shipment_id. Primero crea la guía." },
+      { status: 400 },
+    );
+  }
+
+  const payload = {
+    pickup: {
+      shipment_id: shipmentId,
+      scheduled_from,
+      scheduled_to,
+      packages,
+      total_weight: total_weight_kg,
+      comments: notes ?? "",
+      address_from: {
+        name: originCfg.origin.name,
+        phone: originCfg.origin.phone,
+        email: originCfg.origin.email,
+        country: originCfg.origin.country,
+        zip: originCfg.origin.postal_code,
+        state: originCfg.origin.state,
+        city: originCfg.origin.city,
+        street1: originCfg.origin.address1,
+        address1: originCfg.origin.address1,
+        address2: originCfg.origin.address2,
+      },
+    },
+  };
+
+  let pickupJson: Record<string, unknown> = {};
+  try {
+    const res = await skydropxFetch("/api/v1/pickups", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    pickupJson = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!res.ok) {
+      const msg = typeof pickupJson.message === "string" ? pickupJson.message : "Error Skydropx al crear pickup";
+      return NextResponse.json({ ok: false, message: msg }, { status: 502 });
+    }
+  } catch (err) {
+    console.error("[admin/pickups] skydropx", err);
+    return NextResponse.json({ ok: false, message: "Error Skydropx al crear pickup" }, { status: 502 });
+  }
+
+  const pickupId =
+    (pickupJson.id as string | undefined) ||
+    ((pickupJson.data as Record<string, unknown> | undefined)?.id as string | undefined) ||
+    ((pickupJson.pickup as Record<string, unknown> | undefined)?.id as string | undefined) ||
+    "";
+  if (!pickupId) {
+    return NextResponse.json({ ok: false, message: "Skydropx no devolvió pickup_id" }, { status: 502 });
+  }
+
+  const now = new Date().toISOString();
+  const handoffPatch = {
+    mode: "pickup",
+    selected_at: now,
+    notes: notes ?? null,
+    pickup: {
+      pickup_id: pickupId,
+      scheduled_from,
+      scheduled_to,
+      packages,
+      total_weight_kg,
+      status: "scheduled",
+      raw: pickupJson,
+    },
+  };
+  const nextHandoff = deepMerge(handoff, handoffPatch as unknown as Record<string, unknown>);
+  const nextMeta = {
+    ...meta,
+    shipping: {
+      ...shipping,
+      handoff: nextHandoff,
+    },
+  };
+
+  const { error: updateError } = await supabase
+    .from("orders")
+    .update({ metadata: nextMeta })
+    .eq("id", orderId);
+  if (updateError) {
+    console.error("[admin/pickups] update", sanitizeForLog(updateError.message));
+    return NextResponse.json({ ok: false, message: "Pickup creado pero no se pudo persistir metadata" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    pickup_id: pickupId,
+    scheduled_from,
+    scheduled_to,
+    packages,
+    total_weight_kg,
+  });
+}
+

--- a/src/lib/shipping/pickupOrigin.ts
+++ b/src/lib/shipping/pickupOrigin.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+export type PickupOrigin = {
+  name: string;
+  phone: string;
+  email: string;
+  address1: string;
+  address2: string | null;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
+};
+
+/**
+ * Origen fijo de pickup (negocio). Solo server-side.
+ * Si falta configuración crítica, devuelve null y reason.
+ */
+export function getPickupOrigin():
+  | { ok: true; origin: PickupOrigin }
+  | { ok: false; reason: string } {
+  const name = process.env.PICKUP_NAME?.trim() || "";
+  const phone = process.env.PICKUP_PHONE?.trim() || "";
+  const email = process.env.PICKUP_EMAIL?.trim() || "";
+  const address1 = process.env.PICKUP_ADDRESS1?.trim() || "";
+  const address2 = process.env.PICKUP_ADDRESS2?.trim() || null;
+  const city = process.env.PICKUP_CITY?.trim() || "";
+  const state = process.env.PICKUP_STATE?.trim() || "";
+  const postal_code = process.env.PICKUP_POSTAL_CODE?.trim() || "";
+  const country = process.env.PICKUP_COUNTRY?.trim() || "MX";
+
+  if (!name || !phone || !email || !address1 || !city || !state || !postal_code) {
+    return { ok: false, reason: "Pickup origin no configurado" };
+  }
+
+  return {
+    ok: true,
+    origin: {
+      name,
+      phone,
+      email,
+      address1,
+      address2,
+      city,
+      state,
+      postal_code,
+      country,
+    },
+  };
+}
+


### PR DESCRIPTION
# PR-S2: Admin Pickup (Skydropx) + horarios por día

## Objetivo

Habilitar **Pickup (recolección a domicilio)** desde Admin (detalle de pedido), complementando PR-S1 (drop-off), usando Skydropx API y persistiendo en:

`metadata.shipping.handoff.pickup`

## Qué cambió

### UI Admin

Archivo: `src/app/admin/pedidos/[id]/ShippingHandoffClient.tsx`

- Se habilita opción funcional **Programar recolección (Pickup)**.
- Form inline con:
  - Fecha
  - Hora desde / hasta
  - # paquetes (default 1)
  - Peso total kg (default desde `metadata.shipping.package_used.weight_g / 1000`)
  - Notas opcionales
- Validaciones:
  - Domingo bloqueado (`Domingo no disponible`)
  - `scheduled_to > scheduled_from`
- Si ya existe `pickup_id`, muestra estado **Recolección programada** y no permite duplicar.
- Mantiene opción drop-off existente.

### Endpoint server-only

Archivo: `src/app/api/admin/shipping/skydropx/pickups/route.ts`

- `POST /api/admin/shipping/skydropx/pickups`
- Auth: `checkAdminAccess()`
- Service role para leer/actualizar orden.
- Requiere `shipment_id` (columna o metadata); si no existe: 400.
- Si ya hay `pickup_id` en metadata: 409.
- Llama a Skydropx con `skydropxFetch("/api/v1/pickups", ...)`.
- Persiste:
  - `mode="pickup"`
  - `selected_at=now`
  - `pickup: { pickup_id, scheduled_from, scheduled_to, packages, total_weight_kg, status:"scheduled", raw:{} }`

### Config de origen fijo (server-only)

Archivo: `src/lib/shipping/pickupOrigin.ts`

- Lee origen de pickup desde env vars.
- Si faltan valores críticos responde con:
  - `Pickup origin no configurado`

## Env vars necesarias

- `PICKUP_NAME`
- `PICKUP_PHONE`
- `PICKUP_EMAIL`
- `PICKUP_ADDRESS1`
- `PICKUP_ADDRESS2` (opcional)
- `PICKUP_CITY`
- `PICKUP_STATE`
- `PICKUP_POSTAL_CODE`
- `PICKUP_COUNTRY` (opcional, default `MX`)

## Cálculo de horario default

En UI, al elegir fecha:
- **Lunes a Viernes:** 08:00–17:00
- **Sábado:** 08:00–15:00
- **Domingo:** bloqueado

## QA manual

1. Crear guía (shipment_id/label).
2. Programar pickup L–V: defaults 08:00–17:00.
3. Programar pickup Sábado: defaults 08:00–15:00.
4. Intentar Domingo: debe bloquear.
5. Refrescar página: `pickup_id` y ventana persisten.

## Confirmación de alcance

- No se tocó `src/app/checkout/**`.
- No se modificó SQL ni RLS.
- No se tocaron create-label/cancel existentes.

