### PR TITLE
fix(admin): PR-S2.2 skydropx pickups endpoint host/path

### DIFF
--- a/src/app/api/admin/shipping/skydropx/pickups/route.ts
+++ b/src/app/api/admin/shipping/skydropx/pickups/route.ts
@@ -146,19 +146,35 @@ export async function POST(req: NextRequest): Promise<NextResponse<JsonOk | Json
     },
   };
 
+  const pickupPath = "/api/v1/pickups/";
+  const pickupUrl = new URL(pickupPath, "https://pro.skydropx.com").toString();
   let pickupJson: Record<string, unknown> = {};
   try {
-    const res = await skydropxFetch("/api/v1/pickups", {
+    const res = await skydropxFetch(pickupPath, {
       method: "POST",
       body: JSON.stringify(payload),
-    });
+    }, "pro");
     pickupJson = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     if (!res.ok) {
-      const msg = typeof pickupJson.message === "string" ? pickupJson.message : "Error Skydropx al crear pickup";
-      return NextResponse.json({ ok: false, message: msg }, { status: 502 });
+      const msg =
+        typeof pickupJson.message === "string"
+          ? pickupJson.message
+          : typeof pickupJson.error === "string"
+            ? pickupJson.error
+            : "Error Skydropx al crear pickup";
+      console.error("[admin/pickups] skydropx !ok", {
+        status: res.status,
+        url: pickupUrl,
+        message: sanitizeForLog(msg),
+      });
+      const upstreamStatus = res.status >= 400 && res.status < 600 ? res.status : 502;
+      return NextResponse.json({ ok: false, message: msg }, { status: upstreamStatus });
     }
   } catch (err) {
-    console.error("[admin/pickups] skydropx", err);
+    console.error("[admin/pickups] skydropx", {
+      url: pickupUrl,
+      error: err instanceof Error ? sanitizeForLog(err.message) : "unknown",
+    });
     return NextResponse.json({ ok: false, message: "Error Skydropx al crear pickup" }, { status: 502 });
   }
 

--- a/src/lib/skydropx/client.ts
+++ b/src/lib/skydropx/client.ts
@@ -536,9 +536,12 @@ async function getAccessToken(): Promise<string | null> {
  * Función genérica para hacer requests a la API de Skydropx
  * Maneja automáticamente la autenticación OAuth
  */
+type SkydropxFetchTarget = "shipments" | "pro";
+
 export async function skydropxFetch(
   path: string,
   options: RequestInit = {},
+  target: SkydropxFetchTarget = "shipments",
 ): Promise<Response> {
   const config = getSkydropxConfig();
   if (!config) {
@@ -551,7 +554,10 @@ export async function skydropxFetch(
     throw error;
   }
 
-  const baseUrl = assertAllowedSkydropxUrl(config.restBaseUrl, ALLOWED_SHIPMENTS_HOSTS, "shipments");
+  const baseUrl =
+    target === "pro"
+      ? assertAllowedSkydropxUrl(SKYDROPX_PRO_HOST, ALLOWED_PRO_HOSTS, "pro")
+      : assertAllowedSkydropxUrl(config.restBaseUrl, ALLOWED_SHIPMENTS_HOSTS, "shipments");
   const url = new URL(path.startsWith("/") ? path : `/${path}`, `${baseUrl.origin}/`).toString();
 
   // Log seguro de URL (sin secretos)


### PR DESCRIPTION
## Summary
- Fixes pickup creation endpoint to target Skydropx PRO endpoint with the correct path and trailing slash.
- Pickup calls now resolve to `https://pro.skydropx.com/api/v1/pickups/` (no duplicated `/api/api/...`).
- Improves upstream error handling: logs status + final URL (token-safe), returns Skydropx status code and message to frontend instead of always 502.

## Test plan
- [x] `pnpm -s verify` (exit 0)
- [x] Reviewed pickup request path/host resolution
- [x] Confirmed response mapping preserves upstream 4xx status and message

Made with [Cursor](https://cursor.com)