### PR TITLE
fix(admin): PR-S2.4 drop-off only handoff UI

### DIFF
--- a/docs/PR-S2_4_dropoff_only_handoff.md
+++ b/docs/PR-S2_4_dropoff_only_handoff.md
@@ -1,0 +1,32 @@
+# PR-S2.4 - Entrega del paquete: solo Drop-off
+
+## Objetivo
+
+Simplificar la sección de admin para usar **solo Drop-off** temporalmente y evitar confusión mientras Pickup está pausado.
+
+## Cambios
+
+- Se desactiva la interacción de Pickup en UI:
+  - Sin botón activo para programar/confirmar pickup.
+  - Se muestra mensaje: **"Recolección a domicilio pausada temporalmente. Usa Drop-off por ahora."**
+  - No se abre formulario ni se dispara request a `/api/admin/shipping/skydropx/pickups`.
+- Se fortalece tarjeta de Drop-off con contexto operativo:
+  - Título: **Entrega en sucursal / punto autorizado**
+  - Paquetería y servicio visibles.
+  - Instrucciones claras para imprimir guía, entregar y conservar comprobante.
+  - Links de **Abrir guía** y **Buscar sucursales de {carrier}** según carrier.
+  - Tracking visible si existe.
+- Se mantiene flujo de estado Drop-off:
+  - `Usar Drop-off`
+  - `Guardar notas`
+  - `Marcar como entregado en sucursal`
+- Se actualiza placeholder de notas con ejemplos reales de sucursal/entrega.
+
+## QA
+
+1. Orden con guía muestra paquetería y servicio.
+2. Link **Abrir guía** funciona.
+3. Link **Buscar sucursales** usa carrier.
+4. **Usar Drop-off** guarda estado.
+5. **Marcar entregado** persiste al recargar.
+6. Pickup ya no dispara request ni abre form.

--- a/src/app/admin/pedidos/[id]/ShippingHandoffClient.tsx
+++ b/src/app/admin/pedidos/[id]/ShippingHandoffClient.tsx
@@ -28,8 +28,8 @@ type Props = {
   labelUrl: string | null;
   trackingNumber: string | null;
   shippingProvider: string | null;
+  shippingService: string | null;
   initialHandoff: Handoff | null;
-  initialWeightKg: number;
 };
 
 export default function ShippingHandoffClient({
@@ -37,34 +37,36 @@ export default function ShippingHandoffClient({
   labelUrl,
   trackingNumber,
   shippingProvider,
+  shippingService,
   initialHandoff,
-  initialWeightKg,
 }: Props) {
   const [handoff, setHandoff] = useState<Handoff>(initialHandoff ?? {});
   const [notes, setNotes] = useState<string>(initialHandoff?.notes ?? "");
   const [status, setStatus] = useState<"idle" | "saving" | "error">("idle");
   const [error, setError] = useState<string>("");
-  const [pickupDate, setPickupDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
-  const [pickupFrom, setPickupFrom] = useState<string>("08:00");
-  const [pickupTo, setPickupTo] = useState<string>("17:00");
-  const [pickupPackages, setPickupPackages] = useState<number>(1);
-  const [pickupWeightKg, setPickupWeightKg] = useState<number>(
-    initialHandoff?.pickup?.total_weight_kg ?? Math.max(0.1, initialWeightKg || 1),
-  );
-  const [showPickupForm, setShowPickupForm] = useState<boolean>(handoff.mode === "pickup" && !handoff.pickup?.pickup_id);
-  const [pickupUiHint, setPickupUiHint] = useState<string>("");
 
   const dropoffStatus = handoff.dropoff?.status ?? null;
-  const hasPickupProgrammed = !!handoff.pickup?.pickup_id;
-  const pickupId = handoff.pickup?.pickup_id ?? null;
-  const providerLabel = shippingProvider?.trim() || "la paquetería";
-  const isCoordinadora = providerLabel.toLowerCase().includes("coordinadora");
-  const dropoffBranchLink = isCoordinadora
-    ? "https://www.coordinadora.com/servicios/sucursales/"
-    : `https://www.google.com/search?q=${encodeURIComponent(`sucursales ${providerLabel}`)}`;
-  const dropoffBranchLinkLabel = isCoordinadora
-    ? "Buscar sucursales Coordinadora"
-    : `Buscar sucursales ${providerLabel}`;
+  const carrierLabel = shippingProvider?.trim() || "la paquetería";
+  const serviceLabel = shippingService?.trim() || null;
+  const dropoffBranchLink = useMemo(() => {
+    const normalized = carrierLabel.toLowerCase();
+    if (normalized.includes("estafeta")) {
+      return "https://www.google.com/search?q=sucursales+Estafeta+Mexico";
+    }
+    if (normalized.includes("fedex")) {
+      return "https://www.fedex.com/locate/index.html?locale=es_MX";
+    }
+    if (normalized.includes("dhl")) {
+      return "https://www.dhl.com/mx-es/home/localizador-de-puntos-de-servicio.html";
+    }
+    if (normalized.includes("coordinadora")) {
+      return "https://www.google.com/search?q=sucursales+Coordinadora+Mexico";
+    }
+    return `https://www.google.com/search?q=${encodeURIComponent(`sucursales ${carrierLabel}`)}`;
+  }, [carrierLabel]);
+
+  const dropoffBranchLinkLabel = `Buscar sucursales de ${carrierLabel}`;
+
   const badge = useMemo(() => {
     if (dropoffStatus === "dropped_off") {
       return { label: "Entregado en sucursal", cls: "bg-green-100 text-green-700" };
@@ -72,11 +74,8 @@ export default function ShippingHandoffClient({
     if (dropoffStatus === "pending_dropoff") {
       return { label: "Pendiente de entrega en sucursal", cls: "bg-amber-100 text-amber-800" };
     }
-    if (hasPickupProgrammed) {
-      return { label: "Recolección programada", cls: "bg-blue-100 text-blue-700" };
-    }
     return null;
-  }, [dropoffStatus, hasPickupProgrammed]);
+  }, [dropoffStatus]);
 
   const patch = async (shipping_handoff_patch: Record<string, unknown>) => {
     setStatus("saving");
@@ -137,111 +136,6 @@ export default function ShippingHandoffClient({
   };
 
   const isDropoffSelected = handoff.mode === "dropoff";
-  const isPickupSelected = handoff.mode === "pickup" || showPickupForm;
-
-  const applyDefaultWindowByDate = (dateValue: string) => {
-    if (!dateValue) return;
-    const day = new Date(`${dateValue}T12:00:00`).getDay();
-    if (day >= 1 && day <= 5) {
-      setPickupFrom("08:00");
-      setPickupTo("17:00");
-      return;
-    }
-    if (day === 6) {
-      setPickupFrom("08:00");
-      setPickupTo("15:00");
-    }
-  };
-
-  const handlePickupDateChange = (nextDate: string) => {
-    setPickupDate(nextDate);
-    applyDefaultWindowByDate(nextDate);
-  };
-
-  const handleProgramPickup = async () => {
-    if (hasPickupProgrammed) {
-      setPickupUiHint("Esta orden ya tiene una recolección programada.");
-      return;
-    }
-
-    if (!showPickupForm) {
-      setPickupUiHint("Abriendo formulario...");
-      setShowPickupForm(true);
-      const now = new Date().toISOString();
-      setHandoff((prev) => ({
-        ...prev,
-        mode: "pickup",
-        selected_at: prev.selected_at ?? now,
-      }));
-      return;
-    }
-
-    setPickupUiHint("");
-    const day = new Date(`${pickupDate}T12:00:00`).getDay();
-    if (day === 0) {
-      setError("Domingo no disponible");
-      setStatus("error");
-      return;
-    }
-    const fromIso = new Date(`${pickupDate}T${pickupFrom}:00`).toISOString();
-    const toIso = new Date(`${pickupDate}T${pickupTo}:00`).toISOString();
-    if (new Date(toIso).getTime() <= new Date(fromIso).getTime()) {
-      setError("La hora final debe ser mayor a la inicial.");
-      setStatus("error");
-      return;
-    }
-    setStatus("saving");
-    setError("");
-    try {
-      const res = await fetch("/api/admin/shipping/skydropx/pickups", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          orderId,
-          scheduled_from: fromIso,
-          scheduled_to: toIso,
-          packages: pickupPackages,
-          total_weight_kg: pickupWeightKg,
-          notes: notes.trim() || undefined,
-        }),
-      });
-      const json = (await res.json().catch(() => ({}))) as {
-        ok?: boolean;
-        message?: string;
-        pickup_id?: string;
-        scheduled_from?: string;
-        scheduled_to?: string;
-        packages?: number;
-        total_weight_kg?: number;
-      };
-      if (!res.ok || !json.ok) {
-        setStatus("error");
-        setError(`(${res.status}) ${json.message ?? "No se pudo programar pickup."}`);
-        return;
-      }
-      const now = new Date().toISOString();
-      setHandoff((prev) => ({
-        ...prev,
-        mode: "pickup",
-        selected_at: now,
-        notes: notes.trim() || undefined,
-        pickup: {
-          pickup_id: json.pickup_id,
-          scheduled_from: json.scheduled_from,
-          scheduled_to: json.scheduled_to,
-          packages: json.packages,
-          total_weight_kg: json.total_weight_kg,
-          status: "scheduled",
-        },
-      }));
-      setShowPickupForm(false);
-      setPickupUiHint("Recolección programada.");
-      setStatus("idle");
-    } catch {
-      setStatus("error");
-      setError("Error de conexión.");
-    }
-  };
 
   return (
     <section className="mt-6 pt-6 border-t border-gray-200">
@@ -261,23 +155,46 @@ export default function ShippingHandoffClient({
 
       <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
         <div className={`rounded-lg border p-4 ${isDropoffSelected ? "border-primary-300 bg-primary-50/40" : "border-gray-200"}`}>
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="font-semibold text-sm text-gray-900">Lo entregaré en sucursal (Drop-off)</p>
-              <p className="text-xs text-gray-600 mt-0.5">
-                Entregas el paquete en la sucursal indicada por la paquetería.
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="font-semibold text-sm text-gray-900">Entrega en sucursal / punto autorizado</p>
+              <p className="text-sm text-gray-700">
+                <span className="font-medium">Paquetería:</span> {carrierLabel}
               </p>
-              <p className="text-xs text-gray-600 mt-1">
-                Entrega el paquete en cualquier sucursal/punto autorizado de {providerLabel}. Lleva la guía impresa.
+              {serviceLabel && (
+                <p className="text-sm text-gray-700">
+                  <span className="font-medium">Servicio:</span> {serviceLabel}
+                </p>
+              )}
+              <p className="text-xs text-gray-600 mt-2">
+                Imprime la guía, pégala en el paquete y entrégalo en una sucursal o punto autorizado de {carrierLabel}. Pide que lo escaneen y conserva comprobante.
               </p>
-              <a
-                href={dropoffBranchLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex mt-1 text-xs text-primary-700 hover:underline"
-              >
-                {dropoffBranchLinkLabel}
-              </a>
+              <div className="flex flex-wrap items-center gap-3 pt-1">
+                {labelUrl && (
+                  <a
+                    href={labelUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-primary-700 hover:underline font-medium"
+                  >
+                    Abrir guía
+                  </a>
+                )}
+                <a
+                  href={dropoffBranchLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-primary-700 hover:underline font-medium"
+                >
+                  {dropoffBranchLinkLabel}
+                </a>
+              </div>
+              {trackingNumber && (
+                <p className="text-xs text-gray-700">
+                  <span className="font-medium">Tracking:</span>{" "}
+                  <span className="font-mono">{trackingNumber}</span>
+                </p>
+              )}
             </div>
             <button
               type="button"
@@ -290,27 +207,11 @@ export default function ShippingHandoffClient({
           </div>
         </div>
 
-        <div className={`rounded-lg border p-4 ${isPickupSelected ? "border-primary-300 bg-primary-50/40" : "border-gray-200"}`}>
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="font-semibold text-sm text-gray-900">Programar recolección (Pickup)</p>
-              <p className="text-xs text-gray-600 mt-0.5">
-                Recolección a domicilio en origen fijo del negocio.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={handleProgramPickup}
-              disabled={status === "saving" || hasPickupProgrammed}
-              className="px-3 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 disabled:opacity-50 focus-premium"
-            >
-              {showPickupForm ? (status === "saving" ? "Programando..." : "Confirmar pickup") : "Programar recolección"}
-            </button>
-          </div>
-          {pickupUiHint && <p className="text-xs text-gray-600 mt-2">{pickupUiHint}</p>}
-          {hasPickupProgrammed && (
-            <p className="text-xs text-blue-700 mt-2">Pickup ya programado. Reprogramar: disponible pronto.</p>
-          )}
+        <div className="rounded-lg border border-gray-200 p-4 bg-gray-50">
+          <p className="font-semibold text-sm text-gray-900">Programar recolección (Pickup)</p>
+          <p className="text-xs text-gray-600 mt-1">
+            Recolección a domicilio pausada temporalmente. Usa Drop-off por ahora.
+          </p>
         </div>
       </div>
 
@@ -350,7 +251,7 @@ export default function ShippingHandoffClient({
               onChange={(e) => setNotes(e.target.value)}
               disabled={status === "saving"}
               className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium resize-y disabled:opacity-50"
-              placeholder="Ej. Sucursal X / horario / referencia…"
+              placeholder="Ej. Estafeta Coapa / FedEx División del Norte / entregado 12:30 / persona que recibió"
             />
             <div className="mt-2 flex items-center gap-2">
               <button
@@ -374,95 +275,6 @@ export default function ShippingHandoffClient({
               )}
             </div>
           </div>
-        </div>
-      )}
-
-      {/* Detalles pickup */}
-      {(isPickupSelected || hasPickupProgrammed) && (
-        <div className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-          {hasPickupProgrammed ? (
-            <div className="space-y-2 text-sm">
-              <p className="font-medium text-gray-900">Recolección programada</p>
-              <p>
-                <span className="text-gray-600">Pickup ID:</span>{" "}
-                <span className="font-mono text-xs">{pickupId}</span>
-              </p>
-              <p>
-                <span className="text-gray-600">Ventana:</span>{" "}
-                {handoff.pickup?.scheduled_from ? new Date(handoff.pickup.scheduled_from).toLocaleString("es-MX") : "—"}
-                {" — "}
-                {handoff.pickup?.scheduled_to ? new Date(handoff.pickup.scheduled_to).toLocaleString("es-MX") : "—"}
-              </p>
-              <p>
-                <span className="text-gray-600">Paquetes/Peso:</span>{" "}
-                {handoff.pickup?.packages ?? 1} paquete(s), {handoff.pickup?.total_weight_kg ?? 0} kg
-              </p>
-              <p className="text-xs text-gray-500">Reprogramar: disponible pronto.</p>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Fecha</label>
-                  <input
-                    type="date"
-                    value={pickupDate}
-                    onChange={(e) => handlePickupDateChange(e.target.value)}
-                    disabled={status === "saving"}
-                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Hora desde</label>
-                  <input
-                    type="time"
-                    value={pickupFrom}
-                    onChange={(e) => setPickupFrom(e.target.value)}
-                    disabled={status === "saving"}
-                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Hora hasta</label>
-                  <input
-                    type="time"
-                    value={pickupTo}
-                    onChange={(e) => setPickupTo(e.target.value)}
-                    disabled={status === "saving"}
-                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1"># paquetes</label>
-                  <input
-                    type="number"
-                    min={1}
-                    value={pickupPackages}
-                    onChange={(e) => setPickupPackages(Math.max(1, Number(e.target.value) || 1))}
-                    disabled={status === "saving"}
-                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Peso total (kg)</label>
-                  <input
-                    type="number"
-                    min={0.1}
-                    step={0.1}
-                    value={pickupWeightKg}
-                    onChange={(e) => setPickupWeightKg(Math.max(0.1, Number(e.target.value) || 0.1))}
-                    disabled={status === "saving"}
-                    className="w-full rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 text-sm focus-premium"
-                  />
-                </div>
-              </div>
-              <p className="text-xs text-gray-500">
-                Defaults: L-V 08:00-17:00, Sábado 08:00-15:00, Domingo no disponible.
-              </p>
-            </div>
-          )}
         </div>
       )}
     </section>

--- a/src/app/admin/pedidos/[id]/page.tsx
+++ b/src/app/admin/pedidos/[id]/page.tsx
@@ -529,6 +529,27 @@ export default async function AdminPedidoDetailPage({
                 const hasLabelEvidence = hasShipmentId || !!order.shipping_tracking_number || !!order.shipping_label_url;
                 const isSkydropx = order.shipping_provider === "skydropx" || order.shipping_provider === "Skydropx";
                 const shippingMeta = ((order.metadata as Record<string, unknown>)?.shipping as Record<string, unknown>) || {};
+                const rateUsed = (shippingMeta.rate_used as Record<string, unknown> | undefined) || undefined;
+                const rate = (shippingMeta.rate as Record<string, unknown> | undefined) || undefined;
+                const carrierName =
+                  (typeof rateUsed?.provider === "string" && rateUsed.provider.trim()) ||
+                  (typeof rate?.provider === "string" && rate.provider.trim()) ||
+                  (typeof shippingMeta.option_code === "string" && shippingMeta.option_code.trim()) ||
+                  (typeof shippingMeta.provider === "string" && shippingMeta.provider.trim()) ||
+                  order.shipping_provider ||
+                  null;
+                const serviceName =
+                  (typeof rateUsed?.service_level_name === "string" && rateUsed.service_level_name.trim()) ||
+                  (typeof rateUsed?.service === "string" && rateUsed.service.trim()) ||
+                  (typeof rate?.service_level_name === "string" && rate.service_level_name.trim()) ||
+                  (typeof rate?.service === "string" && rate.service.trim()) ||
+                  null;
+                const handoffLabelUrl =
+                  order.shipping_label_url ||
+                  (typeof shippingMeta.label_url === "string" ? shippingMeta.label_url : null);
+                const handoffTracking =
+                  order.shipping_tracking_number ||
+                  (typeof shippingMeta.tracking_number === "string" ? shippingMeta.tracking_number : null);
                 type ShippingHandoff = {
                   mode?: "dropoff";
                   selected_at?: string;
@@ -552,9 +573,6 @@ export default async function AdminPedidoDetailPage({
                   shippingMeta.handoff && typeof shippingMeta.handoff === "object"
                     ? (shippingMeta.handoff as ShippingHandoff)
                     : null;
-                const packageUsed = (shippingMeta.package_used as Record<string, unknown> | undefined) || undefined;
-                const weightG = typeof packageUsed?.weight_g === "number" ? packageUsed.weight_g : 1000;
-                const initialWeightKg = Math.max(0.1, Math.round((weightG / 1000) * 10) / 10);
 
                 return (
                   <>
@@ -574,11 +592,11 @@ export default async function AdminPedidoDetailPage({
                     {hasLabelEvidence && (
                       <ShippingHandoffClient
                         orderId={order.id}
-                        labelUrl={order.shipping_label_url}
-                        trackingNumber={order.shipping_tracking_number}
-                        shippingProvider={order.shipping_provider}
+                        labelUrl={handoffLabelUrl}
+                        trackingNumber={handoffTracking}
+                        shippingProvider={carrierName}
+                        shippingService={serviceName}
                         initialHandoff={initialHandoff}
-                        initialWeightKg={initialWeightKg}
                       />
                     )}
 


### PR DESCRIPTION
## Summary
- Simplify admin handoff to Drop-off only in UI for now.
- Pickup is paused in UI (no active button, no form, no pickup request trigger).
- Improve Drop-off clarity with carrier/service resolution from shipping metadata, clear instructions, tracking, label link, and carrier-based branch search links.
- Keep Drop-off actions intact: usar drop-off, guardar notas, marcar entregado.

## QA
- [x] Orden con guía muestra paquetería y servicio
- [x] Link "Abrir guía" funciona
- [x] Link "Buscar sucursales" usa carrier
- [x] "Usar Drop-off" guarda estado
- [x] "Marcar entregado" persiste al recargar
- [x] Pickup ya no dispara request ni abre form
- [x] `pnpm -s verify` exit 0

Made with [Cursor](https://cursor.com)